### PR TITLE
Refactor reification to not use powerbag 

### DIFF
--- a/Axiom.fs
+++ b/Axiom.fs
@@ -51,7 +51,7 @@ module Types =
         { /// The axiom to be checked for soundness under Goal.
           Axiom : Axiom<GView, Command>
           /// The view representing the goal for any terms over Axiom.
-          Goal : View }
+          Goal : OView }
 
 /// <summary>
 ///     Pretty printers for axioms.
@@ -72,7 +72,7 @@ module Pretty =
     let printGoalAxiom {Axiom = a; Goal = f} =
         vsep [ headed "Axiom"
                       (a |> printAxiom printCommand printGView |> Seq.singleton)
-               headed "Goal" (f |> printView |> Seq.singleton) ]
+               headed "Goal" (f |> printOView |> Seq.singleton) ]
 
 
 /// Makes an axiom {p}c{q}.
@@ -97,7 +97,7 @@ let instantiateParam fg (ty, name) =
 
 /// Instantiates a defining view into a view expression.
 let instantiateGoal fg dvs =
-    dvs |> Multiset.map (fun { Name = n; Params = ps } ->
+    dvs |> List.map (fun { Name = n; Params = ps } ->
                { Name = n
                  Params = List.map (instantiateParam fg) ps })
 

--- a/Flattener.fs
+++ b/Flattener.fs
@@ -16,14 +16,12 @@ open Starling.Core.GuardedView
 /// Extracts a sequence of all of the parameters in a view in order.
 let paramsOfView ms =
     ms
-    |> Multiset.toFlatSeq
     |> Seq.map (fun v -> v.Params)
     |> Seq.concat
 
 /// Constructs a (hopefully) unique name for a func encompassing a view.
 let funcNameOfView ms =
     ms
-    |> Multiset.toFlatSeq
     // These two steps are to ensure we don't capture an existing name.
     |> Seq.map (fun { Name = n } -> n.Replace("_", "__"))
     |> scons "v"
@@ -64,7 +62,7 @@ let addGlobalsToViewDef gs {View = v; Def = d} =
  *)
 
 /// Adds globals to the arguments of all views in a model.
-let flatten (mdl: Model<PTerm<ViewSet, View>, DView>) =
+let flatten (mdl: Model<PTerm<ViewSet, OView>, DView>) =
     /// Build a function making a list of global arguments, for view assertions.
     let gargs marker = varMapToExprs marker mdl.Globals
 

--- a/FlattenerTests.fs
+++ b/FlattenerTests.fs
@@ -17,7 +17,7 @@ type FlattenerTests() =
 
     /// Test cases for the view func renamer.
     static member ViewFuncNamings =
