### PR TITLE
Make Semantics expanded earlier in the pipeline

### DIFF
--- a/Axiom.fs
+++ b/Axiom.fs
@@ -70,9 +70,9 @@ module Pretty =
         Surround(pre |> pView, cmd |> pCmd, post |> pView)
 
     /// Pretty-prints a goal axiom.
-    let printGoalAxiom { Axiom = a; Goal = f } =
+    let printGoalAxiom printCmd { Axiom = a; Goal = f } =
         vsep [ headed "Axiom"
-                      (a |> printAxiom printCommand printSVGView |> Seq.singleton)
+                      (a |> printAxiom printCmd printSVGView |> Seq.singleton)
                headed "Goal" (f |> printOView |> Seq.singleton) ]
 
 

--- a/Axiom.fs
+++ b/Axiom.fs
@@ -48,9 +48,9 @@ module Types =
           Cmd : 'cmd }
 
     /// An axiom combined with a goal view.
-    type GoalAxiom =
+    type GoalAxiom<'cmd> =
         { /// The axiom to be checked for soundness under Goal.
-          Axiom : Axiom<SVGView, Command>
+          Axiom : Axiom<SVGView, 'cmd>
           /// The view representing the goal for any terms over Axiom.
           Goal : OView }
 

--- a/Flattener.fs
+++ b/Flattener.fs
@@ -67,7 +67,7 @@ let addGlobalsToViewDef gs =
  *)
 
 /// Adds globals to the arguments of all views in a model.
