### PR TITLE
Experimental µZ3 backend.

### DIFF
--- a/Expr.fs
+++ b/Expr.fs
@@ -386,20 +386,26 @@ let getFresh fg =
  * Expression probing
  *)
 
-/// Returns a set of all variables used in an arithmetic expression.
+/// <summary>
+///     Returns a set of all variables used in an arithmetic expression,
+///     paired with their types.
+/// </summary>
 let rec varsInArith =
     function
-    | AConst c -> Set.singleton c
+    | AConst c -> Set.singleton (c, Type.Int)
     | AInt _ -> Set.empty
     | AAdd xs -> xs |> Seq.map varsInArith |> Set.unionMany
     | ASub xs -> xs |> Seq.map varsInArith |> Set.unionMany
     | AMul xs -> xs |> Seq.map varsInArith |> Set.unionMany
     | ADiv (x, y) -> Set.union (varsInArith x) (varsInArith y)
 
-/// Returns a set of all variables used in a Boolean expression.
+/// <summary>
+///     Returns a set of all variables used in a Boolean expression,
+///     paired with their types.
+/// </summary>
 and varsInBool =
     function
-    | BConst c -> Set.singleton c
+    | BConst c -> Set.singleton (c, Type.Bool)
     | BTrue -> Set.empty
     | BFalse -> Set.empty
     | BAnd xs -> xs |> Seq.map varsInBool |> Set.unionMany
@@ -512,8 +518,8 @@ let (|SimpleExpr|CompoundExpr|) =
 
 /// Partial pattern that matches a Boolean expression in terms of exactly one /
 /// constant.
-let rec (|ConstantBoolFunction|_|) = varsInBool >> onlyOne
+let rec (|ConstantBoolFunction|_|) = varsInBool >> Seq.map fst >> onlyOne
 
 /// Partial pattern that matches a Boolean expression in terms of exactly one /
 /// constant.
-let rec (|ConstantArithFunction|_|) = varsInArith >> onlyOne
+let rec (|ConstantArithFunction|_|) = varsInArith >> Seq.map fst >> onlyOne

--- a/ExprEquiv.fs
+++ b/ExprEquiv.fs
@@ -98,8 +98,8 @@ let andEquiv x y : Equiv =
 /// </remarks>
 let equiv x y =
     fun ctx ->
-        let sx, sy = (x |> simp |> Expr.boolToZ3 ctx,
-                      y |> simp |> Expr.boolToZ3 ctx)
+        let sx, sy = (x |> simp |> Expr.boolToZ3 false ctx,
+                      y |> simp |> Expr.boolToZ3 false ctx)
         ctx.MkIff (sx, sy)
 
 /// <summary>

--- a/GuardedView.fs
+++ b/GuardedView.fs
@@ -46,6 +46,7 @@ module Types =
           ///    The guarded item.
           /// </summary>
           Item : 'item }
