### PR TITLE
Convert multiset to map representation

### DIFF
--- a/Collections.fs
+++ b/Collections.fs
@@ -163,3 +163,99 @@ module Multiset =
                       |> ofSeq
         }
         |> Set.ofSeq
+
+/// <summary>
+///     Tests for collections.
+/// </summary>
+module Tests =
+    open NUnit.Framework
+
+    let tcd : obj[] -> TestCaseData = TestCaseData
+
+    /// <summary>
+    ///    NUnit tests for collections.
+    /// </summary>
+    type NUnit () =
+        /// <summary>
+        ///     Test cases for <c>Multiset.ofList</c>.
+        /// </summary>
+        static member ListMultisets =
+            [ TestCaseData([10; 23; 1; 85; 23; 1] : int list)
+                 .Returns(MSet [1; 1; 10; 23; 23; 85] : Multiset<int>)
+              TestCaseData([] : int list)
+                 .Returns(MSet [] : Multiset<int>) ]
+
+        /// <summary>
+        ///     Tests <c>Multiset.ofList</c>.
+        /// </summary>
+        [<TestCaseSource("ListMultisets")>]
+        member x.``Multiset.ofList creates correct multisets`` l =
+            Multiset.ofList l
+
+
+        /// <summary>
+        ///     Test cases for <c>Multiset.toList</c>.
+        /// </summary>
+        static member MultisetLists =
+            [ TestCaseData(MSet [1; 1; 10; 23; 23; 85] : Multiset<int>)
+                 .Returns([1; 1; 10; 23; 23; 85] : int list)
+              TestCaseData(MSet [] : Multiset<int>)
+                 .Returns([] : int list) ]
+
+        /// <summary>
+        ///     Tests <c>Multiset.ofList</c>.
+        /// </summary>
+        [<TestCaseSource("MultisetLists")>]
+        member x.``Multiset.toList creates correct lists`` ms =
+            Multiset.toList ms
+
+
+        /// <summary>
+        ///     Test cases for <c>Multiset.append</c>.
+        /// </summary>
+        static member MultisetAppends =
+            [ (tcd [| (MSet [] : Multiset<int>)
+                      (MSet [] : Multiset<int>) |])
+                 .Returns(MSet [] : Multiset<int>)
+                 .SetName("Appending two empty msets yields the empty mset")
+              (tcd [| (MSet [1; 2; 3] : Multiset<int>)
+                      (MSet [] : Multiset<int>) |])
+                 .Returns(MSet [1; 2; 3] : Multiset<int>)
+                 .SetName("Appending x and an empty mset yields x")
+              (tcd [| (MSet [] : Multiset<int>)
+                      (MSet [4; 5] : Multiset<int>) |])
+                 .Returns(MSet [4; 5] : Multiset<int>)
+                 .SetName("Appending an empty mset and x yields x")
+              (tcd [| (MSet [1; 3; 5] : Multiset<int>)
+                      (MSet [2; 4; 6] : Multiset<int>) |])
+                 .Returns(MSet [1; 2; 3; 4; 5; 6] : Multiset<int>)
+                 .SetName("Appending two msets works as expected") ]
+
+        /// <summary>
+        ///     Tests <c>Multiset.append</c>.
+        /// </summary>
+        [<TestCaseSource("MultisetAppends")>]
+        member x.``Multiset.append appends multisets correctly`` a b =
+            Multiset.append a b
+
+
+        /// <summary>
+        ///     Test cases for <c>Multiset.length</c>.
+        /// </summary>
+        static member MultisetLength =
+            [ (tcd [| (MSet [] : Multiset<int>) |])
+                 .Returns(0)
+                 .SetName("The empty mset contains 0 items")
+              (tcd [| (MSet [1; 2; 3] : Multiset<int>) |])
+                 .Returns(3)
+                 .SetName("A disjoint mset's length is the number of items")
+              (tcd [| (MSet [1; 2; 3; 2; 3] : Multiset<int>) |])
+                 .Returns(5)
+                 .SetName("A non-disjoint mset's length is correct") ]
+
+        /// <summary>
+        ///     Tests <c>Multiset.length</c>.
+        /// </summary>
+        [<TestCaseSource("MultisetLength")>]
+        member x.``Multiset.length takes multiset length correctly`` a =
+            Multiset.length a

--- a/Collections.fs
+++ b/Collections.fs
@@ -182,15 +182,17 @@ module Tests =
         static member ListMultisets =
             [ TestCaseData([10; 23; 1; 85; 23; 1] : int list)
                  .Returns(MSet [1; 1; 10; 23; 23; 85] : Multiset<int>)
+                 .SetName("A populated list produces the expected multiset")
               TestCaseData([] : int list)
-                 .Returns(MSet [] : Multiset<int>) ]
+                 .Returns(MSet [] : Multiset<int>)
+                 .SetName("An empty list produces the empty multiset") ]
 
         /// <summary>
         ///     Tests <c>Multiset.ofList</c>.
         /// </summary>
         [<TestCaseSource("ListMultisets")>]
         member x.``Multiset.ofList creates correct multisets`` l =
-            Multiset.ofList l
+            (Multiset.ofList l) : Multiset<int>
 
 
         /// <summary>
@@ -199,15 +201,17 @@ module Tests =
         static member MultisetLists =
             [ TestCaseData(MSet [1; 1; 10; 23; 23; 85] : Multiset<int>)
                  .Returns([1; 1; 10; 23; 23; 85] : int list)
+                 .SetName("A populated multiset produces the expected list")
               TestCaseData(MSet [] : Multiset<int>)
-                 .Returns([] : int list) ]
+                 .Returns([] : int list)
+                 .SetName("An empty multiset produces the empty list") ]
 
         /// <summary>
         ///     Tests <c>Multiset.ofList</c>.
         /// </summary>
         [<TestCaseSource("MultisetLists")>]
         member x.``Multiset.toList creates correct lists`` ms =
