### PR TITLE
Fixes and improvements for PLASMA seminar.

### DIFF
--- a/ASTPretty.fs
+++ b/ASTPretty.fs
@@ -177,8 +177,8 @@ let printScriptVar cls t v =
 /// Pretty-prints script lines.
 let printScriptLine = 
     function 
-    | Global(t, v) -> printScriptVar "global" t v
-    | Local(t, v) -> printScriptVar "local" t v
+    | Global(t, v) -> printScriptVar "shared" t v
+    | Local(t, v) -> printScriptVar "thread" t v
     | Method m -> printMethod m
     | ViewProto v -> printViewProto v
     | Constraint c -> printConstraint c

--- a/Examples/Fail/badInc.cvf
+++ b/Examples/Fail/badInc.cvf
@@ -1,6 +1,6 @@
 /* A bad increment */
 
-local int x; 
+thread int x; 
 view False(); 
 
 method badInc() { 

--- a/Examples/Fail/badInc2.cvf
+++ b/Examples/Fail/badInc2.cvf
@@ -1,7 +1,7 @@
 // another bad increment
 
 view isTrue(bool b); 
-local int x; 
+thread int x; 
 
 method badInc() { 
   {| isTrue(x==0) |} 

--- a/Examples/Fail/ticketLockBad.cvf
+++ b/Examples/Fail/ticketLockBad.cvf
@@ -2,10 +2,10 @@
  * Linux-style ticketed lock.
  */
 
-global int ticket;  // The next ticket to hand out.
-global int serving; // The current ticket holding the lock.
-local int t;  // The thread's current ticket.
-local int s;  // The thread's current view of serving.
+shared int ticket;  // The next ticket to hand out.
+shared int serving; // The current ticket holding the lock.
+thread int t;  // The thread's current ticket.
+thread int s;  // The thread's current view of serving.
 
 /*
  * Locks the ticket lock.

--- a/Examples/Fail/ticketLockBad2.cvf
+++ b/Examples/Fail/ticketLockBad2.cvf
@@ -2,10 +2,10 @@
  * Linux-style ticketed lock.
  */
 
-global int ticket;  // The next ticket to hand out.
-global int serving; // The current ticket holding the lock.
-local int t;  // The thread's current ticket.
-local int s;  // The thread's current view of serving.
+shared int ticket;  // The next ticket to hand out.
+shared int serving; // The current ticket holding the lock.
+thread int t;  // The thread's current ticket.
+thread int s;  // The thread's current view of serving.
 
 /*
  * Locks the ticket lock.

--- a/Examples/Fail/ticketLockFlippedLoop.cvf
+++ b/Examples/Fail/ticketLockFlippedLoop.cvf
@@ -2,10 +2,10 @@
  * Linux-style ticketed lock, with erroneously flipped loop condition.
  */
 
-global int ticket;  // The next ticket to hand out.
-global int serving; // The current ticket holding the lock.
-local int t;  // The thread's current ticket.
-local int s;  // The thread's current view of serving.
+shared int ticket;  // The next ticket to hand out.
+shared int serving; // The current ticket holding the lock.
+thread int t;  // The thread's current ticket.
+thread int s;  // The thread's current view of serving.
 
 /*
  * Locks the ticket lock.

--- a/Examples/Pass/multicounter.cvf
+++ b/Examples/Pass/multicounter.cvf
@@ -2,8 +2,8 @@
  * Owicki-style parallel counter increment.
  */
 
-global int counter;
-local int t;
+shared int counter;
+thread int t;
 
 method multiIncrement() {
   {| count(0) |}

--- a/Examples/Pass/spinLock.cvf
+++ b/Examples/Pass/spinLock.cvf
@@ -2,8 +2,8 @@
  * Herlihy/Shavit-style compare and swap lock.
  */
 
-global bool lock;  // True iff the lock is taken.
-local bool test;  // Used when trying to take the lock.
+shared bool lock;  // True iff the lock is taken.
+thread bool test;  // Used when trying to take the lock.
 
 /*
  * Locks the CAS lock.

--- a/Examples/Pass/ticketLock.cvf
+++ b/Examples/Pass/ticketLock.cvf
@@ -2,10 +2,10 @@
  * Linux-style ticketed lock.
  */
 
-global int ticket;  // The next ticket to hand out.
-global int serving; // The current ticket holding the lock.
-local int t;  // The thread's current ticket.
-local int s;  // The thread's current view of serving.
+shared int ticket;  // The next ticket to hand out.
+shared int serving; // The current ticket holding the lock.
+thread int t;  // The thread's current ticket.
+thread int s;  // The thread's current view of serving.
 
 /*
  * Locks the ticket lock.

--- a/Examples/Pass/ticketLockNoIf.cvf
+++ b/Examples/Pass/ticketLockNoIf.cvf
@@ -2,10 +2,10 @@
  * Linux-style ticketed lock.
  */
 
-global int ticket;  // The next ticket to hand out.
-global int serving; // The current ticket holding the lock.
-local int t;  // The thread's current ticket.
-local int s;  // The thread's current view of serving.
+shared int ticket;  // The next ticket to hand out.
+shared int serving; // The current ticket holding the lock.
+thread int t;  // The thread's current ticket.
+thread int s;  // The thread's current view of serving.
 
 /*
  * Locks the ticket lock.

--- a/Examples/Pass/ticketLockNoInvariant.cvf
+++ b/Examples/Pass/ticketLockNoInvariant.cvf
@@ -4,10 +4,10 @@
  * Examples/Pass/ticketLockIndefinite.cvf as input.
  */
 
-global int ticket;  // The next ticket to hand out.
-global int serving; // The current ticket holding the lock.
-local int t;  // The thread's current ticket.
-local int s;  // The thread's current view of serving.
+shared int ticket;  // The next ticket to hand out.
+shared int serving; // The current ticket holding the lock.
+thread int t;  // The thread's current ticket.
+thread int s;  // The thread's current view of serving.
 
 /*
  * Locks the ticket lock.

--- a/Examples/Pass/ticketLockNonAtomicRelease.cvf
+++ b/Examples/Pass/ticketLockNonAtomicRelease.cvf
@@ -2,10 +2,10 @@
  * Linux-style ticketed lock.
  */
 
-global int ticket;  // The next ticket to hand out.
-global int serving; // The current ticket holding the lock.
-local int t;  // The thread's current ticket.
-local int s;  // The thread's current view of serving.
+shared int ticket;  // The next ticket to hand out.
+shared int serving; // The current ticket holding the lock.
+thread int t;  // The thread's current ticket.
+thread int s;  // The thread's current view of serving.
 
 /*
  * Locks the ticket lock.

--- a/Examples/Pass/ticketLockNonAtomicRelease2.cvf
+++ b/Examples/Pass/ticketLockNonAtomicRelease2.cvf
@@ -2,10 +2,10 @@
  * Linux-style ticketed lock.
  */
 
-global int ticket;  // The next ticket to hand out.
-global int serving; // The current ticket holding the lock.
-local int t;  // The thread's current ticket.
-local int s;  // The thread's current view of serving.
+shared int ticket;  // The next ticket to hand out.
+shared int serving; // The current ticket holding the lock.
+thread int t;  // The thread's current ticket.
+thread int s;  // The thread's current view of serving.
 
 /*
  * Locks the ticket lock.

--- a/Examples/PassHSF/ticketLockIndefinite.cvf
+++ b/Examples/PassHSF/ticketLockIndefinite.cvf
@@ -2,10 +2,10 @@
  * Linux-style ticketed lock with some constraints left indefinite.
  */
 
-global int ticket;  // The next ticket to hand out.
-global int serving; // The current ticket holding the lock.
-local int t;  // The thread's current ticket.
-local int s;  // The thread's current view of serving.
+shared int ticket;  // The next ticket to hand out.
+shared int serving; // The current ticket holding the lock.
+thread int t;  // The thread's current ticket.
+thread int s;  // The thread's current view of serving.
 
 /*
  * Locks the ticket lock.

--- a/Examples/PassHSF/ticketLockIndefiniteNonAtomicRelease.cvf
+++ b/Examples/PassHSF/ticketLockIndefiniteNonAtomicRelease.cvf
@@ -2,10 +2,10 @@
  * Linux-style ticketed lock.
  */
 
-global int ticket;  // The next ticket to hand out.
-global int serving; // The current ticket holding the lock.
-local int t;  // The thread's current ticket.
-local int s;  // The thread's current view of serving.
+shared int ticket;  // The next ticket to hand out.
+shared int serving; // The current ticket holding the lock.
+thread int t;  // The thread's current ticket.
+thread int s;  // The thread's current view of serving.
 
 /*
  * Locks the ticket lock.

--- a/Examples/WIP/dekker.cvf
+++ b/Examples/WIP/dekker.cvf
@@ -9,12 +9,12 @@ view AHasLock();
 view BReady();
 view BHasLock();
 
-global bool a_want;
-global bool b_want;
+shared bool a_want;
+shared bool b_want;
 
-global bool a_turn; /* True if A's turn; false if B's turn. */
+shared bool a_turn; /* True if A's turn; false if B's turn. */
 
-local bool other_wants;
+thread bool other_wants;
 
 constraint AReady() => a_want;
 constraint BReady() => b_want;

--- a/Examples/WIP/duplicateVars.cvf
+++ b/Examples/WIP/duplicateVars.cvf
@@ -1,2 +1,2 @@
-local int moo;
-local bool moo;
+thread int moo;
+thread bool moo;

--- a/Examples/WIP/peterson.cvf
+++ b/Examples/WIP/peterson.cvf
@@ -2,12 +2,12 @@
  * Peterson lock.
  */
 
-global bool aFlag;
-global bool bFlag;
-global bool aTurn;
+shared bool aFlag;
+shared bool bFlag;
+shared bool aTurn;
 
-local bool oFlag;
-local bool oTurn;
+thread bool oFlag;
+thread bool oTurn;
 
 /*
  * Locks the Peterson lock from A's side.

--- a/Parser.fs
+++ b/Parser.fs
@@ -452,7 +452,7 @@ let parseMethod =
 
 /// Parses a variable with the given initial keyword.
 let parseVar kw = pstring kw >>. ws
-                  // ^- global     ...
+                  // ^- shared     ...
                              >>. parseTypedParam
                              // ^- ... <type> <identifier> ...
                              .>> pstring ";"
@@ -469,10 +469,10 @@ let parseScript =
                              parseViewProto |>> ViewProto
                              // ^- view <identifier> ;
                              //  | view <identifier> <view-proto-param-list> ;
-                             parseVar "global" |>> Global
-                             // ^- global <type> <identifier> ;
-                             parseVar "local" |>> Local] .>> ws ) eof
-                             // ^- local <type> <identifier> ;
+                             parseVar "shared" |>> Global
+                             // ^- shared <type> <identifier> ;
+                             parseVar "thread" |>> Local] .>> ws ) eof
+                             // ^- thread <type> <identifier> ;
 
 (*
  * Frontend

--- a/Pretty.fs
+++ b/Pretty.fs
@@ -39,7 +39,7 @@ let printModelVar (name, ty) =
 /// Pretty-prints a collated script.
 let printCollatedScript (cs: CollatedScript) = 
     VSep([ vsep <| List.map printViewProto cs.VProtos
-           vsep <| List.map (uncurry (printScriptVar "global")) cs.Globals
+           vsep <| List.map (uncurry (printScriptVar "shared")) cs.Globals
            vsep <| List.map (uncurry (printScriptVar "local")) cs.Locals
            vsep <| List.map printConstraint cs.Constraints
            VSep(List.map printMethod cs.Methods, VSkip) ], (vsep [ VSkip; Separator; Nop ]))
@@ -258,7 +258,7 @@ let printSTerm pWPre pGoal = printTerm printBoolExpr pWPre pGoal
 /// Pretty-prints a model given axiom and defining-view printers.
 let printModel pAxiom pDView model = 
     headed "Model" 
-           [ headed "Globals" <| List.map printModelVar (Map.toList model.Globals)
-             headed "Locals" <| List.map printModelVar (Map.toList model.Locals)
+           [ headed "Shared variables" <| List.map printModelVar (Map.toList model.Globals)
+             headed "Thread variables" <| List.map printModelVar (Map.toList model.Locals)
              headed "ViewDefs" <| List.map (printViewDef pDView) model.ViewDefs
              headed "Axioms" <| List.map pAxiom model.Axioms ]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,27 @@ NuGet, and the native Z3 library for your platform.
 
 NuGet should be able to restore the rest of the prerequisites.
 
+The helper scripts mentioned below require a POSIX environment:
+cygwin or MSYS should work on Windows.
+
+To use HSF, you will need a copy of `qarmc`.  An [outdated but
+useable version of `qarmc`](https://www7.in.tum.de/~popeea/research/synthesis/)
+is available.  Install it in your `PATH` to be able to use
+`starling-hsf.sh`.
+
+## Usage
+
+* To check a Starling file using Z3, use `./starling.sh -ssat /path/to/file`.
+* To investigate a failure (of the form `XX: fail` where `XX` is a number),
+  use `./trace.sh /path/to/file XX`.
+* To check a Starling file using HSF/qarmc, use `./starling-hsf.sh /path/to/file`.
+* To run the regression tests, use `./regress.sh`.
+
+## Editor support
+
+A very basic major mode (highlighting only) for GNU Emacs, based on `cc-mode`,
+is available in `syntax/starling-mode.el`.
+
 ## People
 
 * [Matthew Windsor](https://www-users.cs.york.ac.uk/~mbw500/)

--- a/TestStudies.fs
+++ b/TestStudies.fs
@@ -21,10 +21,10 @@ constraint holdLock()   * holdTick(t)  -> serving != t;
 constraint holdTick(ta) * holdTick(tb) -> ta != tb;
 constraint holdLock()   * holdLock()   -> false;
 
-global int ticket;
-global int serving;
-local int t;
-local int s;
+shared int ticket;
+shared int serving;
+thread int t;
+thread int s;
 
 method lock() {
   {| emp |}

--- a/starling-hsf.sh
+++ b/starling-hsf.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Runs Starling and qarmc on an input file.
+# Requires qarmc be on path, or the path to qarmc specified as ${QARMC}.
+
+QARMC=${QARMC:-"qarmc"}
+
+if [ $# != 1 ];
+then
+	echo "usage: $0 FILE"
+	exit 1
+fi
+
+tempfile=hsf.tmp
+
+if [ -e $tempfile ]
+then
+   echo "Temp file already exists: " $tempfile
+   exit 1
+fi
+
+echo "--- STARLING ---"
+./starling.sh -shsf $1 | tee $tempfile
+echo "--- HSF ---"
+$QARMC $tempfile
+rm $tempfile

--- a/syntax/starling-mode.el
+++ b/syntax/starling-mode.el
@@ -1,0 +1,52 @@
+(defconst starling-font-lock-keywords-1
+  (list
+   ;; These are the main structural keywords.
+   (cons (regexp-opt '("view" "method" "constraint")) font-lock-keyword-face)
+   ;; Colour in function definitions.
+   '("method\\s-+\\([a-zA-Z_][a-zA-Z0-9_]*\\)" 1 font-lock-function-name-face))
+  "Minimal highlighting expressions for Starling mode.")
+
+(defconst starling-font-lock-keywords-2
+  (append
+   starling-font-lock-keywords-1
+   (list
+    ;; Treat view assertions as doc comments.
+    '("{|[^|]*|}" . font-lock-doc-face)
+    ;; Add colouring for remaining keywords.
+    (cons (regexp-opt '("shared" "thread" "if" "else" "do" "while")) font-lock-keyword-face)
+    (cons (regexp-opt '("int" "bool")) font-lock-type-face)))
+  "Additional highlighting expressions for Starling mode.")
+
+(defconst starling-font-lock-keywords-3
+  (append
+   starling-font-lock-keywords-2
+   (list
+    ;; Treat true and false as constants.
+    (cons (regexp-opt '("true" "false")) font-lock-constant-face))
+   '(;; Treat func names in a view as function-names.
+     ("view\\s-+\\([a-zA-Z_][a-zA-Z0-9_]*\\)" 1 font-lock-function-name-face)
+     ;; Treat func names in a constraint as function-names.
+     ("constraint\\s-+" "\\([a-zA-Z_][a-zA-Z0-9_]*\\)([^)]*)" nil nil (1 font-lock-function-name-face))
+     ;; Warn about an indefinite constraint.
+     ("constraint\\s-+" "->\\s-+\\([?]\\)\\s-*;" nil nil (1 font-lock-warning-face))
+     ;; Treat emp as builtin inside a constraint.
+     ("constraint\\s-+" "emp" nil nil (0 font-lock-builtin-face))
+     ;; Warn about the ends of an atomic command.
+     ("\\(<\\)[^>]*\\(>\\)\\s-*;"
+      (1 font-lock-warning-face)
+      (2 font-lock-warning-face))))
+  "Yet more highlighting expressions for Starling mode.")
+
+(defconst starling-font-lock-keywords
+  starling-font-lock-keywords-3
+  "Default highlighting expressions for Starling mode.")
+
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.cvf\\'" . starling-mode))
+
+(define-derived-mode starling-mode c-mode
+  "Starling"
+  "Major mode for editing Starling scripts."
+  (setq font-lock-defaults '(starling-font-lock-keywords)))
+
+(provide 'starling-mode)


### PR DESCRIPTION
First, rename `global` to `shared` and `local` to `thread`, to make the intent more clear.

```
global int x;
local int y;
```

becomes

```
shared int x;
thread int y;
```

Second, add a small shell script to automate dumping Horn clauses and running `qarmc` on them.  Tested only on Linux; you will need `qarmc` in `PATH` (or set variable `QARMC` to its location).

Third, add an Emacs major mode to give syntax highlighting (and little else) for starling `cvf` files.

Fourth, update the readme with some usage examples and the Emacs mode.