+        override this.ToString() = sprintf "(%A -> %A)" this.Cond this.Item
 
     (*
      * Shorthand for guarded items.

--- a/GuardedView.fs
+++ b/GuardedView.fs
@@ -17,6 +17,7 @@ module Starling.Core.GuardedView
 open Starling.Collections
 open Starling.Core.Expr
 open Starling.Core.ExprEquiv
+open Starling.Core.Var
 open Starling.Core.Model
 
 
@@ -140,6 +141,29 @@ let (|ITEGuards|_|) ms =
         Some (x.Cond, Multiset.singleton { Cond = BTrue; Item = x.Item },
               mkNot x.Cond, Multiset.empty)
     | _ -> None
+
+
+(*
+ * Variable querying.
+ *)
+
+/// <summary>
+///     Extracts a sequence of all variables in a <c>GFunc</c>.
+/// </summary>
+/// <param name="_arg1">
+///     The <c>GFunc</c> to query.
+/// </param>
+/// <returns>
+///     A sequence of (<c>Const</c>, <c>Type</c>) pairs that represent all of
+///     the variables used in the <c>GFunc</c>.
+/// </returns>
+let varsInGFunc { Cond = guard ; Item = func } =
+    seq {
+        yield! (varsInBool guard)
+        for param in func.Params do
+            yield! (varsIn param)
+    }
+
 
 (*
  * Destructuring and mapping.
@@ -302,3 +326,39 @@ module Pretty =
     let printViewSet =
         printMultiset (printGuarded printOView >> ssurround "((" "))")
         >> ssurround "(|" "|)"
+
+
+/// <summary>
+///     Tests for guarded views.
+/// </summary>
+module Tests =
+    open NUnit.Framework
+
+    /// <summary>
+    ///     NUnit tests for guarded views.
+    /// </summary>
+    type NUnit () =
+        /// <summary>
+        ///     Test cases for extracting variables from <c>GFunc</c>s.
+        /// </summary>
+        static member VarsInGFuncCases =
+            [ TestCaseData(gfunc BTrue "foo" [])
+                  .Returns(Set.empty : Set<(Const * Type)>)
+                  .SetName("GFunc with no guard and no parameters has no variables")
+              TestCaseData(gfunc (bUnmarked "bar") "foo" [])
+                  .Returns((Set.singleton (Unmarked "bar", Bool)) : Set<(Const * Type)>)
+                  .SetName("Variables in a GFunc's guard are returned by varsInGFunc")
+              TestCaseData(gfunc BTrue "foo" [ BExpr (bAfter "x")
+                                               AExpr (aBefore "y") ] )
+                  .Returns((Set.ofArray
+                                [| (After "x", Bool)
+                                   (Before "y", Int) |]): Set<(Const * Type)>)
+                  .SetName("Variables in a GFunc's parameters are returned by varsInGFunc") ]
+
+        /// <summary>
+        ///     Tests <c>varsInGFunc</c>.
+        /// </summary>
+        [<TestCaseSource("VarsInGFuncCases")>]
+        member this.testVarsInGFunc gf =
+            gf |> varsInGFunc |> Set.ofSeq
+

--- a/GuardedView.fs
+++ b/GuardedView.fs
@@ -92,7 +92,7 @@ module Types =
 /// <returns>
 ///     A new <c>GFunc</c> with the given guard, name, and parameters.
 /// </returns>
-let gfunc guard name pars = { Cond = guard ; Item = func name pars }
+let gfunc guard name pars = { Cond = guard ; Item = vfunc name pars }
 
 
 (*

--- a/Instantiate.fs
+++ b/Instantiate.fs
@@ -149,15 +149,15 @@ let funcsInTable (ftab : FuncTable<'defn>) =
 ///     Checks whether <c>func</c> and <c>_arg1</c> agree on parameter
 ///     count.
 /// </summary>
-/// <parameter name="func">
+/// <param name="func">
 ///     The func being looked up, the process of which this check is part.
-/// </parameter>
-/// <parameter name="_arg1">
+/// </param>
+/// <param name="_arg1">
 ///     An <c>Option</c>al pair of <c>DFunc</c> and its defining
 ///     <c>BoolExpr</c>.
 ///     The value <c>None</c> suggests that <c>func</c> has no definition,
 ///     which can be ok (eg. if the <c>func</c> is a non-defining view).
-/// </parameter>
+/// </param>
 /// <returns>
 ///     A Chessie result, where the <c>ok</c> value is the optional pair of
 ///     prototype func and definition, and the failure value is a
@@ -174,18 +174,18 @@ let checkParamCount func =
 /// <summary>
 ///     Look up <c>func</c> in <c>_arg1</c>.
 ///
-///     <param>
+///     <para>
 ///         This checks that the use of <c>func</c> agrees on the number of
 ///         parameters, but not necessarily types.  You will need to add
 ///         type checking if needed.
-///     </param>
+///     </para>
 /// </summary>
-/// <parameter name="func">
+/// <param name="func">
 ///     The func to look up in <c>_arg1</c>.
-/// </parameter>
-/// <parameter name="_arg1">
+/// </param>
+/// <param name="_arg1">
 ///     An associative sequence mapping <c>Func</c>s to some definition.
-/// </parameter>
+/// </param>
 /// <returns>
 ///     A Chessie result, where the <c>ok</c> value is an <c>Option</c>
 ///     containing the pair of
@@ -202,12 +202,12 @@ let lookup func =
 ///     Checks whether <c>func</c> and <c>_arg1</c> agree on parameter
 ///     types.
 /// </summary>
-/// <parameter name="func">
+/// <param name="func">
 ///     The func being looked up, the process of which this check is part.
-/// </parameter>
-/// <parameter name="def">
+/// </param>
+/// <param name="def">
 ///     The <c>DFunc</c> that <paramref name="func" /> has matched.
-/// </parameter>
+/// </param>
 /// <returns>
 ///     A Chessie result, where the <c>ok</c> value is
 ///     <paramref name="func" />, and the failure value is a
@@ -269,19 +269,19 @@ let paramSubFun {Params = fpars} {Params = dpars} =
 ///     value of <c>expr</c> with the arguments of <c>func</c>
 ///     substituted for the parameters of <c>dfunc</c>.
 /// </summary>
-/// <parameter name="func">
+/// <param name="func">
 ///     The <c>VFunc</c> whose arguments are to be substituted into
 ///     <c>expr</c>.
-/// </parameter>
-/// <parameter name="dfunc">
+/// </param>
+/// <param name="dfunc">
 ///     The <c>VFunc</c> whose parameters in <c>expr</c> are to be
 ///     replaced.
-/// </parameter>
-/// <parameter name="expr">
+/// </param>
+/// <param name="expr">
 ///     The <c>BoolExpr</c> in which each instance of a parameter from
 ///     <c>dfunc</c> is to be replaced with its argument in
 ///     <c>func</c>.
-/// </parameter>
+/// </param>
 /// <returns>
 ///     <c>expr</c> with the substitutions above made.
 /// </returns>
@@ -293,14 +293,14 @@ let substitute func dfunc expr =
 ///     resulting Boolean expression, substituting <c>func.Params</c>
 ///     for the parameters in the expression.
 /// </summary>
-/// <parameter name="func">
+/// <param name="func">
 ///     The <c>VFunc</c> whose arguments are to be substituted into
 ///     its definition in <c>_arg1</c>.
-/// </parameter>
-/// <parameter name="_arg1">
+/// </param>
+/// <param name="_arg1">
 ///     The <c>FuncTable</c> whose definition for <c>func</c> is to be
 ///     instantiated.
-/// </parameter>
+/// </param>
 /// <returns>
 ///     The instantiation of <c>func</c> as an <c>Option</c>al
 ///     <c>BoolExpr</c>.

--- a/Instantiate.fs
+++ b/Instantiate.fs
@@ -106,6 +106,26 @@ let makeFuncTable fseq : FuncTable<'defn> =
     Seq.toList fseq
 
 /// <summary>
+///     Creates a <c>FuncTable</c> from a sequence of <c>ViewDef</c>s.
+/// </summary>
+/// <param name="viewdefs">
+///     The view definitions to use to create the <c>FuncTable</c>.
+/// </param>
+/// <returns>
+///     A tuple of a <c>FuncTable</c>, and a list of <c>DFunc</c>s with
+///     indefinite constraints.
+/// </returns>
+let funcTableFromViewDefs viewdefs =
+    let rec buildLists definites indefinites viewdefs' =
+        match viewdefs' with
+        | [] -> (definites, indefinites)
+        | { View = v ; Def = None } :: vs ->
+            buildLists definites (v :: indefinites) vs
+        | { View = v ; Def = Some s } :: vs ->
+            buildLists ((v, s) :: definites) indefinites vs
+    buildLists [] [] viewdefs
+
+/// <summary>
 ///     Returns the <c>Func</c>s contained in a <c>FuncTable</c>.
 /// </summary>
 /// <param name="ftab">

--- a/Main.fs
+++ b/Main.fs
@@ -94,6 +94,7 @@ let requestMap =
                  ("z3", Request.Z3 Backends.Z3.Types.Request.Combine)
                  ("sat", Request.Z3 Backends.Z3.Types.Request.Sat)
                  ("mutranslate", Request.Z3 Backends.Z3.Types.Request.MuTranslate)
+                 ("mufix", Request.Z3 Backends.Z3.Types.Request.MuFix)
                  ("musat", Request.Z3 Backends.Z3.Types.Request.MuSat)
                  ("hsf", Request.HSF) ]
 

--- a/Main.fs
+++ b/Main.fs
@@ -93,6 +93,8 @@ let requestMap =
                  ("reifyZ3", Request.Z3 Backends.Z3.Types.Request.Translate)
                  ("z3", Request.Z3 Backends.Z3.Types.Request.Combine)
                  ("sat", Request.Z3 Backends.Z3.Types.Request.Sat)
+                 ("mutranslate", Request.Z3 Backends.Z3.Types.Request.MuTranslate)
+                 ("musat", Request.Z3 Backends.Z3.Types.Request.MuSat)
                  ("hsf", Request.HSF) ]
 
 /// Converts an optional -s stage name to a request item.

--- a/Main.fs
+++ b/Main.fs
@@ -324,6 +324,10 @@ let runStarling optS reals verbose request =
 
     let choose b t e = if b then lift t else e
 
+    if verbose
+    then
+        eprintfn "Z3 version: %s" (Microsoft.Z3.Version.ToString ())
+
     match request with
     | Request.Frontend rq -> frontend rq >> lift Response.Frontend
     | _ ->

--- a/Model.fs
+++ b/Model.fs
@@ -373,3 +373,21 @@ let isAdvisory =
     function
     | Advisory _ -> true
     | Mandatory _ -> false
+
+
+(*
+ * Variable querying.
+ *)
+
+/// <summary>
+///     Extracts a sequence of all variables in a <c>VFunc</c>.
+/// </summary>
+/// <param name="_arg1">
+///     The <c>VFunc</c> to query.
+/// </param>
+/// <returns>
+///     A sequence of (<c>Const</c>, <c>Type</c>) pairs that represent all of
+///     the variables used in the <c>VFunc</c>.
+/// </returns>
+let varsInVFunc { Params = ps } =
+    ps |> Seq.map varsIn |> Seq.concat

--- a/MuZ3Backend.fs
+++ b/MuZ3Backend.fs
@@ -1,0 +1,617 @@
+/// <summary>
+///     The MuZ3 backend.
+///
+///     <para>
+///         Like the Z3 backend, this uses Z3 as a solver.  Unlike the
+///         Z3 backend, we use the experimental MuZ3 fixedpoint solver
+///         framework instead of using Z3 as an SMT solver.
+///     </para>
+///     <para>
+///         Similarly to the HSF backend, this converts Starling proof
+///         terms into (command && w/pre => goal) clauses, where each
+///         view is left uninterpreted.  Unlike the HSF backend, we
+///         build an 'unsafe' predicate, which is true when we detect
+///         that a definite view expression has been weakened from its
+///         definition.  We also ensure that view definitions cannot be
+///         strengthened by asserting them as rules.
+///     </para>
+///     <para>
+///         MuZ3 can handle indefinite constraints and unknown views,
+///         and does not require external programs.  However, it is
+///         slow and very experimental, both in terms of the external
+///         solver and our support for it.
+///     </para>
+/// </summary>
+
+module Starling.Backends.MuZ3
+
+open Microsoft
+open Starling
+open Starling.Collections
+open Starling.Core.Expr
+open Starling.Core.Var
+open Starling.Core.Model
+open Starling.Core.GuardedView
+open Starling.Core.Instantiate
+open Starling.Core.Sub
+open Starling.Core.Z3
+open Starling.Reifier
+open Starling.Optimiser
+
+
+/// <summary>
+///     Types for the MuZ3 backend.
+/// </summary>
+[<AutoOpen>]
+module Types =
+    /// <summary>
+    ///     Type of MuZ3 results.
+    /// </summary>
+    type MuSat =
+        /// <summary>
+        ///     The proof succeeded with the <c>FuncDecl</c> being assigned
+        ///     with the given <c>Expr</c>.
+        /// </summary>
+        | Sat of Z3.Expr
+        /// <summary>
+        ///     The proof failed with the assignments of the <c>FuncDecl</c>s
+        ///     given by the <c>Expr</c>.
+        /// </summary>
+        | Unsat of Z3.Expr
+        /// <summary>
+        ///     The proof gave an odd result.
+        /// </summary>
+        | Unknown of reason: string
+
+    /// <summary>
+    ///     A MuZ3 model.
+    /// </summary>
+    type MuModel =
+        { /// <summary>
+          ///     List of definite viewdefs, as (view, def) pairs, to check.
+          /// </summary>
+          Definites : (VFunc * BoolExpr) list
+          /// <summary>
+          ///     Map of (view name, FuncDecl) bindings.
+          /// </summary>
+          FuncDecls : Map<string, Z3.FuncDecl>
+          /// <summary>
+          ///     List of fixedpoint rules.
+          /// </summary>
+          Rules : Map<string, Z3.BoolExpr> }
+
+    /// <summary>
+    ///     Type of requests to the MuZ3 backend.
+    /// </summary>
+    type Request =
+        /// Produce a MuZ3 model; return `Response.MuTranslate`.
+        | Translate
+        /// Produce a MuZ3 fixedpoint; return `Response.MuFix`.
+        | Fix
+        /// Produce a MuZ3 sat list; return `Response.MuSat`.
+        | Sat
+
+    /// <summary>
+    ///     Type of responses from the MuZ3 backend.
+    /// </summary>
+    [<NoComparison>]
+    type Response =
+        /// Output of the MuZ3 translation step only.
+        | Translate of MuModel
+        /// Output of the MuZ3 fixedpoint generation step only.
+        | Fix of fixedpoint : Z3.Fixedpoint * unsafe : Z3.FuncDecl
+        /// Output of the MuZ3 proof.
+        | Sat of MuSat
+
+
+/// <summary>
+///     Pretty printers for the MuZ3 types.
+/// </summary>
+module Pretty =            
+    open Starling.Core.Pretty
+    open Starling.Core.Expr.Pretty
+    open Starling.Core.Model.Pretty
+    open Starling.Core.Instantiate.Pretty
+    open Starling.Core.Z3.Pretty
+
+    /// Pretty-prints a MuSat.
+    let printMuSat =
+        function
+        | MuSat.Sat ex -> vsep [ String "Proof FAILED."
+                                 headed "Counter-example" [ printZ3Exp ex ] ]
+        | MuSat.Unsat ex -> vsep [ String "Proof SUCCEEDED."
+                                   headed "View assignments" [ printZ3Exp ex ] ]
+        | MuSat.Unknown reason -> colonSep [ String "Proof status unknown"
+                                             String reason ]
+    
+    /// Pretty-prints a MuModel.
+    let printMuModel { Definites = ds ; Rules = rs ; FuncDecls = fdm } =
+        printAssoc
+            Indented
+            [ (String "Definites",
+               ds |>
+               List.map (fun (f, d) -> equality (printVFunc f)
+                                                (printBoolExpr d))
+               |> vsep)
+              (String "Rules",
+               rs
+               |> Map.toSeq
+               |> Seq.map (fun (g, sym) ->
+                               commaSep [ String (sym.ToString())
+                                          String (g.ToString()) ] )
+               |> vsep)
+              (String "Goals",
+               printMap Inline String (fun s -> String (s.ToString())) fdm) ]
+
+    /// Pretty-prints a response.
+    let printResponse mview =
+        function
+        | Response.Translate mm ->
+            printMuModel mm
+        | Response.Fix (mf, _) ->
+            String (mf.ToString ())
+        | Response.Sat s ->
+            printMuSat s
+
+
+/// <summary>
+///     Functions for translating Starling elements into MuZ3.
+/// </summary>
+module Translator =
+    open Starling.Core.Z3.Expr
+
+    /// <summary>
+    ///     Converts a type into a Z3 sort.
+    /// </summary>
+    /// <param name="ctx">
+    ///     The Z3 context to use to generate the sorts.
+    /// </param>
+    /// <returns>
+    ///     A function mapping types to sorts.
+    /// </returns>
+    let typeToSort (ctx : Z3.Context) =
+        function
+        | Type.Int -> ctx.MkIntSort () :> Z3.Sort
+        | Type.Bool -> ctx.MkBoolSort () :> Z3.Sort
+
+    (*
+     * View definitions
+     *)
+
+    /// <summary>
+    ///     Creates a <c>FuncDecl</c> from a <c>DFunc</c>.
+    /// </summary>
+    /// <param name="ctx">
+    ///     The Z3 context being used to create the <c>FuncDecl</c>.
+    /// </param>
+    /// <param name="_arg1">
+    ///     The <c>DFunc</c> to model as a <c>FuncDecl</c>.
+    /// </param>
+    /// <returns>
+    ///     A <c>FuncDecl</c> modelling the <c>DFunc</c>.
+    /// </returns>
+    let funcDeclOfDFunc (ctx : Z3.Context) { Name = n ; Params = pars } =
+        ctx.MkFuncDecl(
+            n,
+            pars |> Seq.map (fst >> typeToSort ctx) |> Seq.toArray,
+            ctx.MkBoolSort () :> Z3.Sort)
+
+    /// <summary>
+    ///     Creates an application of a <c>FuncDecl</c> to a list of
+    ///     <c>Expr</c> parameters.
+    /// </summary>
+    /// <param name="ctx">
+    ///     The Z3 context being used to model the parameters.
+    /// </param>
+    /// <param name="funcDecl">
+    ///     The <c>FuncDecl</c> to apply.
+    /// </param>
+    /// <param name="ps">
+    ///     The <c>Expr</c> parameters to use.
+    /// </param>
+    /// <returns>
+    ///     A <c>BoolExpr</c> representing an application of
+    ///     <paramref name="ps"/> to <paramref name="funcDecl"/>.
+    /// </returns>
+    let applyFunc ctx (funcDecl : Z3.FuncDecl) ps =
+        let psa : Z3.Expr[] = ps |> List.map (exprToZ3 ctx) |> List.toArray
+        funcDecl.Apply psa
+        :?> Z3.BoolExpr
+
+    /// <summary>
+    ///     Processes a view definition for MuZ3.
+    /// </summary>
+    /// <param name="ctx">
+    ///     The Z3 context being used to model the <c>ViewDef</c>.
+    /// </param>
+    /// <param name="_arg1">
+    ///     The <c>ViewDef</c> to process.
+    /// </param>
+    /// <returns>
+    ///     A pair of a pair of the name of the view and the <c>FuncDecl</c>
+    ///     produced for the view, and an optional <c>BoolExpr</c>
+    ///     assertion defining the view.
+    /// </returns>
+    let translateViewDef (ctx : Z3.Context) ( { View = vs; Def = ex } : ViewDef<DFunc> ) =
+        let funcDecl = funcDeclOfDFunc ctx vs
+        let mapEntry = (vs.Name, funcDecl)
+
+        let rule =
+            Option.map
+                (fun dex ->
+                     (* This is a definite constraint, so we want muZ3 to
+                        use the existing constraint body for it.  We do this
+                        by creating a rule that vs <=> dex.
+                           
+                        We need to make an application of our new FuncDecl to
+                        create the constraints for it, if any.
+
+                        The parameters of a DFunc are in (type, name) format,
+                        which we need to convert to expression format first.
+                        dex uses Unmarked constants, so we do too. *)
+                     let eparams = List.map (uncurry (mkVarExp Unmarked)) vs.Params
+                     let vfunc = { Name = vs.Name ; Params = eparams }
+
+                     (vfunc, dex))
+                ex
+
+        (mapEntry, rule)
+
+    /// <summary>
+    ///     Constructs a declaration map and rule list from <c>ViewDef</c>s.
+    /// </summary>
+    /// <param name="ctx">
+    ///     The Z3 context being used to model the <c>ViewDef</c>s.
+    /// </param>
+    /// <param name="ds">
+    ///     The sequence of <c>ViewDef</c>s to model.
+    /// </param>
+    /// <returns>
+    ///     A tuple of a <c>Map</c> binding names to <c>FuncDecl</c>s and a
+    ///     list of (view, def) pairs defining definite viewdefs.
+    /// </returns>
+    let translateViewDefs ctx ds =
+        ds
+        |> Seq.map (translateViewDef ctx)
+        |> List.ofSeq
+        |> List.unzip
+        (* The LHS contains a list of tuples that need to make a map.
+           The RHS needs to be filtered for indefinite constraints. *)
+        |> pairMap Map.ofSeq (Seq.choose id)
+
+    (*
+     * Views
+     *)
+
+    /// <summary>
+    ///     Models a <c>VFunc</c>.
+    /// </summary>
+    /// <param name="ctx">
+    ///     The Z3 context to use to model the func.
+    /// </param>
+    /// <param name="funcDecls">
+    ///     The map of <c>FuncDecls</c> to use in the modelling.
+    /// </param>
+    /// <param name="_arg1">
+    ///     The <c>VFunc</c> to model.
+    /// </param>
+    /// <returns>
+    ///     A Z3 boolean expression relating to the <c>VFunc</c>.
+    ///     If <paramref name="_arg1"/> is in <paramref name="funcDecls"/>, 
+    ///     then the expression is an application of the <c>FuncDecl</c>
+    ///     with the parameters in <paramref name="_arg1"/>.
+    ///     Else, it is true.
+    /// </returns>
+    let translateVFunc ctx (funcDecls : Map<string, Z3.FuncDecl>) { Name = n ; Params = ps } =
+        match funcDecls.TryFind n with
+        | Some fd -> applyFunc ctx fd ps
+        | None -> ctx.MkTrue ()
+
+    /// <summary>
+    ///     Models a <c>GView</c>.
+    /// </summary>
+    /// <param name="ctx">
+    ///     The Z3 context to use to model the func.
+    /// </param>
+    /// <param name="funcDecls">
+    ///     The map of <c>FuncDecls</c> to use in the modelling.
+    /// </param>
+    /// <returns>
+    ///     A function taking a <c>GView</c> and returning a Z3
+    ///     Boolean expression characterising it.
+    /// </returns>
+    let translateGView (ctx : Z3.Context) funcDecls =
+        Multiset.toFlatSeq
+        >> Seq.choose
+               (fun { Cond = g ; Item = v } ->
+                    let vZ = translateVFunc ctx funcDecls v
+                    if (vZ.IsTrue)
+                    then None
+                    else Some <|
+                         if (isTrue g)
+                         then vZ
+                         else (ctx.MkImplies (boolToZ3 ctx g, vZ)))
+        >> Seq.toArray
+        >> (fun a -> ctx.MkAnd a)
+
+    (*
+     * Variables
+     *)
+
+    /// <summary>
+    ///     Constructs a rule implying view, whose body is a conjunction of
+    ///     a <c>BoolExpr</c> and a <c>GView</c>.
+    /// </summary>
+    /// <param name="ctx">
+    ///     The Z3 context to use to model the func.
+    /// </param>
+    /// <param name="funcDecls">
+    ///     The map of <c>FuncDecls</c> to use in the modelling.
+    /// </param>
+    /// <param name="bodyExpr">
+    ///     The body, as a Starling <c>BoolExpr</c>.  May be <c>BTrue</c> if
+    ///     no view is desired.
+    /// </param>
+    /// <param name="bodyView">
+    ///     The view part, as a Starling <c>GView</c>.  May be emp if no view
+    ///     is desired.
+    /// </param>
+    /// <param name="head">
+    ///     The <c>VFunc</c> making up the head.
+    /// </param>
+    /// <returns>
+    ///     An <c>Option</c>al rule, which is present only if <c>head</c> is defined
+    ///     in <c>funcDecls</c>.
+    ///
+    ///     If present, the rule is of the form <c>(forall (vars) (=> body
+    ///     func))</c>, where <c>vars</c> is the union of the variables in
+    ///     <c>body</c>, <c>gview</c> and <c>head</c>.
+    /// </returns>
+    let mkRule (ctx : Z3.Context) funcDecls bodyExpr bodyView head =
+        let vars =
+            seq {
+                yield! (varsInBool bodyExpr)
+
+                for gfunc in Multiset.toFlatList bodyView do
+                    yield! (varsInGFunc gfunc)
+
+                yield! (varsInVFunc head)
+            }
+            // Make sure we don't quantify over a variable twice.
+            |> Set.ofSeq
+            |> Set.map (fun (name, ty) ->
+                            ctx.MkConst (constToString name, typeToSort ctx ty))
+            |> Set.toArray
+
+        let bodyExprZ = boolToZ3 ctx bodyExpr
+
+        let bodyZ =
+            if (Multiset.length bodyView = 0)
+            then bodyExprZ
+            else ctx.MkAnd [| bodyExprZ ; translateGView ctx funcDecls bodyView |]
+
+        let headZ = translateVFunc ctx funcDecls head
+
+        (* Don't emit a rule if it entails true: not only is such a rule
+           trivial, but MuZ3 will complain about interpreted heads. *)
+        if headZ.IsTrue
+        then None
+        else
+            let core = ctx.MkImplies (bodyZ, headZ)
+
+            (* If this rule involves one or more variables, we must universally
+               quantify over them.
+               MuZ3 will complain if we universally quantify over nothing,
+               though, so we need to be careful! *)
+
+            Some (if Array.isEmpty vars
+                  then core
+                  else ctx.MkForall (vars, core) :> Z3.BoolExpr)
+
+    /// <summary>
+    ///     Constructs a rule for initialising a variable.
+    /// </summary>
+    /// <param name="ctx">
+    ///     The Z3 context to use to model the rule.
+    /// </param>
+    /// <param name="funcs">
+    ///     A map of active view <c>FuncDecl</c>s.
+    /// </param>
+    /// <param name="svars">
+    ///     Map of shared variables in the program.
+    /// </param>
+    /// <returns>
+    ///     A sequence containing at most one pair of <c>string</c> and
+    ///     Z3 <c>BoolExpr</c> representing the variable initialisation rule.
+    /// </returns>
+    let translateVariables ctx funcDecls svars =
+        let vpars =
+            svars
+            |> Map.toList
+            |> List.map (uncurry (flip (mkVarExp Unmarked)))
+
+        // TODO(CaptainHayashi): actually get these initialisations from
+        // somewhere.
+        let body =
+            vpars
+            |> List.map
+                   (fun v -> BEq (v,
+                                  match v with
+                                  | AExpr _ -> AExpr (AInt 0L)
+                                  | BExpr _ -> BExpr (BFalse)))
+            |> mkAnd
+
+        let head = { Name = "emp" ; Params = vpars }
+
+        mkRule ctx funcDecls body Multiset.empty head
+        |> function
+           | Some x -> Seq.singleton ("init", x)
+           | None -> Seq.empty
+
+
+    (*
+     * Terms
+     *)
+
+    /// <summary>
+    ///     Constructs a muZ3 rule for a proof term.
+    /// </summary>
+    /// <param name="ctx">
+    ///     The Z3 context to use for modelling the term.
+    /// </param>
+    /// <param name="funcDecls">
+    ///     The map of <c>FuncDecl</c>s to use when creating view
+    ///     applications.
+    /// </param>
+    /// <param name="_arg1">
+    ///     Pair of term name and <c>Term</c>.
+    /// </param>
+    /// <returns>
+    ///     An <c>Option</c> containing a pair of the term name and the Z3
+    ///     <c>BoolExpr</c> representing the rule form of the proof term.
+    /// </returns>
+    let translateTerm ctx funcDecls (name : string, {Cmd = c ; WPre = w ; Goal = g}) =
+        mkRule ctx funcDecls c w g |> Option.map (mkPair name)
+
+    /// <summary>
+    ///     Constructs muZ3 rules and goals for a model.
+    /// </summary>
+    /// <param name="ctx">
+    ///     The Z3 context to use for modelling the fixpoint.
+    /// </param>
+    /// <param name="_arg1">
+    ///     The model to turn into a fixpoint.
+    /// </param>
+    /// <returns>
+    ///     A pair of the sequence of (<c>BoolExpr</c>, <c>Symbol</c>) goals
+    ///     used to prove the model, and the map of names to <c>FuncDecl</c>s
+    ///     to use to start queries.
+    /// </returns>
+    let translate ctx { Globals = svars ; ViewDefs = ds ; Axioms = xs } =
+        let funcDecls, definites = translateViewDefs ctx ds
+        let vrules = translateVariables ctx funcDecls svars
+        let trules = xs |> Map.toSeq |> Seq.choose (translateTerm ctx funcDecls)
+
+        { Definites = List.ofSeq definites
+          Rules = Seq.append vrules trules |> Map.ofSeq
+          FuncDecls = funcDecls }
+
+
+/// <summary>
+///     Proof execution using MuZ3.
+/// </summary>
+module Run =
+    open Starling.Core.Z3.Expr
+
+    /// <summary>
+    ///     Generates a MuZ3 fixedpoint.
+    /// </summary>
+    /// <param name="ctx">
+    ///     The Z3 context to use for modelling the fixedpoint.
+    /// </param>
+    /// <param name="_arg1">
+    ///     The <c>MuModel</c> to use in generation.
+    /// </param>
+    /// <returns>
+    ///     The pair of Z3 <c>Fixedpoint</c> and unsafeness <c>FuncDecl</c>.
+    /// </returns>
+    let fixgen (ctx : Z3.Context) { Definites = ds; Rules = rs ; FuncDecls = fm } =
+        let fixedpoint = ctx.MkFixedpoint ()
+
+        let pars = ctx.MkParams ()
+        pars.Add("engine", ctx.MkSymbol("pdr"))
+        fixedpoint.Parameters <- pars
+
+        List.iter
+            (fun (view, def) ->
+                 match (Translator.mkRule ctx fm def Multiset.empty view) with
+                 | Some rule -> fixedpoint.AddRule rule
+                 | None -> ())
+            ds
+
+        let unsafe = ctx.MkFuncDecl ("unsafe", [||], ctx.MkBoolSort () :> Z3.Sort)
+        fixedpoint.RegisterRelation unsafe
+        let unsafeapp = unsafe.Apply [| |] :?> Z3.BoolExpr
+
+        List.iter
+            (fun (view, def) ->
+                 // TODO(CaptainHayashi): de-duplicate this with mkRule.
+                 let vars =
+                    seq {
+                        yield! (varsInBool def)
+                        for param in view.Params do
+                            yield! (varsIn param)
+                    }
+                    |> Set.ofSeq
+                    |> Set.map (fun (name, ty) ->
+                                    ctx.MkConst (constToString name,
+                                                 Translator.typeToSort ctx ty))
+                    |> Set.toArray
+
+                 fixedpoint.AddRule (
+                    ctx.MkForall
+                        (vars,
+                         ctx.MkImplies (ctx.MkAnd [| def |> mkNot |> boolToZ3 ctx
+                                                     Translator.translateVFunc ctx fm view |],
+                                        unsafeapp))))
+            ds
+
+        Map.iter (fun (s : string) g -> fixedpoint.AddRule (g, ctx.MkSymbol s :> Z3.Symbol)) rs
+        Map.iter (fun _ g -> fixedpoint.RegisterRelation g) fm
+
+        (fixedpoint, unsafe)
+
+    /// <summary>
+    ///     Runs a MuZ3 fixedpoint.
+    /// </summary>
+    /// <param name="fixedpoint">
+    ///     The <c>Fixedpoint</c> to run.
+    /// </param>
+    /// <param name="unsafe">
+    ///     The <c>FuncDecl</c> naming the unsafeness predicate.
+    /// </param>
+    /// <returns>
+    ///     A <c>MuResult</c>.
+    /// </returns>
+    let run (fixedpoint : Z3.Fixedpoint) unsafe =
+        match (fixedpoint.Query [| unsafe |]) with
+        | Z3.Status.SATISFIABLE ->
+             MuSat.Sat (fixedpoint.GetAnswer ())
+        | Z3.Status.UNSATISFIABLE ->
+             MuSat.Unsat (fixedpoint.GetAnswer ())
+        | Z3.Status.UNKNOWN ->
+             MuSat.Unknown (fixedpoint.GetReasonUnknown ())
+         | _ -> MuSat.Unknown "query result out of bounds"
+
+
+/// Shorthand for the translator stage of the MuZ3 pipeline.
+let translate = Translator.translate
+/// Shorthand for the fixpoint generation stage of the MuZ3 pipeline.
+let fix = Run.fixgen
+/// Shorthand for the satisfiability stage of the MuZ3 pipeline.
+let sat = uncurry Run.run
+
+/// <summary>
+///     The Starling MuZ3 backend driver.
+/// </summary>
+/// <param name="req">
+///     The request to handle.
+/// </param>
+/// <returns>
+///     A function implementing the chosen MuZ3 backend process.
+/// </returns>
+let run req =
+    use ctx = new Z3.Context()
+    match req with
+    | Request.Translate ->
+        translate ctx
+        >> Response.Translate
+    | Request.Fix ->
+        translate ctx
+        >> fix ctx
+        >> Response.Fix
+    | Request.Sat ->
+        translate ctx
+        >> fix ctx
+        >> sat
+        >> Response.Sat

--- a/Optimiser.fs
+++ b/Optimiser.fs
@@ -460,7 +460,7 @@ module Graph =
                       >> Set.toSeq
                       >> Seq.forall
                              (// ...the variable is thread-local.
-                              fun c ->
+                              fun (c, _) ->
                                   match (Map.tryFind (stripMark c) tVars) with
                                   | Some _ -> true
                                   | _ -> false))

--- a/Pretty.fs
+++ b/Pretty.fs
@@ -121,8 +121,7 @@ type MapSep =
 ///     The <c>MapSep</c> to use when joining the key and value.
 /// </param>
 /// <param name="_arg1">
-///     An association list, as a sequence,to print using <paramref name="pK" />
-///     and <paramref name="pV" />.
+///     An association list, as a sequence, to print.
 /// </param>
 /// <returns>
 ///     A printer for the given association list.

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -118,7 +118,7 @@ let frame model expr =
     let evars =
         expr
         |> varsInBool
-        |> Seq.choose (function | After x -> Some x
+        |> Seq.choose (function | (After x, _) -> Some x
                                 | _ -> None)
         |> Set.ofSeq
 

--- a/Z3.fs
+++ b/Z3.fs
@@ -33,36 +33,38 @@ module Pretty =
 /// </summary>
 module Expr =
     /// Converts a Starling arithmetic expression to a Z3 ArithExpr.
-    let rec arithToZ3 (ctx: Z3.Context) =
+    let rec arithToZ3 reals (ctx: Z3.Context) =
         function
+        | AConst c when reals -> c |> constToString |> ctx.MkRealConst :> Z3.ArithExpr
         | AConst c -> c |> constToString |> ctx.MkIntConst :> Z3.ArithExpr
+        | AInt i when reals -> (i |> ctx.MkReal) :> Z3.ArithExpr
         | AInt i -> (i |> ctx.MkInt) :> Z3.ArithExpr
-        | AAdd xs -> ctx.MkAdd (xs |> Seq.map (arithToZ3 ctx) |> Seq.toArray)
-        | ASub xs -> ctx.MkSub (xs |> Seq.map (arithToZ3 ctx) |> Seq.toArray)
-        | AMul xs -> ctx.MkMul (xs |> Seq.map (arithToZ3 ctx) |> Seq.toArray)
-        | ADiv (x, y) -> ctx.MkDiv (arithToZ3 ctx x, arithToZ3 ctx y)
+        | AAdd xs -> ctx.MkAdd (xs |> Seq.map (arithToZ3 reals ctx) |> Seq.toArray)
+        | ASub xs -> ctx.MkSub (xs |> Seq.map (arithToZ3 reals ctx) |> Seq.toArray)
+        | AMul xs -> ctx.MkMul (xs |> Seq.map (arithToZ3 reals ctx) |> Seq.toArray)
+        | ADiv (x, y) -> ctx.MkDiv (arithToZ3 reals ctx x, arithToZ3 reals ctx y)
 
     /// Converts a Starling Boolean expression to a Z3 ArithExpr.
-    and boolToZ3 (ctx : Z3.Context) =
+    and boolToZ3 reals (ctx : Z3.Context) =
         function
         | BConst c -> c |> constToString |> ctx.MkBoolConst
         | BTrue -> ctx.MkTrue ()
         | BFalse -> ctx.MkFalse ()
-        | BAnd xs -> ctx.MkAnd (xs |> Seq.map (boolToZ3 ctx) |> Seq.toArray)
-        | BOr xs -> ctx.MkOr (xs |> Seq.map (boolToZ3 ctx) |> Seq.toArray)
-        | BImplies (x, y) -> ctx.MkImplies (boolToZ3 ctx x, boolToZ3 ctx y)
-        | BEq (x, y) -> ctx.MkEq (exprToZ3 ctx x, exprToZ3 ctx y)
-        | BGt (x, y) -> ctx.MkGt (arithToZ3 ctx x, arithToZ3 ctx y)
-        | BGe (x, y) -> ctx.MkGe (arithToZ3 ctx x, arithToZ3 ctx y)
-        | BLe (x, y) -> ctx.MkLe (arithToZ3 ctx x, arithToZ3 ctx y)
-        | BLt (x, y) -> ctx.MkLt (arithToZ3 ctx x, arithToZ3 ctx y)
-        | BNot x -> x |> boolToZ3 ctx |> ctx.MkNot
+        | BAnd xs -> ctx.MkAnd (xs |> Seq.map (boolToZ3 reals ctx) |> Seq.toArray)
+        | BOr xs -> ctx.MkOr (xs |> Seq.map (boolToZ3 reals ctx) |> Seq.toArray)
+        | BImplies (x, y) -> ctx.MkImplies (boolToZ3 reals ctx x, boolToZ3 reals ctx y)
+        | BEq (x, y) -> ctx.MkEq (exprToZ3 reals ctx x, exprToZ3 reals ctx y)
+        | BGt (x, y) -> ctx.MkGt (arithToZ3 reals ctx x, arithToZ3 reals ctx y)
+        | BGe (x, y) -> ctx.MkGe (arithToZ3 reals ctx x, arithToZ3 reals ctx y)
+        | BLe (x, y) -> ctx.MkLe (arithToZ3 reals ctx x, arithToZ3 reals ctx y)
+        | BLt (x, y) -> ctx.MkLt (arithToZ3 reals ctx x, arithToZ3 reals ctx y)
+        | BNot x -> x |> boolToZ3 reals ctx |> ctx.MkNot
 
     /// Converts a Starling expression to a Z3 Expr.
-    and exprToZ3 (ctx: Z3.Context) =
+    and exprToZ3 reals (ctx: Z3.Context) =
         function
-        | BExpr b -> boolToZ3 ctx b :> Z3.Expr
-        | AExpr a -> arithToZ3 ctx a :> Z3.Expr
+        | BExpr b -> boolToZ3 reals ctx b :> Z3.Expr
+        | AExpr a -> arithToZ3 reals ctx a :> Z3.Expr
 
 /// <summary>
 ///     Z3 invocation.

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -54,7 +54,7 @@ module Types =
         /// <summary>
         ///     The proof gave an odd result.
         /// </summary>
-        | Unknown
+        | Unknown of reason: string
 
     /// <summary>
     ///     A MuZ3 model.
@@ -109,9 +109,9 @@ module Pretty =
     /// Pretty-prints a MuSat.
     let printMuSat =
         function
-        | MuSat.Sat ex -> commaSep [ String "sat" ; printZ3Exp ex ]
-        | MuSat.Unsat ex -> commaSep [ String "unsat" ; printZ3Exp ex ]
-        | MuSat.Unknown -> String "?"
+        | MuSat.Sat ex -> colonSep [ String "sat" ; printZ3Exp ex ]
+        | MuSat.Unsat ex -> colonSep [ String "unsat" ; printZ3Exp ex ]
+        | MuSat.Unknown reason -> colonSep [ String "unknown" ; String reason ]
     
     /// Pretty-prints a MuModel.
     let printMuModel { Assertions = ts ; Rules = rs ; FuncDecls = fdm } =
@@ -546,7 +546,9 @@ module MuTranslator =
                      MuSat.Sat (fixedpoint.GetAnswer ())
                  | Z3.Status.UNSATISFIABLE ->
                      MuSat.Unsat (fixedpoint.GetAnswer ())
-                 | _ -> MuSat.Unknown)
+                 | Z3.Status.UNKNOWN ->
+                     MuSat.Unknown (fixedpoint.GetReasonUnknown ())
+                 | _ -> MuSat.Unknown "query result out of bounds")
             fm
 
 

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -480,11 +480,9 @@ module MuTranslator =
                 yield! (varsInBool bodyExpr)
 
                 for gfunc in Multiset.toFlatList bodyView do