-            Multiset.toList ms
+            (Multiset.toList ms) : int list
 
 
         /// <summary>
@@ -236,7 +240,7 @@ module Tests =
         /// </summary>
         [<TestCaseSource("MultisetAppends")>]
         member x.``Multiset.append appends multisets correctly`` a b =
-            Multiset.append a b
+            (Multiset.append a b) : Multiset<int>
 
 
         /// <summary>
@@ -257,5 +261,5 @@ module Tests =
         ///     Tests <c>Multiset.length</c>.
         /// </summary>
         [<TestCaseSource("MultisetLength")>]
-        member x.``Multiset.length takes multiset length correctly`` a =
+        member x.``Multiset.length takes multiset length correctly`` (a : Multiset<int>) =
             Multiset.length a

--- a/Collections.fs
+++ b/Collections.fs
@@ -57,10 +57,20 @@ module Multiset =
      * Construction
      *)
 
-    /// Creates a new, empty multiset.
+    /// <summary>
+    ///     The empty multiset.
+    /// </summary>
     let empty = MSet (Map.empty)
 
-    /// Creates a new multiset with the given sequence as its contents.
+    /// <summary>
+    ///     Creates a multiset with the given flat sequence as its contents.
+    /// </summary>
+    /// <param name="xs">
+    ///     The flat sequence to use to create the multiset.
+    /// </param>
+    /// <returns>
+    ///     A multiset containing the given items.
+    /// </returns>
     let ofSeq xs =
         xs
         // First, collate into (k, [k, k, ...]) form...
@@ -70,11 +80,27 @@ module Multiset =
         |> Map.ofSeq
         |> MSet
 
-    /// Creates a new multiset with the given list as its contents.
+    /// <summary>
+    ///     Creates a multiset with the given flat list as its contents.
+    /// </summary>
+    /// <param name="xs">
+    ///     The flat list to use to create the multiset.
+    /// </param>
+    /// <returns>
+    ///     A multiset containing the given items.
+    /// </returns>
     let ofList xs =
         xs |> List.toSeq |> ofSeq
 
-    /// Creates a new singleton multiset.
+    /// <summary>
+    ///     Creates a multiset with one item.
+    /// </summary>
+    /// <param name="x">
+    ///     The item to place in the multiset.
+    /// </param>
+    /// <returns>
+    ///     A singleton multiset.
+    /// </returns>
     let singleton x = ofList [ x ]
 
 
@@ -82,20 +108,44 @@ module Multiset =
      * Destruction
      *)
 
-    /// Converts a multiset to a sorted seq.
+    /// <summary>
+    ///     Converts a multiset to a sorted, flattened sequence.
+    /// </summary>
+    /// <param name="ms">
+    ///     The multiset to convert.
+    /// </param>
+    /// <returns>
+    ///     The sorted, flattened sequence.
+    /// </returns>
     let toSeq (MSet ms) =
         ms
         |> Map.toSeq
         |> Seq.map (fun (k, amount) -> Seq.replicate amount k)
         |> Seq.concat
 
-    /// Converts a multiset to a sorted list.
+    /// <summary>
+    ///     Converts a multiset to a sorted, flattened list.
+    /// </summary>
+    /// <param name="ms">
+    ///     The multiset to convert.
+    /// </param>
+    /// <returns>
+    ///     The sorted, flattened list.
+    /// </returns>
     let toList ms =
         ms
         |> toSeq
         |> List.ofSeq
 
-    /// Converts a multiset to a set, removing duplicates.
+    /// <summary>
+    ///     Converts a multiset to a set, removing duplicates.
+    /// </summary>
+    /// <param name="ms">
+    ///     The multiset to convert.
+    /// </param>
+    /// <returns>
+    ///     The set of items in the multiset.
+    /// </returns>
     let toSet ms =
         ms
         |> toSeq

--- a/Expr.fs
+++ b/Expr.fs
@@ -259,7 +259,10 @@ let aAfter c = c |> After |> AConst
 /// Creates a before-marked arithmetic constant.
 let aBefore c = c |> Before |> AConst
 
-/// Creates an intermediate-marked Boolean constant.
+/// Creates an goal-marked arithmetic constant.
+let aGoal i c = (i, c) |> Goal |> AConst
+
+/// Creates an intermediate-marked arithmetic constant.
 let aInter i c = (i, c) |> Intermediate |> AConst
 
 /// Creates an unmarked Boolean constant.
@@ -270,6 +273,9 @@ let bAfter c = c |> After |> BConst
 
 /// Creates a before-marked Boolean constant.
 let bBefore c = c |> Before |> BConst
+
+/// Creates an goal-marked Boolean constant.
+let bGoal i c = (i, c) |> Goal |> BConst
 
 /// Creates an intermediate-marked Boolean constant.
 let bInter i c = (i, c) |> Intermediate |> BConst

--- a/Flattener.fs
+++ b/Flattener.fs
@@ -16,14 +16,14 @@ open Starling.Core.GuardedView
 /// Extracts a sequence of all of the parameters in a view in order.
 let paramsOfView ms =
     ms
-    |> Multiset.toSeq
+    |> Multiset.toFlatSeq
     |> Seq.map (fun v -> v.Params)
     |> Seq.concat
 
 /// Constructs a (hopefully) unique name for a func encompassing a view.
 let funcNameOfView ms =
     ms
-    |> Multiset.toSeq
+    |> Multiset.toFlatSeq
     // These two steps are to ensure we don't capture an existing name.
     |> Seq.map (fun { Name = n } -> n.Replace("_", "__"))
     |> scons "v"

--- a/FlattenerTests.fs
+++ b/FlattenerTests.fs
@@ -17,7 +17,7 @@ type FlattenerTests() =
 
     /// Test cases for the view func renamer.
     static member ViewFuncNamings =
