### PR TITLE
Combined some of the term simplification into a single place.

### DIFF
--- a/Expander.fs
+++ b/Expander.fs
@@ -13,7 +13,7 @@ let rec resolveCondViewIn (suffix : Set<BoolExpr>) =
     | Func v -> 
         [ { Cond = 
                 suffix
-                |> Set.toArray
+                |> Set.toList
                 |> mkAnd
             Item = v } ]
     | ITE(expr, tviews, fviews) -> 

--- a/Expr.fs
+++ b/Expr.fs
@@ -137,13 +137,6 @@ let isTrue =
     | BTrue -> true
     | _      -> false
       
-/// Partial match on tautologies.
-let (|Tautology|Contradiction|Simplified|Unchanged|) x =
-    match simp x with 
-    | BTrue  -> Tautology 
-    | BFalse -> Contradiction
-    | sx     -> if x = sx then Unchanged else Simplified sx 
-
 /// Extracts the name from a Starling constant.
 let stripMark =
     function

--- a/Horn.fs
+++ b/Horn.fs
@@ -161,9 +161,9 @@ let topLevelExpr =
     // The main difference here is that we model conjunctions directly as a
     // Horn literal list.
     function
-    | BAnd xs -> xs |> Seq.filter (isTrue >> not)
-    | x -> Seq.singleton x
-    >> Seq.map boolExpr
+    | BAnd xs -> xs
+    | x -> [x]
+    >> List.map boolExpr
     >> collect
     >> lift List.ofSeq
 

--- a/Model.fs
+++ b/Model.fs
@@ -210,6 +210,9 @@ type Term<'cmd, 'wpre, 'goal> =
 /// A term over semantic-relation commands.
 type STerm<'wpre, 'goal> = Term<BoolExpr, 'wpre, 'goal>
 
+/// A term using only internal boolean expressions.
+type FTerm = Term<BoolExpr,BoolExpr,BoolExpr>
+
 
 /// Rewrites a Term by transforming its Cmd with fC, its WPre with fW,
 /// and its Goal with fG.

--- a/Optimiser.fs
+++ b/Optimiser.fs
@@ -103,12 +103,7 @@ let guardReduce {Cmd = c; WPre = w; Goal = g} =
  *)
 
 /// Performs tautology/contradiction/identity collapsing on a BoolExpr.
-let rec tciCollapseBool =
-    function
-    | Tautology -> BTrue
-    | Contradiction -> BFalse
-    | Identity x -> tciCollapseBool x
-    | x -> x
+let rec tciCollapseBool = simp
 
 /// Performs tautology/contradiction/identity collapsing on an Expr.
 let tciCollapseExpr =

--- a/OptimiserTests.fs
+++ b/OptimiserTests.fs
@@ -124,7 +124,23 @@ type OptimiserTests() =
             .SetName("Simplify true&&false&&!false&&false==false as a contradiction")
           TestCaseData(BImplies (BTrue, bEq BTrue BFalse))
             .Returns(BFalse)
-            .SetName("Simplify true=>true==false as a contradiction") ]
+            .SetName("Simplify true=>true==false as a contradiction") 
+          TestCaseData(BImplies ((bAfter "s"), BFalse))
+            .Returns(BNot (bAfter "s"))
+            .SetName("Simplify =>False into a Negation") 
+          TestCaseData(BImplies ((bAfter "s"), BTrue))
+            .Returns(BTrue)
+            .SetName("Simplify =>True into a True") 
+          TestCaseData(BImplies (BGt ((aAfter "s"), (aAfter "t")), BFalse))
+            .Returns(BLe ((aAfter "s"), (aAfter "t" )))
+            .SetName("Simplify =>False wrapped around a > into <=") 
+          TestCaseData(BImplies (BTrue, (bAfter "s")))
+            .Returns((bAfter "s"))
+            .SetName("Simplify True=>s into s") 
+          TestCaseData(BImplies (BFalse, (bAfter "s")))
+            .Returns(BTrue)
+            .SetName("Simplify False=>s into True") 
+            ]
 
      /// Test collapsing of tautologies and contradictions
     [<TestCaseSource("ObviousBools")>]

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -153,11 +153,9 @@ let semanticsOf model prim =
     let actions = emitPrim prim
     // Temporarily build an And so we can check it with frame.
     // TODO(CaptainHayashi): eliminate this round-trip?