-                    for param in gfunc.Item.Params do
-                        yield! (varsIn param)
+                    yield! (varsInGFunc gfunc)
 
-                for param in head.Params do
-                    yield! (varsIn param)
+                yield! (varsInVFunc head)
             }
             // Make sure we don't quantify over a variable twice.
             |> Set.ofSeq

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -534,6 +534,11 @@ module MuTranslator =
     /// </returns>
     let run (ctx : Z3.Context) { Assertions = ts; Rules = rs ; FuncDecls = fm } =
         let fixedpoint = ctx.MkFixedpoint ()
+
+        let pars = ctx.MkParams ()
+        pars.Add("engine", ctx.MkSymbol("pdr"))
+        pars.Add("pdr.flexible_trace", true)
+        fixedpoint.Parameters <- pars
         
         fixedpoint.Assert ts
         Map.iter (fun (s : string) g -> fixedpoint.AddRule (g, ctx.MkSymbol s :> Z3.Symbol)) rs

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -429,9 +429,15 @@ module MuTranslator =
     /// </returns>
     let translateGView (ctx : Z3.Context) funcDecls =
         Multiset.toFlatSeq
-        >> Seq.map (fun { Cond = g ; Item = v } ->
-                        ctx.MkImplies (boolToZ3 ctx g,
-                                       translateVFunc ctx funcDecls v))
+        >> Seq.choose
+               (fun { Cond = g ; Item = v } ->
+                    let vZ = translateVFunc ctx funcDecls v
+                    if (vZ.IsTrue)
+                    then None
+                    else Some <|
+                         if (isTrue g)
+                         then vZ
+                         else (ctx.MkImplies (boolToZ3 ctx g, vZ)))
         >> Seq.toArray
         >> (fun a -> ctx.MkAnd a)
 

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -593,7 +593,6 @@ module MuTranslator =
           Rules = Seq.append vrules trules |> Map.ofSeq
           FuncDecls = funcDecls }
 