-        let ms : VFunc list -> View = Multiset.ofList
+        let ms : VFunc list -> View = Multiset.ofFlatList
         [ TestCaseData(ms [ { Name = "foo"; Params = [] }
                             { Name = "bar_baz"; Params = [] } ])
             .Returns("v_bar__baz_foo") // Remember, multisets sort!
@@ -34,7 +34,7 @@ type FlattenerTests() =
     /// Test cases for the full defining-view func converter.
     /// These all use the Globals environment above.
     static member DViewFuncs =
-        let ms : DFunc list -> DView = Multiset.ofList
+        let ms : DFunc list -> DView = Multiset.ofFlatList
         [ TestCaseData(ms [ { Name = "holdLock"; Params = [] }
                             { Name = "holdTick"; Params = [(Type.Int, "t")] } ])
              .Returns({ Name = "v_holdLock_holdTick"
@@ -54,7 +54,7 @@ type FlattenerTests() =
     /// Test cases for the full view func converter.
     /// These all use the Globals environment above.
     static member ViewFuncs =
-        let ms : VFunc list -> View = Multiset.ofList
+        let ms : VFunc list -> View = Multiset.ofFlatList
         [ TestCaseData(ms [ { Name = "holdLock"; Params = [] }
                             { Name = "holdTick"; Params = [AExpr (aUnmarked "t")] } ])
              .Returns({ Name = "v_holdLock_holdTick"

--- a/GraphTests.fs
+++ b/GraphTests.fs
@@ -49,7 +49,7 @@ type GraphTests() =
                             Command = [] },
                       Entry ))
                     ("unlock_V1",
-                     (Mandatory <| Multiset.empty (),
+                     (Mandatory <| Multiset.empty,
                       Set.singleton
                           { Name = "unlock_N0"
                             Dest = "unlock_V0"
@@ -103,7 +103,7 @@ type GraphTests() =
                 Some <|
                 { Nodes =
                       Map.ofList
-                          [ ("unlock_V1", (Mandatory <| Multiset.empty (),
+                          [ ("unlock_V1", (Mandatory <| Multiset.empty,
                                            EntryExit)) ]
                   Edges =
                       Map.ofList

--- a/GuardedView.fs
+++ b/GuardedView.fs
@@ -137,7 +137,7 @@ let (|ITEGuards|_|) ms =
     // {| G -> P |} is trivially equivalent to {| G -> P * ¬G -> emp |}.
     | [ x ] ->
         Some (x.Cond, Multiset.singleton { Cond = BTrue; Item = x.Item },
-              mkNot x.Cond, Multiset.empty ())
+              mkNot x.Cond, Multiset.empty)
     | _ -> None
 
 (*

--- a/GuardedView.fs
+++ b/GuardedView.fs
@@ -130,7 +130,7 @@ let (|Never|_|) { Cond = c ; Item = i } =
 ///     </para>
 /// </summary>
 let (|ITEGuards|_|) ms =
-    match (Multiset.toList ms) with
+    match (Multiset.toFlatList ms) with
     | [ x ; y ] when (equivHolds (negates x.Cond y.Cond)) ->
         Some (x.Cond, Multiset.singleton { Cond = BTrue; Item = x.Item },
               y.Cond, Multiset.singleton { Cond = BTrue; Item = y.Item })
@@ -224,11 +224,11 @@ let mapItems f = Multiset.map (mapItem f)
 /// </returns>
 let pruneGuardedSet gset =
     gset
-    |> Multiset.toSeq
+    |> Multiset.toFlatSeq
     |> Seq.filter (function
                    | Never _ -> false
                    | _       -> true)
-    |> Multiset.ofSeq
+    |> Multiset.ofFlatSeq
 
 
 /// <summary>

--- a/Guarder.fs
+++ b/Guarder.fs
@@ -20,8 +20,8 @@ let rec guardCFuncIn (suffix : Set<BoolExpr>) =
                 |> mkAnd
             Item = v } ]
     | CFunc.ITE(expr, tviews, fviews) ->
-        List.concat [ guardCViewIn (suffix.Add expr) (Multiset.toList tviews)
-                      guardCViewIn (suffix.Add(mkNot expr)) (Multiset.toList fviews) ]
+        List.concat [ guardCViewIn (suffix.Add expr) (Multiset.toFlatList tviews)
+                      guardCViewIn (suffix.Add(mkNot expr)) (Multiset.toFlatList fviews) ]
 
 /// Resolves a list of views, given a set of conditions held true.
 and guardCViewIn suffix = concatMap (guardCFuncIn suffix)
@@ -29,9 +29,9 @@ and guardCViewIn suffix = concatMap (guardCFuncIn suffix)
 /// Resolves a full condition-view multiset into a guarded-view multiset.
 let guardCView : CView -> GView =
     // TODO(CaptainHayashi): woefully inefficient.
-    Multiset.toList
+    Multiset.toFlatList
     >> guardCViewIn Set.empty
-    >> Multiset.ofList
+    >> Multiset.ofFlatList
 
 /// Resolves a full condition-view ViewExpr into a guarded-view multiset.
 let guardCViewExpr : ViewExpr<CView> -> ViewExpr<GView> =

--- a/GuarderTests.fs
+++ b/GuarderTests.fs
@@ -14,8 +14,8 @@ type GuarderTests() =
     
     /// Test cases for converting CondViews to GuarViews
     static member CondViews = 
-        let msec : CView = Multiset.empty()
-        let mseg : GView = Multiset.empty()
+        let msec : CView = Multiset.empty
+        let mseg : GView = Multiset.empty
         [ TestCaseData(msec).Returns(mseg).SetName("Convert the empty CView to the empty GView")
           
           TestCaseData(Multiset.ofList [ Func { Name = "foo"

--- a/GuarderTests.fs
+++ b/GuarderTests.fs
@@ -18,73 +18,76 @@ type GuarderTests() =
         let mseg : GView = Multiset.empty
         [ TestCaseData(msec).Returns(mseg).SetName("Convert the empty CView to the empty GView")
           
-          TestCaseData(Multiset.ofList [ Func { Name = "foo"
-                                                Params = [ AExpr(AConst(Unmarked "bar")) ] }
-                                         Func { Name = "bar"
-                                                Params = [ AExpr(AConst(Unmarked "baz")) ] } ])
-              .Returns(Multiset.ofList [ { Cond = BTrue
-                                           Item = 
-                                               { Name = "foo"
-                                                 Params = [ AExpr(AConst(Unmarked "bar")) ] } }
-                                         { Cond = BTrue
-                                           Item = 
-                                               { Name = "bar"
-                                                 Params = [ AExpr(AConst(Unmarked "baz")) ] } } ])
+          TestCaseData(Multiset.ofFlatList [ Func { Name = "foo"
+                                                    Params = [ AExpr(AConst(Unmarked "bar")) ] }
+                                             Func { Name = "bar"
+                                                    Params = [ AExpr(AConst(Unmarked "baz")) ] } ])
+              .Returns(Multiset.ofFlatList [ { Cond = BTrue
+                                               Item = 
+                                                   { Name = "foo"
+                                                     Params = [ AExpr(AConst(Unmarked "bar")) ] } }
+                                             { Cond = BTrue
+                                               Item = 
+                                                   { Name = "bar"
+                                                     Params = [ AExpr(AConst(Unmarked "baz")) ] } } ])
               .SetName("Convert a flat CondView-list to a GuarView-list with no guards")
           
-          TestCaseData(Multiset.ofList [ CFunc.ITE((BConst(Unmarked "s")), 
-                                             Multiset.ofList [ Func { Name = "foo"
-                                                                      Params = [ AExpr(AConst(Unmarked "bar")) ] } ], 
-                                             Multiset.ofList [ Func { Name = "bar"
-                                                                      Params = [ AExpr(AConst(Unmarked "baz")) ] } ]) ])
-              .Returns(Multiset.ofList [ { Cond = BConst(Unmarked "s")
-                                           Item = 
-                                               { Name = "foo"
-                                                 Params = [ AExpr(AConst(Unmarked "bar")) ] } }
-                                         { Cond = BNot(BConst(Unmarked "s"))
-                                           Item = 
-                                               { Name = "bar"
-                                                 Params = [ AExpr(AConst(Unmarked "baz")) ] } } ])
+          TestCaseData(Multiset.ofFlatList [ CFunc.ITE((BConst(Unmarked "s")), 
+                                                       Multiset.ofFlatList [ Func { Name = "foo"
+                                                                                    Params = [ AExpr(AConst(Unmarked "bar")) ] } ], 
+                                                       Multiset.ofFlatList [ Func { Name = "bar"
+                                                                                    Params = [ AExpr(AConst(Unmarked "baz")) ] } ]) ])
+              .Returns(Multiset.ofFlatList [ { Cond = BConst(Unmarked "s")
+                                               Item = 
+                                                   { Name = "foo"
+                                                     Params = [ AExpr(AConst(Unmarked "bar")) ] } }
+                                             { Cond = BNot(BConst(Unmarked "s"))
+                                               Item = 
+                                                   { Name = "bar"
+                                                     Params = [ AExpr(AConst(Unmarked "baz")) ] } } ])
               .SetName("Convert a singly-nested CondView-list to a GuarView-list with unit guards")
           
-          TestCaseData(Multiset.ofList [ CFunc.ITE(BConst(Unmarked "s"), 
-                                             Multiset.ofList [ CFunc.ITE(BConst(Unmarked "t"), 
-                                                                   Multiset.ofList [ Func { Name = "foo"
-                                                                                            Params = [ AExpr(AConst(Unmarked "bar")) ] }
-                                                                                     Func { Name = "bar"
-                                                                                            Params = [ AExpr(AConst(Unmarked "baz")) ] } ], 
-                                                                   Multiset.ofList [ Func { Name = "fizz"
-                                                                                            Params = [ AExpr(AConst(Unmarked "buzz")) ] } ])
-                                                               Func { Name = "in"
-                                                                      Params = [ AExpr(AConst(Unmarked "out")) ] } ], 
-                                             Multiset.ofList [ Func { Name = "ding"
-                                                                      Params = [ AExpr(AConst(Unmarked "dong")) ] } ]) ])
-              .Returns(Multiset.ofList [ { Cond = 
-                                               BAnd [ BConst(Unmarked "s")
-                                                      BConst(Unmarked "t") ]
-                                           Item = 
-                                               { Name = "foo"
-                                                 Params = [ AExpr(AConst(Unmarked "bar")) ] } }
-                                         { Cond = 
-                                               BAnd [ BConst(Unmarked "s")
-                                                      BConst(Unmarked "t") ]
-                                           Item = 
-                                               { Name = "bar"
-                                                 Params = [ AExpr(AConst(Unmarked "baz")) ] } }
-                                         { Cond = 
-                                               BAnd [ BConst(Unmarked "s")
-                                                      BNot(BConst(Unmarked "t")) ]
-                                           Item = 
-                                               { Name = "fizz"
-                                                 Params = [ AExpr(AConst(Unmarked "buzz")) ] } }
-                                         { Cond = BConst(Unmarked "s")
-                                           Item = 
-                                               { Name = "in"
-                                                 Params = [ AExpr(AConst(Unmarked "out")) ] } }
-                                         { Cond = BNot(BConst(Unmarked "s"))
-                                           Item = 
-                                               { Name = "ding"
-                                                 Params = [ AExpr(AConst(Unmarked "dong")) ] } } ])
+          TestCaseData(Multiset.ofFlatList
+                           [ CFunc.ITE(BConst(Unmarked "s"), 
+                                       Multiset.ofFlatList
+                                           [ CFunc.ITE(BConst(Unmarked "t"), 
+                                                       Multiset.ofFlatList [ Func { Name = "foo"
+                                                                                    Params = [ AExpr(AConst(Unmarked "bar")) ] }
+                                                                             Func { Name = "bar"
+                                                                                    Params = [ AExpr(AConst(Unmarked "baz")) ] } ], 
+                                                       Multiset.ofFlatList [ Func { Name = "fizz"
+                                                                                    Params = [ AExpr(AConst(Unmarked "buzz")) ] } ])
+                                             Func { Name = "in"
+                                                    Params = [ AExpr(AConst(Unmarked "out")) ] } ], 
+                                       Multiset.ofFlatList
+                                           [ Func { Name = "ding"
+                                                    Params = [ AExpr(AConst(Unmarked "dong")) ] } ]) ])
+              .Returns(Multiset.ofFlatList [ { Cond = 
+                                                   BAnd [ BConst(Unmarked "s")
+                                                          BConst(Unmarked "t") ]
+                                               Item = 
+                                                   { Name = "foo"
+                                                     Params = [ AExpr(AConst(Unmarked "bar")) ] } }
+                                             { Cond = 
+                                                   BAnd [ BConst(Unmarked "s")
+                                                          BConst(Unmarked "t") ]
+                                               Item = 
+                                                   { Name = "bar"
+                                                     Params = [ AExpr(AConst(Unmarked "baz")) ] } }
+                                             { Cond = 
+                                                   BAnd [ BConst(Unmarked "s")
+                                                          BNot(BConst(Unmarked "t")) ]
+                                               Item = 
+                                                   { Name = "fizz"
+                                                     Params = [ AExpr(AConst(Unmarked "buzz")) ] } }
+                                             { Cond = BConst(Unmarked "s")
+                                               Item = 
+                                                   { Name = "in"
+                                                     Params = [ AExpr(AConst(Unmarked "out")) ] } }
+                                             { Cond = BNot(BConst(Unmarked "s"))
+                                               Item = 
+                                                   { Name = "ding"
+                                                     Params = [ AExpr(AConst(Unmarked "dong")) ] } } ])
               .SetName("Convert a complex-nested CondView-list to a GuarView-list with complex guards") ]
     
     // Test conversion of CViews into GViews.

--- a/Horn.fs
+++ b/Horn.fs
@@ -333,7 +333,7 @@ let hsfGFunc dvs env { Cond = c; Item = ms } =
 let hsfConditionBody dvs env ps sem =
     let psH =
         ps
-        |> Multiset.toSeq
+        |> Multiset.toFlatSeq
         |> Seq.choose (hsfGFunc dvs env)
         |> collect
         |> lift List.ofSeq

--- a/InstantiateTests.fs
+++ b/InstantiateTests.fs
@@ -58,7 +58,7 @@ type InstantiateTests() =
           TestCaseData(vfunc "baz" [BTrue |> BExpr ; aAfter "burble" |> AExpr])
             .Returns([TypeMismatch ((Int, "quux"), Bool)
                       TypeMismatch ((Bool, "flop"), Int)] |> Some)
-            .SetName("Instantiate func with two arguments of different types") ]
+            .SetName("Instantiate func with two arguments of incorrect types") ]
           
     /// Tests whether invalid instantiations (don't) work.
     [<TestCaseSource("InvalidInstantiations")>]

--- a/Model.fs
+++ b/Model.fs
@@ -162,7 +162,7 @@ module Pretty =
 
     /// Pretty-prints a multiset given a printer for its contents.
     let printMultiset pItem =
-        Multiset.toList
+        Multiset.toFlatList
         >> List.map pItem
         >> semiSep
 

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -558,7 +558,7 @@ let modelViewDef svars vprotos { CView = av; CExpression = ae } =
         let! c = match ae with
                  | Some dae -> modelBoolExpr e dae |> lift Some |> mapMessages (curry CEExpr dae)
                  | _ -> ok None
-        return { View = Multiset.ofSeq v
+        return { View = Multiset.ofFlatSeq v
                  Def = c }
     }
     |> mapMessages (curry BadConstraint av)
@@ -590,8 +590,8 @@ let inViewDefs viewdefs dview =
              then
                  List.forall2
                      (fun vdfunc dfunc -> vdfunc.Name = dfunc.Name)
-                     (Multiset.toList viewdef)
-                     (Multiset.toList dview)
+                     (Multiset.toFlatList viewdef)
+                     (Multiset.toFlatList dview)
              else false)
         viewdefs
 
@@ -648,7 +648,7 @@ let genAllViewsAt depth funcs =
     let rec f depth existing =
         match depth with
         // Multiset and set conversion removes duplicate views.
-        | 0 -> existing |> Seq.map Multiset.ofList |> Set.ofSeq
+        | 0 -> existing |> Seq.map Multiset.ofFlatList |> Set.ofSeq
         | n ->
             let existing' =
                 seq { yield []

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -745,7 +745,7 @@ let rec modelCView protos ls =
                  |> mapMessages (curry ViewError.BadExpr e))
               (modelCView protos ls l)
               (modelCView protos ls r)
-    | Unit -> Multiset.empty() |> ok
+    | Unit -> Multiset.empty |> ok
     | Join(l, r) ->
         lift2 (Multiset.append)
               (modelCView protos ls l)

--- a/ModellerTests.fs
+++ b/ModellerTests.fs
@@ -33,14 +33,14 @@ type ModellerTests() =
                      ("baz", Type.Bool)
                      ("emp", Type.Bool) ]
 
-    static member EmptyCView : unit -> CView = Multiset.empty
+    static member EmptyCView : CView = Multiset.empty
 
     /// <summary>
     ///     Test cases for checking view modelling on correct view exprs.
     /// </summary>
     static member ViewExprsGood =
         [ TestCaseData(View.Unit)
-             .Returns(Some (ModellerTests.EmptyCView ()))
+             .Returns(Some (ModellerTests.EmptyCView))
              .SetName("Modelling the unit view returns the empty multiset")
           TestCaseData(afunc "holdLock" [] |> View.Func)
              .Returns(Some (Multiset.singleton (CFunc.Func (vfunc "holdLock" []))))
@@ -203,7 +203,7 @@ type ModellerTests() =
              .SetName("Searching for no viewdefs does not change a full viewdef set")
           TestCaseData({ Search = Some 0; InitDefs = []})
              .Returns(ModellerTests.viewDefSet
-                          [ { View = Multiset.empty ()
+                          [ { View = Multiset.empty
                               Def = None }])
              .SetName("Searching for size-0 viewdefs adds emp to an empty viewdef set")
           TestCaseData({ Search = Some 0; InitDefs = ticketLockViewDefs })
@@ -211,7 +211,7 @@ type ModellerTests() =
              .SetName("Searching for size-0 viewdefs does not change a full viewdef set")
           TestCaseData({ Search = Some 1; InitDefs = [] })
              .Returns(ModellerTests.viewDefSet
-                          [ { View = Multiset.empty ()
+                          [ { View = Multiset.empty
                               Def = None }
                             { View = Multiset.singleton (func "holdLock" [])
                               Def = None }
@@ -220,7 +220,7 @@ type ModellerTests() =
              .SetName("Searching for size-1 viewdefs yields viewdefs for emp and the view prototypes")
           TestCaseData({ Search = Some 2; InitDefs = [] })
              .Returns(ModellerTests.viewDefSet
-                          [ { View = Multiset.empty ()
+                          [ { View = Multiset.empty
                               Def = None }
                             { View = Multiset.singleton (func "holdLock" [])
                               Def = None }

--- a/ModellerTests.fs
+++ b/ModellerTests.fs
@@ -224,17 +224,20 @@ type ModellerTests() =
                               Def = None }
                             { View = Multiset.singleton (func "holdLock" [])
                               Def = None }
-                            { View = Multiset.ofList [ func "holdLock" []
-                                                       func "holdLock" [] ]
+                            { View = Multiset.ofFlatList
+                                         [ func "holdLock" []
+                                           func "holdLock" [] ]
                               Def = None }
-                            { View = Multiset.ofList [ func "holdLock" []
-                                                       func "holdTick" [(Type.Int, "t0")] ]
+                            { View = Multiset.ofFlatList
+                                         [ func "holdLock" []
+                                           func "holdTick" [(Type.Int, "t0")] ]
                               Def = None }
                             { View = Multiset.singleton (func "holdTick" [(Type.Int, "t0")])
                               Def = None }
 
-                            { View = Multiset.ofList [ func "holdTick" [(Type.Int, "t0")]
-                                                       func "holdTick" [(Type.Int, "t1")] ]
+                            { View = Multiset.ofFlatList
+                                         [ func "holdTick" [(Type.Int, "t0")]
+                                           func "holdTick" [(Type.Int, "t1")] ]
                               Def = None }])
              .SetName("Searching for size-2 viewdefs yields the correct views") ]
 

--- a/Reifier.fs
+++ b/Reifier.fs
@@ -12,7 +12,7 @@ open Starling.Core.GuardedView
 /// Tries to look up a multiset View in the defining views dvs.
 let findDefOfView dvs uviewm =
     // Why we do this is explained later.
-    let uview = Multiset.toList uviewm
+    let uview = Multiset.toFlatList uviewm
     (* We look up view-defs based on count of views and names of each
      * view in the def.
      *
@@ -24,7 +24,7 @@ let findDefOfView dvs uviewm =
          * so convert both sides to a (sorted) list.  We rely on the
          * sortedness to make the next step sound.
          *)
-        let vd = Multiset.toList vdm
+        let vd = Multiset.toFlatList vdm
         (* Do these two views have the same number of terms?
          * If not, using forall2 is an error.
          *)
@@ -42,18 +42,18 @@ let reifySingle view =
     let guars, views = 
         view
         |> Multiset.map gFuncTuple
-        |> Multiset.toList
+        |> Multiset.toFlatList
         |> List.unzip
     { // Then, separately add them into a ReView.
       Cond = mkAnd guars
-      Item = Multiset.ofList views }
+      Item = Multiset.ofFlatList views }
 
 /// Reifies an entire view application.
 let reifyView vap = 
     vap
     |> Multiset.power
     |> Seq.map reifySingle
-    |> Multiset.ofSeq
+    |> Multiset.ofFlatSeq
 
 /// Reifies all of the views in a term.
 let reifyTerm = 

--- a/ReifierTests.fs
+++ b/ReifierTests.fs
@@ -17,29 +17,33 @@ type ReifierTests() =
         // TODO(CaptainHayashi): this isn't part of the reifier anymore...
         [   (
                 new TestCaseData(
-                    Multiset.ofList [ { Name = "holdLock"
-                                        Params = [] }
-                                      { Name = "holdTick"
-                                        Params = [ AExpr (aUnmarked "t") ] } ]
+                    Multiset.ofFlatList
+                        [ { Name = "holdLock"
+                            Params = [] }
+                          { Name = "holdTick"
+                            Params = [ AExpr (aUnmarked "t") ] } ]
                 )
             ).Returns(
-                Some(Multiset.ofList [ { Name = "holdLock"
-                                         Params = [] }
-                                       { Name = "holdTick"
-                                         Params = [ (Type.Int, "t") ] } ])
+                Some(Multiset.ofFlatList
+                         [ { Name = "holdLock"
+                             Params = [] }
+                           { Name = "holdTick"
+                             Params = [ (Type.Int, "t") ] } ])
             ).SetName("Find definition of view in the same order")
             (
                 new TestCaseData(
-                    Multiset.ofList [ { Name = "holdTick"
-                                        Params = [ AExpr (aUnmarked "t") ] }
-                                      { Name = "holdLock"
-                                        Params = [] } ]
+                    Multiset.ofFlatList
+                        [ { Name = "holdTick"
+                            Params = [ AExpr (aUnmarked "t") ] }
+                          { Name = "holdLock"
+                            Params = [] } ]
                 )
             ).Returns(
-                Some(Multiset.ofList [ { Name = "holdLock"
-                                         Params = [] }
-                                       { Name = "holdTick"
-                                         Params = [ (Type.Int, "t") ] } ])
+                Some(Multiset.ofFlatList
+                         [ { Name = "holdLock"
+                             Params = [] }
+                           { Name = "holdTick"
+                             Params = [ (Type.Int, "t") ] } ])
             ).SetName("Find definition of view in a reversed order")
         ]
 

--- a/TermGen.fs
+++ b/TermGen.fs
@@ -85,13 +85,13 @@ let termGenPre gax =
     let pre =
         gax.Axiom.Pre
         |> subExprInGView (liftMarker Before always)
-        |> Multiset.toList
+        |> Multiset.toFlatList
     let post =
         gax.Axiom.Post
         |> subExprInGView (liftMarker After always)
-        |> Multiset.toList
-    let goal = gax.Goal |> Multiset.toList
-    List.append pre (termGenFrame goal post) |> Multiset.ofList
+        |> Multiset.toFlatList
+    let goal = gax.Goal |> Multiset.toFlatList
+    List.append pre (termGenFrame goal post) |> Multiset.ofFlatList
 
 /// Generates a term from a goal axiom.
 let termGenAxiom gax =

--- a/TermGen.fs
+++ b/TermGen.fs
@@ -67,7 +67,11 @@ let termGenFrame r q =
      * Since r is unguarded at the start of the minus, we lift it
      * to the guarded view (true|r).
      *)
-    List.fold termGenFrameView (List.map guard r) q
+    let rl, ql = Multiset.toFlatList r, Multiset.toFlatList q
+
+    ql
+    |> List.fold termGenFrameView (List.map guard rl)
+    |> Multiset.ofFlatList
 
 /// Generates a (weakest) precondition from a framed axiom.
 let termGenPre gax =
@@ -85,13 +89,12 @@ let termGenPre gax =
     let pre =
         gax.Axiom.Pre
         |> subExprInGView (liftMarker Before always)
-        |> Multiset.toFlatList
     let post =
         gax.Axiom.Post
         |> subExprInGView (liftMarker After always)
-        |> Multiset.toFlatList
-    let goal = gax.Goal |> Multiset.toFlatList
-    List.append pre (termGenFrame goal post) |> Multiset.ofFlatList
+    let goal = gax.Goal
+
+    Multiset.append pre (termGenFrame goal post)
 
 /// Generates a term from a goal axiom.
 let termGenAxiom gax =

--- a/TestStudies.fs
+++ b/TestStudies.fs
@@ -184,7 +184,7 @@ let sIsT = aEq (aUnmarked "s") (aUnmarked "t")
 let ticketLockLock =
     { Signature = func "lock" []
       Body =
-          { Pre = Mandatory <| Multiset.empty()
+          { Pre = Mandatory <| Multiset.empty
             Contents =
                 [ { Command =
                         func "!ILoad++"
@@ -221,7 +221,7 @@ let ticketLockUnlock =
                 [ { Command =
                         func "!I++" [ AExpr (aBefore "serving"); AExpr (aAfter "serving") ]
                         |> List.singleton |> Prim
-                    Post = Mandatory <| Multiset.empty() }]}}
+                    Post = Mandatory <| Multiset.empty }]}}
 
 /// The methods of the ticket lock.
 let ticketLockMethods =
@@ -233,7 +233,7 @@ let ticketLockMethods =
 let ticketLockGuardedLock =
     { Signature = func "lock" []
       Body =
-          { Pre = Mandatory <| Multiset.empty()
+          { Pre = Mandatory <| Multiset.empty
             Contents =
                 [ { Command =
                         func "!ILoad++"
@@ -268,11 +268,11 @@ let ticketLockGuardedUnlock : PMethod<ViewExpr<GView>> =
                 [ { Command =
                         func "!I++" [ AExpr (aBefore "serving"); AExpr (aAfter "serving") ]
                         |> List.singleton |> Prim
-                    Post = Mandatory <| Multiset.empty() } ] } }
+                    Post = Mandatory <| Multiset.empty } ] } }
 
 /// The view definitions of the ticket lock model.
 let ticketLockViewDefs =
-    [ { View = Multiset.empty()
+    [ { View = Multiset.empty
         Def = Some <| BGe(aUnmarked "ticket", aUnmarked "serving") }
       { View =
             Multiset.ofList [ { Name = "holdTick"
@@ -318,7 +318,7 @@ let ticketLockLockSubgraph : Subgraph =
     { Nodes =
           Map.ofList
               [ ("lock_V0",
-                     (Mandatory <| Multiset.empty (), Entry))
+                     (Mandatory <| Multiset.empty, Entry))
                 ("lock_V1", (Mandatory <| sing (gHoldTick BTrue), Normal))
                 ("lock_V2", (Mandatory <| sing (gHoldLock BTrue), Exit))
                 ("lock_V3", (Mandatory <| sing (gHoldTick BTrue), Normal))
@@ -370,7 +370,7 @@ let ticketLockUnlockSubgraph : Subgraph =
                      (Mandatory <|
                       Multiset.singleton
                          (gfunc BTrue "holdLock" [] ), Entry))
-                ("unlock_V1", (Mandatory <| Multiset.empty () , Exit)) ]
+                ("unlock_V1", (Mandatory <| Multiset.empty, Exit)) ]
       Edges =
            Map.ofList
               [ ("unlock_C0",
@@ -385,7 +385,7 @@ let ticketLockLockGraph : Graph =
       Contents =
           Map.ofList
               [ ("lock_V0",
-                 ((Mandatory <| Multiset.empty (),
+                 ((Mandatory <| Multiset.empty,
                    Set.singleton
                       { OutEdge.Name = "lock_C0"
                         OutEdge.Dest = "lock_V1"
@@ -494,7 +494,7 @@ let ticketLockUnlockGraph : Graph =
                   Set.empty,
                   Entry))
                 ("unlock_V1",
-                 (Mandatory <| Multiset.empty (),
+                 (Mandatory <| Multiset.empty,
                   Set.empty,
                   Set.singleton
                       { Name = "unlock_C0"

--- a/TestStudies.fs
+++ b/TestStudies.fs
@@ -254,7 +254,7 @@ let ticketLockGuardedLock =
                                                  |> List.singleton |> Prim
                                              Post =
                                                  Mandatory <|
-                                                 Multiset.ofList
+                                                 Multiset.ofFlatList
                                                      [ gHoldLock sIsT
                                                        gHoldTick (BNot sIsT) ] } ] } )
                     Post = Mandatory <| sing (gHoldLock BTrue) } ] } }
@@ -275,30 +275,35 @@ let ticketLockViewDefs =
     [ { View = Multiset.empty
         Def = Some <| BGe(aUnmarked "ticket", aUnmarked "serving") }
       { View =
-            Multiset.ofList [ { Name = "holdTick"
-                                Params = [ (Type.Int, "t") ] } ]
+            Multiset.ofFlatList
+                [ { Name = "holdTick"
+                    Params = [ (Type.Int, "t") ] } ]
         Def = Some <| BGt(aUnmarked "ticket", aUnmarked "t") }
       { View =
-            Multiset.ofList [ { Name = "holdLock"
-                                Params = [] } ]
+            Multiset.ofFlatList
+                [ { Name = "holdLock"
+                    Params = [] } ]
         Def = Some <| BGt(aUnmarked "ticket", aUnmarked "serving") }
       { View =
-            Multiset.ofList [ { Name = "holdLock"
-                                Params = [] }
-                              { Name = "holdTick"
-                                Params = [ (Type.Int, "t") ] } ]
+            Multiset.ofFlatList
+                [ { Name = "holdLock"
+                    Params = [] }
+                  { Name = "holdTick"
+                    Params = [ (Type.Int, "t") ] } ]
         Def = Some <| BNot(aEq (aUnmarked "serving") (aUnmarked "t")) }
       { View =
-            Multiset.ofList [ { Name = "holdTick"
-                                Params = [ (Type.Int, "ta") ] }
-                              { Name = "holdTick"
-                                Params = [ (Type.Int, "tb") ] } ]
+            Multiset.ofFlatList
+                [ { Name = "holdTick"
+                    Params = [ (Type.Int, "ta") ] }
+                  { Name = "holdTick"
+                    Params = [ (Type.Int, "tb") ] } ]
         Def = Some <| BNot(aEq (aUnmarked "ta") (aUnmarked "tb")) }
       { View =
-            Multiset.ofList [ { Name = "holdLock"
-                                Params = [] }
-                              { Name = "holdLock"
-                                Params = [] } ]
+            Multiset.ofFlatList
+                [ { Name = "holdLock"
+                    Params = [] }
+                  { Name = "holdLock"
+                    Params = [] } ]
         Def = Some <| BFalse } ]
 
 /// The model of the ticket lock.
@@ -324,7 +329,7 @@ let ticketLockLockSubgraph : Subgraph =
                 ("lock_V3", (Mandatory <| sing (gHoldTick BTrue), Normal))
                 ("lock_V4",
                      (Mandatory <|
-                      Multiset.ofList
+                      Multiset.ofFlatList
                          [ gHoldLock sIsT
                            gHoldTick (BNot sIsT) ], Normal)) ]
       Edges =
@@ -448,7 +453,7 @@ let ticketLockLockGraph : Graph =
                    Normal))
                 ("lock_V4",
                  (Mandatory <|
-                  Multiset.ofList
+                  Multiset.ofFlatList
                       [ gHoldLock sIsT
                         gHoldTick (BNot sIsT) ],
                   Set.ofList

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -108,7 +108,7 @@ module Translator =
 
     /// Interprets an entire view application over the given functable.
     let interpretGView ft =
-        Multiset.toSeq
+        Multiset.toFlatSeq
         >> Seq.map (interpretGFunc ft)
         >> collect
         >> lift Seq.toList

--- a/starling.fsproj
+++ b/starling.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -43,8 +43,8 @@
   <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
-    <Compile Include="Collections.fs" />
     <Compile Include="Utils.fs" />
+    <Compile Include="Collections.fs" />
     <Compile Include="Pretty.fs" />
     <Compile Include="Var.fs" />
     <Compile Include="Expr.fs" />

--- a/starling.sln
+++ b/starling.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "starling", "starling.fsproj", "{FB248950-5C1B-4AE6-B7AE-E167C623D60F}"
 EndProject


### PR DESCRIPTION
**NOTE**: This pull request is based on `mw-cfg-optimise`, not `master`.  Merging this will merge the former in if it hasn't already gone through!

This is a small⁺ pull request converting the multiset representation from a sorted list to an occurrence map.  It currently keeps the same interface (with some renaming), because I don't yet have a metatheoretically correct multiset minus on anything other than removing 1 func from 1 func.

We now also have unit tests for some multiset operations, as well as a small amount of term generation tests ready for when we change the term generator to allow iterated views.

⁺if `mw-cfg-optimise` goes through