-    let actionsAnd = actions |> List.toArray
-    let aframe = frame model (mkAnd actionsAnd)
+    let aframe = frame model (mkAnd actions)
     actions
-    |> Seq.ofList
-    |> Seq.append aframe
+    |> List.append (Seq.toList aframe)
     |> mkAnd 
 
 /// Marks all of the variables in a View using the given  marker.

--- a/Utils.fs
+++ b/Utils.fs
@@ -104,3 +104,14 @@ let mapMessages f = either (fun (v, msgs) -> Ok(v, List.map f msgs)) (fun msgs -
 /// Like fold, but constantly binds the given function over a Chessie result.
 /// The initial state is wrapped in 'ok'.
 let seqBind f initialS = Seq.fold (fun s x -> bind (f x) s) (ok initialS)
+
+
+/// Fold that can be terminated earlier by the step function f returning None.
+/// If Any step returns None, the whole fold returns None.
+let rec foldFastTerm  (f : 'State -> 'T -> 'State option)  (s : 'State) (l : 'T list) =  
+     match l with 
+     | []   -> Some s
+     | x::l -> 
+        match f s x with 
+        | Some s -> foldFastTerm f s l
+        | None -> None 

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -73,6 +73,10 @@ let sat = Run.run >> lift
 let run resp =
     use ctx = new Z3.Context()
     match resp with
-    | Request.Translate -> translate ctx >> lift Response.Translate
+    | Request.Translate ->
+        //This is hear as previous version did the conversion in a different order. 
+        translate ctx >> 
+        lift (mapAxioms (mapTerm (Starling.Z3.Translator.boolToZ3 ctx) (Starling.Z3.Translator.boolToZ3 ctx) (Starling.Z3.Translator.boolToZ3 ctx)) )>>
+        lift Response.Translate
     | Request.Combine -> translate ctx >> combine ctx >> lift Response.Combine
     | Request.Sat -> translate ctx >> combine ctx >> sat ctx >> lift Response.Sat

--- a/Z3Translator.fs
+++ b/Z3Translator.fs
@@ -123,13 +123,12 @@ let reifyZView model =
 let instantiateZTerm vdefs =
     tryMapTerm ok (reifyZView vdefs) (reifyZUnguarded vdefs)
 
-/// Z3-reifies all of the views in a term over the given defining model.
-let reifyZTerm ctx vdefs : STerm<GView, VFunc> -> Result<ZTerm, Error> =
+/// Reifies all of the views in a term over the given defining model.
+let reifyZTerm ctx vdefs : STerm<GView, VFunc> -> Result<FTerm, Error> =
     instantiateZTerm vdefs
-    >> lift (mapTerm (boolToZ3 ctx) (boolToZ3 ctx) (boolToZ3 ctx))
 
-    /// Reifies all of the terms in a term list.
-let reifyZ3 ctx model : Result<Model<ZTerm, DFunc>, Error> =
+/// Reifies all of the terms in a term list.
+let reifyZ3 ctx model : Result<Model<FTerm, DFunc>, Error> =
     tryMapAxioms (reifyZTerm ctx (model.ViewDefs)) model
 
 /// Combines the components of a reified term.
@@ -142,7 +141,7 @@ let combineTerm (ctx: Z3.Context) {Cmd = c; WPre = w; Goal = g} =
      *   - ((c^w) ^ ¬g) deMorgan
      *   - (c^w^¬g) associativity.
      *)
-    ctx.MkAnd [| c; w; ctx.MkNot g |]
+    boolToZ3 ctx (mkAnd [c ; w; mkNot g] )
 
 /// Combines reified terms into a list of Z3 terms.
 let combineTerms ctx = mapAxioms (combineTerm ctx)


### PR DESCRIPTION
Made a simp function that performs all the relevant boolean simplification.  It is an attempt to stop us traversing terms quite as much as the current approach.  It is still not that good as it never assumes terms have already been simplified.  But should work deeper into terms that the current approach.

@CaptainHayashi I wasn't happy applying this directly to your branch, as you might not prefer it.  So decide if you want the change.