-
     /// <summary>
     ///     Generates a MuZ3 fixedpoint.
     /// </summary>

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -114,9 +114,12 @@ module Pretty =
     /// Pretty-prints a MuSat.
     let printMuSat =
         function
-        | MuSat.Sat ex -> colonSep [ String "sat" ; printZ3Exp ex ]
-        | MuSat.Unsat ex -> colonSep [ String "unsat" ; printZ3Exp ex ]
-        | MuSat.Unknown reason -> colonSep [ String "unknown" ; String reason ]
+        | MuSat.Sat ex -> vsep [ String "Proof FAILED."
+                                 headed "Counter-example" [ printZ3Exp ex ] ]
+        | MuSat.Unsat ex -> vsep [ String "Proof SUCCEEDED."
+                                   headed "View assignments" [ printZ3Exp ex ] ]
+        | MuSat.Unknown reason -> colonSep [ String "Proof status unknown"
+                                             String reason ]
     
     /// Pretty-prints a MuModel.
     let printMuModel { Definites = ds ; Rules = rs ; FuncDecls = fdm } =

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -212,13 +212,11 @@ module Translator =
     ///   </para>
     /// </remarks>
     let makeFuncTable model =
-        model.ViewDefs
-        |> Seq.map
-            (function
-             | { View = vs; Def = None } -> IndefiniteConstraint vs |> fail
-             | { View = vs; Def = Some s } -> (vs, s) |> ok)
-        |> collect
-        |> lift Starling.Core.Instantiate.makeFuncTable
+        (* We cannot have any indefinite constraints for Z3.
+           These are the snd in the pair coming from funcTableFromViewDefs. *)
+        match (funcTableFromViewDefs model.ViewDefs) with
+        | ftab, [] -> ok ftab
+        | _, indefs -> indefs |> List.map IndefiniteConstraint |> Bad
 
     /// <summary>
     ///   Interprets all views in a model, converting them to <c>FTerm</c>s.

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -411,6 +411,7 @@ module MuTranslator =
 
     /// <summary>
     ///     Models a <c>GView</c>.