-        let ms : VFunc list -> View = Multiset.ofFlatList
+        let ms : VFunc list -> OView = Multiset.ofFlatList >> Multiset.toFlatList
         [ TestCaseData(ms [ { Name = "foo"; Params = [] }
                             { Name = "bar_baz"; Params = [] } ])
             .Returns("v_bar__baz_foo") // Remember, multisets sort!
@@ -28,13 +28,13 @@ type FlattenerTests() =
     /// Tests the view predicate name generator.
     [<TestCaseSource("ViewFuncNamings")>]
     member x.``the flattened view name generator generates names correctly`` v =
-        let pn : View -> string = funcNameOfView 
+        let pn : OView -> string = funcNameOfView 
         pn v
 
     /// Test cases for the full defining-view func converter.
     /// These all use the Globals environment above.
     static member DViewFuncs =
-        let ms : DFunc list -> DView = Multiset.ofFlatList
+        let ms : DFunc list -> DView = Multiset.ofFlatList >> Multiset.toFlatList
         [ TestCaseData(ms [ { Name = "holdLock"; Params = [] }
                             { Name = "holdTick"; Params = [(Type.Int, "t")] } ])
              .Returns({ Name = "v_holdLock_holdTick"
@@ -54,7 +54,7 @@ type FlattenerTests() =
     /// Test cases for the full view func converter.
     /// These all use the Globals environment above.
     static member ViewFuncs =
-        let ms : VFunc list -> View = Multiset.ofFlatList
+        let ms : VFunc list -> OView = Multiset.ofFlatList >> Multiset.toFlatList
         [ TestCaseData(ms [ { Name = "holdLock"; Params = [] }
                             { Name = "holdTick"; Params = [AExpr (aUnmarked "t")] } ])
              .Returns({ Name = "v_holdLock_holdTick"
@@ -66,7 +66,7 @@ type FlattenerTests() =
 
     /// Tests the viewdef LHS translator.
     [<TestCaseSource("ViewFuncs")>]
-    member x.``the view func translator works correctly`` (v: View) =
+    member x.``the view func translator works correctly`` (v: OView) =
         v |> funcOfView (FlattenerTests.Globals
                          |> Map.toSeq
                          |> Seq.map (function

--- a/GuardedView.fs
+++ b/GuardedView.fs
@@ -69,7 +69,7 @@ module Types =
     /// <summary>
     ///     A multiset of guarded views, as produced by reification.
     /// </summary>
-    type ViewSet = Multiset<Guarded<View>>
+    type ViewSet = Multiset<Guarded<OView>>
 
 
 (*
@@ -299,5 +299,5 @@ module Pretty =
     ///     A pretty-printer command to print the <c>ViewSet</c>.
     /// </returns>
     let printViewSet =
-        printMultiset (printGuarded printView >> ssurround "((" "))")
+        printMultiset (printGuarded printOView >> ssurround "((" "))")
         >> ssurround "(|" "|)"

--- a/Main.fs
+++ b/Main.fs
@@ -112,9 +112,9 @@ type Response =
     /// The result of goal-axiom-pair generation.
     | GoalAdd of Model<GoalAxiom, DView>
     /// The result of term generation.
-    | TermGen of Model<PTerm<GView, View>, DView>
+    | TermGen of Model<PTerm<GView, OView>, DView>
     /// The result of term reification.
-    | Reify of Model<PTerm<ViewSet, View>, DView>
+    | Reify of Model<PTerm<ViewSet, OView>, DView>
     /// The result of term flattening.
     | Flatten of Model<PTerm<GView, VFunc>, DFunc>
     /// The result of semantic expansion.
@@ -149,13 +149,13 @@ let printResponse mview =
     | TermGen m ->
         printModelView
             mview
-            (printPTerm printGView printView)
+            (printPTerm printGView printOView)
             printDView
             m
     | Reify m ->
         printModelView
             mview
-            (printPTerm printViewSet printView)
+            (printPTerm printViewSet printOView)
             printDView
             m
     | Flatten m ->

--- a/Model.fs
+++ b/Model.fs
@@ -66,7 +66,12 @@ module Types =
     type View = Multiset<VFunc>
 
     /// A view definition.
-    type DView = Multiset<DFunc>
+    type DView = List<DFunc>
+
+    /// <summary>
+    ///     A basic view, as an ordered list of VFuncs.
+    /// </summary>
+    type OView = List<VFunc>
 
     /// <summary>
     ///     A view expression, combining a view with its kind.
@@ -175,8 +180,11 @@ module Pretty =
     /// Pretty-prints a View.
     let printView = printMultiset printVFunc
 
+    /// Pretty-prints a View.
+    let printOView = List.map printVFunc >> semiSep  >> squared
+
     /// Pretty-prints a DView.
-    let printDView = printMultiset printDFunc >> squared
+    let printDView = List.map printDFunc >> semiSep  >> squared
 
     /// Pretty-prints view expressions.
     let rec printViewExpr pView =

--- a/ModellerTests.fs
+++ b/ModellerTests.fs
@@ -203,7 +203,7 @@ type ModellerTests() =
              .SetName("Searching for no viewdefs does not change a full viewdef set")
           TestCaseData({ Search = Some 0; InitDefs = []})
              .Returns(ModellerTests.viewDefSet
-                          [ { View = Multiset.empty
+                          [ { View = Multiset.empty |> Multiset.toFlatList
                               Def = None }])
              .SetName("Searching for size-0 viewdefs adds emp to an empty viewdef set")
           TestCaseData({ Search = Some 0; InitDefs = ticketLockViewDefs })
@@ -211,33 +211,32 @@ type ModellerTests() =
              .SetName("Searching for size-0 viewdefs does not change a full viewdef set")
           TestCaseData({ Search = Some 1; InitDefs = [] })
              .Returns(ModellerTests.viewDefSet
-                          [ { View = Multiset.empty
+                          [ { View = []
                               Def = None }
-                            { View = Multiset.singleton (func "holdLock" [])
+                            { View = Multiset.singleton (func "holdLock" [] )|> Multiset.toFlatList
                               Def = None }
-                            { View = Multiset.singleton (func "holdTick" [(Type.Int, "t0")])
+                            { View = Multiset.singleton (func "holdTick" [(Type.Int, "t0")]) |> Multiset.toFlatList
                               Def = None }])
              .SetName("Searching for size-1 viewdefs yields viewdefs for emp and the view prototypes")
           TestCaseData({ Search = Some 2; InitDefs = [] })
              .Returns(ModellerTests.viewDefSet
-                          [ { View = Multiset.empty
+                          [ { View = []
                               Def = None }
-                            { View = Multiset.singleton (func "holdLock" [])
+                            { View = [func "holdLock" []]
+                              Def = None }
+                            { View = [ func "holdLock" []
+                                       func "holdLock" [] ]
                               Def = None }
                             { View = Multiset.ofFlatList
                                          [ func "holdLock" []
-                                           func "holdLock" [] ]
+                                           func "holdTick" [(Type.Int, "t0")] ] |> Multiset.toFlatList
                               Def = None }
-                            { View = Multiset.ofFlatList
-                                         [ func "holdLock" []
-                                           func "holdTick" [(Type.Int, "t0")] ]
-                              Def = None }
-                            { View = Multiset.singleton (func "holdTick" [(Type.Int, "t0")])
+                            { View = [func "holdTick" [(Type.Int, "t0")]]
                               Def = None }
 
                             { View = Multiset.ofFlatList
                                          [ func "holdTick" [(Type.Int, "t0")]
-                                           func "holdTick" [(Type.Int, "t1")] ]
+                                           func "holdTick" [(Type.Int, "t1")] ] |> Multiset.toFlatList
                               Def = None }])
              .SetName("Searching for size-2 viewdefs yields the correct views") ]
 

--- a/Reifier.fs
+++ b/Reifier.fs
@@ -9,7 +9,7 @@ open Starling.Core.Command
 open Starling.Core.GuardedView
 
 /// Calculate the multiset of ways that this View matches the pattern in dv and add to the assumulator.
-let reifySingleDef view accumulator (dv : ViewDef<DView>) : ViewSet  = 
+let reifySingleDef view accumulator (dv : ViewDef<DView>) = 
 
     let rec matchMultipleViews (pattern : DFunc list) (view : GFunc list) accumulator result =
         match pattern with
@@ -19,10 +19,11 @@ let reifySingleDef view accumulator (dv : ViewDef<DView>) : ViewSet  =
                     result
                     |> List.map gFuncTuple
                     |> List.unzip
-                Multiset.add accumulator 
+                Set.add 
                     { // Then, separately add them into a ReView.
                     Cond = mkAnd guars
                     Item = List.rev views }
+                    accumulator 
         | p :: pattern ->
             let rec matchSingleView (view : GFunc list) rview accumulator =
                match view with
@@ -41,7 +42,7 @@ let reifySingleDef view accumulator (dv : ViewDef<DView>) : ViewSet  =
 /// Reifies an dvs entire view application.
 let reifyView (dvs : ViewDef<DView> List)  vap : ViewSet = 
     let goal = Multiset.toFlatList vap
-    Seq.fold (reifySingleDef goal) Multiset.empty dvs
+    Seq.fold (reifySingleDef goal) Set.empty dvs |> Multiset.ofFlatSeq
 
 /// Reifies all of the views in a term.
 let reifyTerm dvs = 

--- a/ReifierTests.fs
+++ b/ReifierTests.fs
@@ -46,10 +46,3 @@ type ReifierTests() =
                              Params = [ (Type.Int, "t") ] } ])
             ).SetName("Find definition of view in a reversed order")
         ]
-
-    [<TestCaseSource("FindDefOfViewCases")>]
-    /// Tests whether findDefOfView behaves correctly.
-    member x.``findDefOfView finds view defs correctly on the ticketed lock`` view =
-        view
-        |> findDefOfView ticketLockModel.ViewDefs
-        |> Option.map (fun x -> x.View)

--- a/TestStudies.fs
+++ b/TestStudies.fs
@@ -272,38 +272,38 @@ let ticketLockGuardedUnlock : PMethod<ViewExpr<GView>> =
 
 /// The view definitions of the ticket lock model.
 let ticketLockViewDefs =
-    [ { View = Multiset.empty
+    [ { View = []
         Def = Some <| BGe(aUnmarked "ticket", aUnmarked "serving") }
       { View =
             Multiset.ofFlatList
                 [ { Name = "holdTick"
-                    Params = [ (Type.Int, "t") ] } ]
+                    Params = [ (Type.Int, "t") ] } ] |> Multiset.toFlatList
         Def = Some <| BGt(aUnmarked "ticket", aUnmarked "t") }
       { View =
             Multiset.ofFlatList
                 [ { Name = "holdLock"
-                    Params = [] } ]
+                    Params = [] } ] |> Multiset.toFlatList
         Def = Some <| BGt(aUnmarked "ticket", aUnmarked "serving") }
       { View =
             Multiset.ofFlatList
                 [ { Name = "holdLock"
                     Params = [] }
                   { Name = "holdTick"
-                    Params = [ (Type.Int, "t") ] } ]
+                    Params = [ (Type.Int, "t") ] } ] |> Multiset.toFlatList
         Def = Some <| BNot(aEq (aUnmarked "serving") (aUnmarked "t")) }
       { View =
             Multiset.ofFlatList
                 [ { Name = "holdTick"
                     Params = [ (Type.Int, "ta") ] }
                   { Name = "holdTick"
-                    Params = [ (Type.Int, "tb") ] } ]
+                    Params = [ (Type.Int, "tb") ] } ] |> Multiset.toFlatList
         Def = Some <| BNot(aEq (aUnmarked "ta") (aUnmarked "tb")) }
       { View =
             Multiset.ofFlatList
                 [ { Name = "holdLock"
                     Params = [] }
                   { Name = "holdLock"
-                    Params = [] } ]
+                    Params = [] } ] |> Multiset.toFlatList
         Def = Some <| BFalse } ]
 
 /// The model of the ticket lock.


### PR DESCRIPTION
Altered to use ordered views in multiple places to account for the
order of matching.

Reify now uses the definitions to build the patterns, rather than
filtering the powerbag of the view.

Correct behaviour for matching with a definitions that has a definition
that does is not symettric about repeated views in the constraint.
We need to add a test for this case.