-let flatten (mdl: UVModel<PTerm<SMViewSet, OView>>) =
+let flatten (mdl: UVModel<Term<'cmd, SMViewSet, OView>>) =
     /// Build a function making a list of global arguments, for view assertions.
     let gargs marker = varMapToExprs (marker >> Reg) mdl.Globals
 

--- a/Main.fs
+++ b/Main.fs
@@ -122,7 +122,7 @@ type Response =
     /// Stop at graph axiomatisation.
     | Axiomatise of UVModel<Axiom<SVGView, Command>>
     /// The result of goal-axiom-pair generation.
-    | GoalAdd of UVModel<GoalAxiom>
+    | GoalAdd of UVModel<GoalAxiom<Command>>
     /// The result of term generation.
     | TermGen of UVModel<PTerm<SMGView, OView>>
     /// The result of term reification.

--- a/Main.fs
+++ b/Main.fs
@@ -125,12 +125,12 @@ type Response =
     | GoalAdd of UVModel<GoalAxiom<Command>>
     /// The result of term generation.
     | TermGen of UVModel<PTerm<SMGView, OView>>
-    /// The result of term reification.
-    | Reify of UVModel<PTerm<SMViewSet, OView>>
-    /// The result of term flattening.
-    | Flatten of UFModel<PTerm<SMGView, SMVFunc>>
     /// The result of semantic expansion.
-    | Semantics of UFModel<STerm<SMGView, SMVFunc>>
+    | Semantics of UVModel<STerm<SMGView, OView>>
+    /// The result of term reification.
+    | Reify of UVModel<STerm<SMViewSet, OView>>
+    /// The result of term flattening.
+    | Flatten of UFModel<STerm<SMGView, SMVFunc>>
     /// The result of term optimisation.
     | TermOptimise of UFModel<STerm<SMGView, SMVFunc>>
     /// The result of Z3 backend processing.
@@ -152,11 +152,11 @@ let printResponse mview =
         printUVModelView printGoalAxiom mview m
     | TermGen m ->
         printUVModelView (printPTerm printSMGView printOView) mview m
-    | Reify m ->
-        printUVModelView (printPTerm printSMViewSet printOView) mview m
-    | Flatten m ->
-        printUFModelView (printPTerm printSMGView printSMVFunc) mview m
     | Semantics m ->
+        printUVModelView (printSTerm printSMGView printOView) mview m
+    | Reify m ->
+        printUVModelView (printSTerm printSMViewSet printOView) mview m
+    | Flatten m ->
         printUFModelView (printSTerm printSMGView printSMVFunc) mview m
     | TermOptimise m ->
         printUFModelView (printSTerm printSMGView printSMVFunc) mview m
@@ -341,9 +341,9 @@ let runStarling times optS reals verbose request =
     ** phase  axiomatise     Request.Axiomatise     Response.Axiomatise
     ** phase  goalAdd        Request.GoalAdd        Response.GoalAdd
     ** phase  termGen        Request.TermGen        Response.TermGen
+    ** phase  semantics      Request.Semantics      Response.Semantics
     ** phase  reify          Request.Reify          Response.Reify
     ** phase  flatten        Request.Flatten        Response.Flatten
-    ** phase  semantics      Request.Semantics      Response.Semantics
     ** phase  termOptimise   Request.TermOptimise   Response.TermOptimise
     ** backend
 

--- a/Main.fs
+++ b/Main.fs
@@ -11,6 +11,8 @@ open Starling.Core.Graph.Pretty
 open Starling.Core.Var
 open Starling.Core.Model
 open Starling.Core.Model.Pretty
+open Starling.Core.Symbolic
+open Starling.Core.Symbolic.Pretty
 open Starling.Core.Command
 open Starling.Core.Command.Pretty
 open Starling.Core.GuardedView
@@ -123,10 +125,10 @@ type Response =
     | Axiomatise of UVModel<Axiom<SVGView, Command>>
     /// The result of goal-axiom-pair generation.
     | GoalAdd of UVModel<GoalAxiom<Command>>
-    /// The result of term generation.
-    | TermGen of UVModel<PTerm<SMGView, OView>>
     /// The result of semantic expansion.
-    | Semantics of UVModel<STerm<SMGView, OView>>
+    | Semantics of UVModel<GoalAxiom<SMBoolExpr>>
+    /// The result of term generation.
+    | TermGen of UVModel<STerm<SMGView, OView>>
     /// The result of term reification.
     | Reify of UVModel<STerm<SMViewSet, OView>>
     /// The result of term flattening.
@@ -149,10 +151,10 @@ let printResponse mview =
     | Axiomatise m ->
         printUVModelView (printAxiom printCommand printSVGView) mview m
     | GoalAdd m ->
-        printUVModelView printGoalAxiom mview m
-    | TermGen m ->
-        printUVModelView (printPTerm printSMGView printOView) mview m
+        printUVModelView (printGoalAxiom printCommand) mview m
     | Semantics m ->
+        printUVModelView (printGoalAxiom printSMBoolExpr) mview m
+    | TermGen m ->
         printUVModelView (printSTerm printSMGView printOView) mview m
     | Reify m ->
         printUVModelView (printSTerm printSMViewSet printOView) mview m
@@ -340,8 +342,8 @@ let runStarling times optS reals verbose request =
     ** phase  graphOptimise  Request.GraphOptimise  Response.GraphOptimise
     ** phase  axiomatise     Request.Axiomatise     Response.Axiomatise
     ** phase  goalAdd        Request.GoalAdd        Response.GoalAdd
-    ** phase  termGen        Request.TermGen        Response.TermGen
     ** phase  semantics      Request.Semantics      Response.Semantics
+    ** phase  termGen        Request.TermGen        Response.TermGen
     ** phase  reify          Request.Reify          Response.Reify
     ** phase  flatten        Request.Flatten        Response.Flatten
     ** phase  termOptimise   Request.TermOptimise   Response.TermOptimise

--- a/Reifier.fs
+++ b/Reifier.fs
@@ -56,6 +56,6 @@ let reifyTerm dvs =
     mapTerm id (reifyView dvs) id
 
 /// Reifies all of the terms in a model's axiom list.
-let reify : UVModel<PTerm<SMGView, OView>> -> UVModel<PTerm<SMViewSet, OView>> =
+let reify : UVModel<Term<'a, SMGView, OView>> -> UVModel<Term<'a, SMViewSet, OView>> =
     fun ms ->
         mapAxioms (reifyTerm ms.ViewDefs) ms

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -189,6 +189,6 @@ let translateAxiom model =
 
 /// Translate a model over Prims to a model over semantic expressions.
 let translate
-  (model : UFModel<PTerm<SMGView, SMVFunc>>)
-  : Result<UFModel<STerm<SMGView, SMVFunc>>, Error> =
+  (model : Model<Term<Command, 'wpre, 'goal>, 'viewdef>)
+  : Result<Model<Term<SMBoolExpr, 'wpre, 'goal>, 'viewdef>, Error> =
     tryMapAxioms (translateAxiom model) model

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -180,15 +180,12 @@ let semanticsOfCommand
              | [] -> frame svars tvars BTrue |> List.ofSeq |> mkAnd
              | xs -> List.reduce composeBools xs)
 
-/// Translates a model axiom into an axiom over a semantic expression.
-let translateAxiom model =
-    tryMapTerm
-        (semanticsOfCommand model.Semantics model.Globals model.Locals)
-        ok
-        ok
-
+open Starling.Core.Axiom.Types
 /// Translate a model over Prims to a model over semantic expressions.
 let translate
-  (model : Model<Term<Command, 'wpre, 'goal>, 'viewdef>)
-  : Result<Model<Term<SMBoolExpr, 'wpre, 'goal>, 'viewdef>, Error> =
-    tryMapAxioms (translateAxiom model) model
+  (model : Model<GoalAxiom<Command>, 'viewdef>)
+  : Result<Model<GoalAxiom<SMBoolExpr>, 'viewdef>, Error> =
+    let modelSemantics = semanticsOfCommand model.Semantics model.Globals model.Locals
+    let replaceCmd ga c = { Goal = ga.Goal; Axiom = {Pre = ga.Axiom.Pre; Post = ga.Axiom.Post; Cmd = c }}
+    let transSem ga = bind (replaceCmd ga >> ok) (modelSemantics ga.Axiom.Cmd)
+    tryMapAxioms transSem model

--- a/TermGen.fs
+++ b/TermGen.fs
@@ -81,7 +81,7 @@ let termGenFrame (r : OView) (q : SMGView) =
 
 /// Generates a (weakest) precondition from a framed axiom.
 let termGenPre
-  (gax : GoalAxiom)
+  (gax : GoalAxiom<'cmd>)
   : SMGView =
     (* Theoretically speaking, this is crunching an axiom {P} C {Q} and
      * goal view R into (P * (R \ Q)), where R \ Q is the weakest frame.
@@ -102,15 +102,15 @@ let termGenPre
 
 /// Generates a term from a goal axiom.
 let termGenAxiom
-  (gax : GoalAxiom)
-  : PTerm<SMGView, OView> =
+  (gax : GoalAxiom<'cmd>)
+  : Term<'cmd, SMGView, OView> =
     { WPre = termGenPre gax
       Goal = gax.Goal
       Cmd = gax.Axiom.Cmd }
 
 /// Converts a model's goal axioms to terms.
-let termGen : UVModel<GoalAxiom> -> UVModel<PTerm<SMGView, OView>> =
-    mapAxioms termGenAxiom
+let termGen  (mdl : UVModel<GoalAxiom<'cmd>>) :  UVModel<Term<'cmd, SMGView, OView>> =
+    mapAxioms termGenAxiom mdl
 
 
 /// <summary>


### PR DESCRIPTION
To enable symbolic execution of atomic steps, we need to move it earlier in the pipeline. The TermGen phase needs to know the variables before and after the execution. This pull request lays the groundwork for making those changes.