+    /// </summary>
     /// <param name="ctx">
     ///     The Z3 context to use to model the func.
     /// </param>

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -39,6 +39,8 @@ module Types =
         | Translate of Model<ZTerm, DFunc>
         /// Output of the final Z3 terms only.
         | Combine of Model<Microsoft.Z3.BoolExpr, DFunc>
+        /// Output of the MuZ3 translation step only.
+        | MuTranslate of Microsoft.Z3.Fixedpoint
         /// Output of satisfiability reports for the Z3 terms.
         | Sat of Map<string, Microsoft.Z3.Status>
 
@@ -76,7 +78,13 @@ module Pretty =
                 printZ3Exp
                 printDFunc
                 m
-        | Response.Sat s -> printMap Inline String printSat s
+        | Response.MuTranslate f ->
+            printAssoc
+                Indented
+                [ (String "Rules", f.Rules |> Seq.map printZ3Exp |> vsep)
+                  (String "Assertions", f.Assertions |> Seq.map printZ3Exp |> vsep) ]
+        | Response.Sat s ->
+            printMap Inline String printSat s
 
     /// Pretty-prints Z3 translation errors.
     let printError =

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -198,9 +198,9 @@ module Translator =
     /// <summary>
     ///   Tries to make a <c>FuncTable</c> from <c>model</c>'s view definitions.
     /// </summary>
-    /// <parameter name="model">
+    /// <param name="model">
     ///   The model whose <c>ViewDefs</c> are to be turned into a <c>FuncTable</c>.
-    /// </parameter>
+    /// </param>
     /// <returns>
     ///   A Chessie result, which, when ok, contains a <c>FuncTable</c> mapping
     ///   each defining view in <c>model</c> to its <c>BoolExpr</c> meaning.
@@ -221,9 +221,9 @@ module Translator =
     /// <summary>
     ///   Interprets all views in a model, converting them to <c>FTerm</c>s.
     /// </summary>
-    /// <parameter name="model">
+    /// <param name="model">
     ///   The model whose views are to be interpreted.
-    /// </parameter>
+    /// </param>
     /// <returns>
     ///   A Chessie result, which, when ok, contains a <c>Model</c> equivalent to
     ///   <c>model</c> except that each view is replaced with the <c>BoolExpr</c>
@@ -313,6 +313,7 @@ module MuTranslator =
     /// <returns>
     ///     A <c>BoolExpr</c> representing an application of
     ///     <paramref name="ps"/> to <paramref name="funcDecl"/>.
+    /// </returns>
     let applyFunc ctx (funcDecl : Z3.FuncDecl) ps =
         let psa : Z3.Expr[] = ps |> List.map (exprToZ3 ctx) |> List.toArray
         funcDecl.Apply psa

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -1,4 +1,18 @@
-/// The part of the Z3 backend that translates terms to Z3.
+/// <summary>
+///     The Z3 backend.
+///
+///     <para>
+///         This converts Starling proof terms into fully interpreted
+///         negated implications, and uses Z3 as a SMT solver to check
+///         the satisfiability of those terms one by one.
+///     </para>
+///     <para>
+///         The Z3 backend is relatively stable, fast, and can accept a
+///         large amount of Starling features, but does not support
+///         indefinite view constraints or placeholder views.  This
+///         means it is best for checking existing Starling proofs.
+///     </para>
+/// </summary>
 module Starling.Backends.Z3
 
 open Microsoft
@@ -32,48 +46,6 @@ module Types =
         | Combine
         /// Translate, combine, and run term Z3 expressions; return `Response.Sat`.
         | Sat
-        /// Produce a MuZ3 model; return `Response.MuTranslate`.
-        | MuTranslate
-        /// Produce a MuZ3 fixedpoint; return `Response.MuFix`.
-        | MuFix
-        /// Produce a MuZ3 sat list; return `Response.MuSat`.
-        | MuSat
-
-    /// <summary>
-    ///     Type of MuZ3 results.
-    /// </summary>
-    type MuSat =
-        /// <summary>
-        ///     The proof succeeded with the <c>FuncDecl</c> being assigned
-        ///     with the given <c>Expr</c>.
-        /// </summary>
-        | Sat of Z3.Expr
-        /// <summary>
-        ///     The proof failed with the assignments of the <c>FuncDecl</c>s
-        ///     given by the <c>Expr</c>.
-        /// </summary>
-        | Unsat of Z3.Expr
-        /// <summary>
-        ///     The proof gave an odd result.
-        /// </summary>
-        | Unknown of reason: string
-
-    /// <summary>
-    ///     A MuZ3 model.
-    /// </summary>
-    type MuModel =
-        { /// <summary>
-          ///     List of definite viewdefs, as (view, def) pairs, to check.
-          /// </summary>
-          Definites : (VFunc * BoolExpr) list
-          /// <summary>
-          ///     Map of (view name, FuncDecl) bindings.
-          /// </summary>
-          FuncDecls : Map<string, Z3.FuncDecl>
-          /// <summary>
-          ///     List of fixedpoint rules.
-          /// </summary>
-          Rules : Map<string, Z3.BoolExpr> }
 
     /// Type of responses from the Z3 backend.
     [<NoComparison>]
@@ -84,12 +56,6 @@ module Types =
         | Combine of Model<Z3.BoolExpr, DFunc>
         /// Output of satisfiability reports for the Z3 terms.
         | Sat of Map<string, Z3.Status>
-        /// Output of the MuZ3 translation step only.
-        | MuTranslate of MuModel
-        /// Output of the MuZ3 fixedpoint generation step only.
-        | MuFix of fixedpoint : Z3.Fixedpoint * unsafe : Z3.FuncDecl
-        /// Output of the MuZ3 proof.
-        | MuSat of MuSat
 
     /// A Z3 translation error.
     type Error =
@@ -111,35 +77,6 @@ module Pretty =
     open Starling.Core.Instantiate.Pretty
     open Starling.Core.Z3.Pretty
 
-    /// Pretty-prints a MuSat.
-    let printMuSat =
-        function
-        | MuSat.Sat ex -> vsep [ String "Proof FAILED."
-                                 headed "Counter-example" [ printZ3Exp ex ] ]
-        | MuSat.Unsat ex -> vsep [ String "Proof SUCCEEDED."
-                                   headed "View assignments" [ printZ3Exp ex ] ]
-        | MuSat.Unknown reason -> colonSep [ String "Proof status unknown"
-                                             String reason ]
-    
-    /// Pretty-prints a MuModel.
-    let printMuModel { Definites = ds ; Rules = rs ; FuncDecls = fdm } =
-        printAssoc
-            Indented
-            [ (String "Definites",
-               ds |>
-               List.map (fun (f, d) -> equality (printVFunc f)
-                                                (printBoolExpr d))
-               |> vsep)
-              (String "Rules",
-               rs
-               |> Map.toSeq
-               |> Seq.map (fun (g, sym) ->
-                               commaSep [ String (sym.ToString())
-                                          String (g.ToString()) ] )
-               |> vsep)
-              (String "Goals",
-               printMap Inline String (fun s -> String (s.ToString())) fdm) ]
-
     /// Pretty-prints a response.
     let printResponse mview =
         function
@@ -157,12 +94,6 @@ module Pretty =
                 m
         | Response.Sat s ->
             printMap Inline String printSat s
-        | Response.MuTranslate mm ->
-            printMuModel mm
-        | Response.MuFix (mf, _) ->
-            String (mf.ToString ())
-        | Response.MuSat s ->
-            printMuSat s
 
     /// Pretty-prints Z3 translation errors.
     let printError =
@@ -265,427 +196,6 @@ module Translator =
 
 
 /// <summary>
-///     Functions for translating Starling elements into MuZ3.
-/// </summary>
-module MuTranslator =
-    open Starling.Core.Z3.Expr
-
-    /// <summary>
-    ///     Converts a type into a Z3 sort.
-    /// </summary>
-    /// <param name="ctx">
-    ///     The Z3 context to use to generate the sorts.
-    /// </param>
-    /// <returns>
-    ///     A function mapping types to sorts.
-    /// </returns>
-    let typeToSort (ctx : Z3.Context) =
-        function
-        | Type.Int -> ctx.MkIntSort () :> Z3.Sort
-        | Type.Bool -> ctx.MkBoolSort () :> Z3.Sort
-
-    (*
-     * View definitions
-     *)
-
-    /// <summary>
-    ///     Creates a <c>FuncDecl</c> from a <c>DFunc</c>.
-    /// </summary>
-    /// <param name="ctx">
-    ///     The Z3 context being used to create the <c>FuncDecl</c>.
-    /// </param>
-    /// <param name="_arg1">
-    ///     The <c>DFunc</c> to model as a <c>FuncDecl</c>.
-    /// </param>
-    /// <returns>
-    ///     A <c>FuncDecl</c> modelling the <c>DFunc</c>.
-    /// </returns>
-    let funcDeclOfDFunc (ctx : Z3.Context) { Name = n ; Params = pars } =
-        ctx.MkFuncDecl(
-            n,
-            pars |> Seq.map (fst >> typeToSort ctx) |> Seq.toArray,
-            ctx.MkBoolSort () :> Z3.Sort)
-
-    /// <summary>
-    ///     Creates an application of a <c>FuncDecl</c> to a list of
-    ///     <c>Expr</c> parameters.
-    /// </summary>
-    /// <param name="ctx">
-    ///     The Z3 context being used to model the parameters.
-    /// </param>
-    /// <param name="funcDecl">
-    ///     The <c>FuncDecl</c> to apply.
-    /// </param>
-    /// <param name="ps">
-    ///     The <c>Expr</c> parameters to use.
-    /// </param>
-    /// <returns>
-    ///     A <c>BoolExpr</c> representing an application of
-    ///     <paramref name="ps"/> to <paramref name="funcDecl"/>.
-    /// </returns>
-    let applyFunc ctx (funcDecl : Z3.FuncDecl) ps =
-        let psa : Z3.Expr[] = ps |> List.map (exprToZ3 ctx) |> List.toArray
-        funcDecl.Apply psa
-        :?> Z3.BoolExpr
-
-    /// <summary>
-    ///     Processes a view definition for MuZ3.
-    /// </summary>
-    /// <param name="ctx">
-    ///     The Z3 context being used to model the <c>ViewDef</c>.
-    /// </param>
-    /// <param name="_arg1">
-    ///     The <c>ViewDef</c> to process.
-    /// </param>
-    /// <returns>
-    ///     A pair of a pair of the name of the view and the <c>FuncDecl</c>
-    ///     produced for the view, and an optional <c>BoolExpr</c>
-    ///     assertion defining the view.
-    /// </returns>
-    let translateViewDef (ctx : Z3.Context) ( { View = vs; Def = ex } : ViewDef<DFunc> ) =
-        let funcDecl = funcDeclOfDFunc ctx vs
-        let mapEntry = (vs.Name, funcDecl)
-
-        let rule =
-            Option.map
-                (fun dex ->
-                     (* This is a definite constraint, so we want muZ3 to
-                        use the existing constraint body for it.  We do this
-                        by creating a rule that vs <=> dex.
-                           
-                        We need to make an application of our new FuncDecl to
-                        create the constraints for it, if any.
-
-                        The parameters of a DFunc are in (type, name) format,
-                        which we need to convert to expression format first.
-                        dex uses Unmarked constants, so we do too. *)
-                     let eparams = List.map (uncurry (mkVarExp Unmarked)) vs.Params
-                     let vfunc = { Name = vs.Name ; Params = eparams }
-
-                     (vfunc, dex))
-                ex
-
-        (mapEntry, rule)
-
-    /// <summary>
-    ///     Constructs a declaration map and rule list from <c>ViewDef</c>s.
-    /// </summary>
-    /// <param name="ctx">
-    ///     The Z3 context being used to model the <c>ViewDef</c>s.
-    /// </param>
-    /// <param name="ds">
-    ///     The sequence of <c>ViewDef</c>s to model.
-    /// </param>
-    /// <returns>
-    ///     A tuple of a <c>Map</c> binding names to <c>FuncDecl</c>s and a
-    ///     list of (view, def) pairs defining definite viewdefs.
-    /// </returns>
-    let translateViewDefs ctx ds =
-        ds
-        |> Seq.map (translateViewDef ctx)
-        |> List.ofSeq
-        |> List.unzip
-        (* The LHS contains a list of tuples that need to make a map.
-           The RHS needs to be filtered for indefinite constraints. *)
-        |> pairMap Map.ofSeq (Seq.choose id)
-
-    (*
-     * Views
-     *)
-
-    /// <summary>
-    ///     Models a <c>VFunc</c>.
-    /// </summary>
-    /// <param name="ctx">
-    ///     The Z3 context to use to model the func.
-    /// </param>
-    /// <param name="funcDecls">
-    ///     The map of <c>FuncDecls</c> to use in the modelling.
-    /// </param>
-    /// <param name="_arg1">
-    ///     The <c>VFunc</c> to model.
-    /// </param>
-    /// <returns>
-    ///     A Z3 boolean expression relating to the <c>VFunc</c>.
-    ///     If <paramref name="_arg1"/> is in <paramref name="funcDecls"/>, 
-    ///     then the expression is an application of the <c>FuncDecl</c>
-    ///     with the parameters in <paramref name="_arg1"/>.
-    ///     Else, it is true.
-    /// </returns>
-    let translateVFunc ctx (funcDecls : Map<string, Z3.FuncDecl>) { Name = n ; Params = ps } =
-        match funcDecls.TryFind n with
-        | Some fd -> applyFunc ctx fd ps
-        | None -> ctx.MkTrue ()
-
-    /// <summary>
-    ///     Models a <c>GView</c>.
-    /// </summary>
-    /// <param name="ctx">
-    ///     The Z3 context to use to model the func.
-    /// </param>
-    /// <param name="funcDecls">
-    ///     The map of <c>FuncDecls</c> to use in the modelling.
-    /// </param>
-    /// <returns>
-    ///     A function taking a <c>GView</c> and returning a Z3
-    ///     Boolean expression characterising it.
-    /// </returns>
-    let translateGView (ctx : Z3.Context) funcDecls =
-        Multiset.toFlatSeq
-        >> Seq.choose
-               (fun { Cond = g ; Item = v } ->
-                    let vZ = translateVFunc ctx funcDecls v
-                    if (vZ.IsTrue)
-                    then None
-                    else Some <|
-                         if (isTrue g)
-                         then vZ
-                         else (ctx.MkImplies (boolToZ3 ctx g, vZ)))
-        >> Seq.toArray
-        >> (fun a -> ctx.MkAnd a)
-
-    (*
-     * Variables
-     *)
-
-    /// <summary>
-    ///     Constructs a rule implying view, whose body is a conjunction of
-    ///     a <c>BoolExpr</c> and a <c>GView</c>.
-    /// </summary>
-    /// <param name="ctx">
-    ///     The Z3 context to use to model the func.
-    /// </param>
-    /// <param name="funcDecls">
-    ///     The map of <c>FuncDecls</c> to use in the modelling.
-    /// </param>
-    /// <param name="bodyExpr">
-    ///     The body, as a Starling <c>BoolExpr</c>.  May be <c>BTrue</c> if
-    ///     no view is desired.
-    /// </param>
-    /// <param name="bodyView">
-    ///     The view part, as a Starling <c>GView</c>.  May be emp if no view
-    ///     is desired.
-    /// </param>
-    /// <param name="head">
-    ///     The <c>VFunc</c> making up the head.
-    /// </param>
-    /// <returns>
-    ///     An <c>Option</c>al rule, which is present only if <c>head</c> is defined
-    ///     in <c>funcDecls</c>.
-    ///
-    ///     If present, the rule is of the form <c>(forall (vars) (=> body
-    ///     func))</c>, where <c>vars</c> is the union of the variables in
-    ///     <c>body</c>, <c>gview</c> and <c>head</c>.
-    /// </returns>
-    let mkRule (ctx : Z3.Context) funcDecls bodyExpr bodyView head =
-        let vars =
-            seq {
-                yield! (varsInBool bodyExpr)
-
-                for gfunc in Multiset.toFlatList bodyView do
-                    yield! (varsInGFunc gfunc)
-
-                yield! (varsInVFunc head)
-            }
-            // Make sure we don't quantify over a variable twice.
-            |> Set.ofSeq
-            |> Set.map (fun (name, ty) ->
-                            ctx.MkConst (constToString name, typeToSort ctx ty))
-            |> Set.toArray
-
-        let bodyExprZ = boolToZ3 ctx bodyExpr
-
-        let bodyZ =
-            if (Multiset.length bodyView = 0)
-            then bodyExprZ
-            else ctx.MkAnd [| bodyExprZ ; translateGView ctx funcDecls bodyView |]
-
-        let headZ = translateVFunc ctx funcDecls head
-
-        (* Don't emit a rule if it entails true: not only is such a rule
-           trivial, but MuZ3 will complain about interpreted heads. *)
-        if headZ.IsTrue
-        then None
-        else
-            let core = ctx.MkImplies (bodyZ, headZ)
-
-            (* If this rule involves one or more variables, we must universally
-               quantify over them.
-               MuZ3 will complain if we universally quantify over nothing,
-               though, so we need to be careful! *)
-
-            Some (if Array.isEmpty vars
-                  then core
-                  else ctx.MkForall (vars, core) :> Z3.BoolExpr)
-
-    /// <summary>
-    ///     Constructs a rule for initialising a variable.
-    /// </summary>
-    /// <param name="ctx">
-    ///     The Z3 context to use to model the rule.
-    /// </param>
-    /// <param name="funcs">
-    ///     A map of active view <c>FuncDecl</c>s.
-    /// </param>
-    /// <param name="svars">
-    ///     Map of shared variables in the program.
-    /// </param>
-    /// <returns>
-    ///     A sequence containing at most one pair of <c>string</c> and
-    ///     Z3 <c>BoolExpr</c> representing the variable initialisation rule.
-    /// </returns>
-    let translateVariables ctx funcDecls svars =
-        let vpars =
-            svars
-            |> Map.toList
-            |> List.map (uncurry (flip (mkVarExp Unmarked)))
-
-        // TODO(CaptainHayashi): actually get these initialisations from
-        // somewhere.
-        let body =
-            vpars
-            |> List.map
-                   (fun v -> BEq (v,
-                                  match v with
-                                  | AExpr _ -> AExpr (AInt 0L)
-                                  | BExpr _ -> BExpr (BFalse)))
-            |> mkAnd
-
-        let head = { Name = "emp" ; Params = vpars }
-
-        mkRule ctx funcDecls body Multiset.empty head
-        |> function
-           | Some x -> Seq.singleton ("init", x)
-           | None -> Seq.empty
-
-
-    (*
-     * Terms
-     *)
-
-    /// <summary>
-    ///     Constructs a muZ3 rule for a proof term.
-    /// </summary>
-    /// <param name="ctx">
-    ///     The Z3 context to use for modelling the term.
-    /// </param>
-    /// <param name="funcDecls">
-    ///     The map of <c>FuncDecl</c>s to use when creating view
-    ///     applications.
-    /// </param>
-    /// <param name="_arg1">
-    ///     Pair of term name and <c>Term</c>.
-    /// </param>
-    /// <returns>
-    ///     An <c>Option</c> containing a pair of the term name and the Z3
-    ///     <c>BoolExpr</c> representing the rule form of the proof term.
-    /// </returns>
-    let translateTerm ctx funcDecls (name : string, {Cmd = c ; WPre = w ; Goal = g}) =
-        mkRule ctx funcDecls c w g |> Option.map (mkPair name)
-
-    /// <summary>
-    ///     Constructs muZ3 rules and goals for a model.
-    /// </summary>
-    /// <param name="ctx">
-    ///     The Z3 context to use for modelling the fixpoint.
-    /// </param>
-    /// <param name="_arg1">
-    ///     The model to turn into a fixpoint.
-    /// </param>
-    /// <returns>
-    ///     A pair of the sequence of (<c>BoolExpr</c>, <c>Symbol</c>) goals
-    ///     used to prove the model, and the map of names to <c>FuncDecl</c>s
-    ///     to use to start queries.
-    /// </returns>
-    let translate ctx { Globals = svars ; ViewDefs = ds ; Axioms = xs } =
-        let funcDecls, definites = translateViewDefs ctx ds
-        let vrules = translateVariables ctx funcDecls svars
-        let trules = xs |> Map.toSeq |> Seq.choose (translateTerm ctx funcDecls)
-
-        { Definites = List.ofSeq definites
-          Rules = Seq.append vrules trules |> Map.ofSeq
-          FuncDecls = funcDecls }
-
-    /// <summary>
-    ///     Generates a MuZ3 fixedpoint.
-    /// </summary>
-    /// <param name="ctx">
-    ///     The Z3 context to use for modelling the fixedpoint.
-    /// </param>
-    /// <param name="_arg1">
-    ///     The <c>MuModel</c> to use in generation.
-    /// </param>
-    /// <returns>
-    ///     The pair of Z3 <c>Fixedpoint</c> and unsafeness <c>FuncDecl</c>.
-    /// </returns>
-    let fixgen (ctx : Z3.Context) { Definites = ds; Rules = rs ; FuncDecls = fm } =
-        let fixedpoint = ctx.MkFixedpoint ()
-
-        let pars = ctx.MkParams ()
-        pars.Add("engine", ctx.MkSymbol("pdr"))
-        fixedpoint.Parameters <- pars
-
-        List.iter
-            (fun (view, def) ->
-                 match (mkRule ctx fm def Multiset.empty view) with
-                 | Some rule -> fixedpoint.AddRule rule
-                 | None -> ())
-            ds
-
-        let unsafe = ctx.MkFuncDecl ("unsafe", [||], ctx.MkBoolSort () :> Z3.Sort)
-        fixedpoint.RegisterRelation unsafe
-        let unsafeapp = unsafe.Apply [| |] :?> Z3.BoolExpr
-
-        List.iter
-            (fun (view, def) ->
-                 // TODO(CaptainHayashi): de-duplicate this with mkRule.
-                 let vars =
-                    seq {
-                        yield! (varsInBool def)
-                        for param in view.Params do
-                            yield! (varsIn param)
-                    }
-                    |> Set.ofSeq
-                    |> Set.map (fun (name, ty) ->
-                                    ctx.MkConst (constToString name, typeToSort ctx ty))
-                    |> Set.toArray
-
-                 fixedpoint.AddRule (
-                    ctx.MkForall (vars,
-                                  ctx.MkImplies (ctx.MkAnd [| def |> mkNot |> boolToZ3 ctx
-                                                              translateVFunc ctx fm view |],
-                                                 unsafeapp))))
-            ds
-
-        Map.iter (fun (s : string) g -> fixedpoint.AddRule (g, ctx.MkSymbol s :> Z3.Symbol)) rs
-        Map.iter (fun _ g -> fixedpoint.RegisterRelation g) fm
-
-        (fixedpoint, unsafe)
-
-    /// <summary>
-    ///     Runs a MuZ3 fixedpoint.
-    /// </summary>
-    /// <param name="fixedpoint">
-    ///     The <c>Fixedpoint</c> to run.
-    /// </param>
-    /// <param name="unsafe">
-    ///     The <c>FuncDecl</c> naming the unsafeness predicate.
-    /// </param>
-    /// <returns>
-    ///     A <c>MuResult</c>.
-    /// </returns>
-    let run (fixedpoint : Z3.Fixedpoint) unsafe =
-        match (fixedpoint.Query [| unsafe |]) with
-        | Z3.Status.SATISFIABLE ->
-             MuSat.Sat (fixedpoint.GetAnswer ())
-        | Z3.Status.UNSATISFIABLE ->
-             MuSat.Unsat (fixedpoint.GetAnswer ())
-        | Z3.Status.UNKNOWN ->
-             MuSat.Unknown (fixedpoint.GetReasonUnknown ())
-         | _ -> MuSat.Unknown "query result out of bounds"
-
-
-/// <summary>
 ///     Proof execution using Z3.
 /// </summary>
 module Run =
@@ -699,12 +209,6 @@ module Run =
     let run ctx = axioms >> Map.map (runTerm ctx)
 
 
-/// Shorthand for the translator stage of the MuZ3 pipeline.
-let mutranslate = MuTranslator.translate
-/// Shorthand for the fixpoint generation stage of the MuZ3 pipeline.
-let mufix = MuTranslator.fixgen
-/// Shorthand for the satisfiability stage of the MuZ3 pipeline.
-let musat = uncurry MuTranslator.run
 /// Shorthand for the translator stage of the Z3 pipeline.
 let translate = Translator.interpret
 /// Shorthand for the combination stage of the Z3 pipeline.
@@ -712,9 +216,15 @@ let combine = Translator.combineTerms >> lift
 /// Shorthand for the satisfiability stage of the Z3 pipeline.
 let sat = Run.run >> lift
 
-/// Runs the Starling Z3 backend.
-/// Takes two arguments: the first is the `Response` telling the backend what
-/// to output; the second is the reified model to process with Z3.
+/// <summary>
+///     The Starling Z3 backend driver.
+/// </summary>
+/// <param name="req">
+///     The request to handle.
+/// </param>
+/// <returns>
+///     A function implementing the chosen Z3 backend process.
+/// </returns>
 let run resp =
     use ctx = new Z3.Context()
     match resp with
@@ -726,18 +236,3 @@ let run resp =
         >> lift Response.Translate
     | Request.Combine -> translate >> combine ctx >> lift Response.Combine
     | Request.Sat -> translate >> combine ctx >> sat ctx >> lift Response.Sat
-    | Request.MuTranslate ->
-        mutranslate ctx
-        >> Response.MuTranslate
-        >> ok
-    | Request.MuFix ->
-        mutranslate ctx
-        >> mufix ctx
-        >> Response.MuFix
-        >> ok
-    | Request.MuSat ->
-        mutranslate ctx
-        >> mufix ctx
-        >> musat
-        >> Response.MuSat
-        >> ok

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -610,7 +610,6 @@ module MuTranslator =
 
         let pars = ctx.MkParams ()
         pars.Add("engine", ctx.MkSymbol("pdr"))
-        pars.Add("pdr.flexible_trace", true)
         fixedpoint.Parameters <- pars
 
         List.iter

--- a/starling.fsproj
+++ b/starling.fsproj
@@ -72,6 +72,7 @@
     <Compile Include="Horn.fs" />
     <Compile Include="Frontend.fs" />
     <Compile Include="Z3Backend.fs" />
+    <Compile Include="MuZ3Backend.fs" />
     <Compile Include="TestStudies.fs" />
     <Compile Include="ExprTests.fs" />
     <Compile Include="GraphTests.fs" />


### PR DESCRIPTION
This pull request implements a very rough, experimental backend using µZ3.

The backend is _very_ slow, possibly buggy, and has been rush-implemented in various places, but works enough to get some positive results on the test cases.

This also adds a new, temporary `-R` flag, which causes Z3 and µZ3 to emit Z3 expressions over Reals whenever they would normally emit Ints.  This is because, theoretically, µZ3 should speed up over Reals… at time of writing, this is buggy.

**NOTE:** This changes code in the Z3 backend _and_ `Main.fs`: any changes to these will need some non-trivial merging!
