### PR TITLE
Approximation of symbols, and associated refactorings

### DIFF
--- a/AST.fs
+++ b/AST.fs
@@ -8,6 +8,7 @@ open Starling.Collections
 open Starling.Core.Model
 open Starling.Core.Var.Types
 
+
 /// <summary>
 ///     Types used in the AST.
 /// </summary>

--- a/Collections.fs
+++ b/Collections.fs
@@ -191,6 +191,51 @@ module Multiset =
         Map.fold addn xs ymap
 
     /// <summary>
+    ///     Maps <c>f</c> over the unique items of a multiset, passing
+    ///     an accumulator in some arbitrary order.
+    /// </summary>
+    /// <param name="f">
+    ///     The function to map over the multiset.  This takes the
+    ///     accumulator, the item, and the number of times that item
+    ///     appears in the multiset.  It should return the new item.  It
+    ///     is assumed the number of appearances does not change.
+    /// </param>
+    /// <param name="init">
+    ///     The initial value of the accumulator.
+    /// </param>
+    /// <typeparam name="acc">
+    ///     The type of the accumulator.
+    /// </typeparam>
+    /// <typeparam name="src">
+    ///     The type of variables in the list to map.
+    /// </typeparam>
+    /// <typeparam name="dst">
+    ///     The type of variables in the list after mapping.
+    /// </typeparam>
+    /// <returns>
+    ///     The pair of the final value of the accumulator, and the
+    ///     result of mapping <c>f</c> over the multiset.
+    /// </returns>
+    /// <remarks>
+    ///     Since multisets are ordered, mapping can change the position of
+    ///     items.
+    /// </remarks>
+    let mapAccum
+      (f : 'acc -> 'src -> int -> ('acc * 'dst))
+      (init : 'acc)
+      (MSet ms : Multiset<'src>)
+      : ('acc * Multiset<'dst>) =
+        // TODO(CaptainHayashi): convert map to a similar abstraction.
+        ms
+        |> Map.toList
+        |> mapAccumL
+               (fun acc (src, num) ->
+                   let acc', dst = f acc src num
+                   (acc, (dst, num)))
+               init
+        |> pairMap id (Map.ofList >> MSet)
+
+    /// <summary>
     ///     Maps <c>f</c> over a multiset.
     /// </summary>
     /// <remarks>

--- a/Collections.fs
+++ b/Collections.fs
@@ -6,6 +6,7 @@ module Starling.Collections
 open Chessie.ErrorHandling
 open Starling.Utils
 
+
 /// <summary>
 ///     A function-like construct.
 /// </summary>
@@ -71,7 +72,7 @@ module Multiset =
     ///     Adds an element n times to a multiset
     /// </summary>
     let addn (MSet ms) k m =
-        let n = ms.TryFind k |> Option.fold (fun x y -> y) 0
+        let n = ms.TryFind k |> Option.fold (fun _ y -> y) 0
         MSet (ms.Add (k, n+m))
 
     /// <summary>
@@ -158,7 +159,7 @@ module Multiset =
     ///     The set of items in the multiset.
     /// </returns>
     let toSet (MSet ms) =
-        Map.fold (fun set k n -> Set.add k set) Set.empty ms
+        Map.fold (fun set k _ -> Set.add k set) Set.empty ms
 
     (*
      * Operations
@@ -258,22 +259,6 @@ module Multiset =
             | n -> repeat_add (add map (f k)) k (n-1)
         //Note that this is used with side-effecting f, so must be called n times for each addition.
         Map.fold repeat_add empty xs
-
-    /// Produces the power-multiset of a multiset, as a set of multisets.
-    let power msm =
-        (* Solve the problem using Boolean arithmetic on the index of the
-         * powerset item.
-         *)
-        let ms = toFlatList msm
-        seq {
-            for i in 0..(1 <<< List.length ms) - 1 do
-                yield (seq { 0..(List.length ms) - 1 } |> Seq.choose (fun j ->
-                                                              let cnd : int = i &&& (1 <<< j)
-                                                              if cnd <> 0 then Some ms.[j]
-                                                              else None))
-                      |> ofFlatSeq
-        }
-        |> Set.ofSeq
 
     /// <summary>
     ///     Collapses a multiset of results to a result on a multiset.

--- a/Collections.fs
+++ b/Collections.fs
@@ -235,7 +235,7 @@ module Multiset =
         |> mapAccumL
                (fun acc (src, num) ->
                    let acc', dst = f acc src num
-                   (acc, (dst, num)))
+                   (acc', (dst, num)))
                init
         |> pairMap id (Map.ofList >> MSet)
 

--- a/Examples/WIP/lclist-starling.cvf
+++ b/Examples/WIP/lclist-starling.cvf
@@ -134,11 +134,11 @@ constraint hasNode(a) -> true && %{ heap #2; nodeLocked(#1) }(a, heap);
 
 
 // Constraints on views
-constraint has1Lock(a,_) * has1Lock(c,__)  -> true && %{ heap #3; #1!=#2 }(a, c, heap);
-constraint has1Lock(a,_) * has2Lock(c,d)   -> true && %{ heap #4; #1!=#2 * #1!=#3 }(a, c, d, heap);
-constraint has2Lock(a,b) * has2Lock(c,d)   -> true && %{ heap #5; #1!=#2 * #1!=#4 * #2!=#3 * #2!=#4 }(a, b, c, d, heap);
-constraint has1Lock(a,_) * hasNode(c)      -> true && %{ heap #3; #1!=#2 }(a, c, heap);
-constraint has2Lock(a,b) * hasNode(c)      -> true && %{ heap #3; #1!=#2 * #2!=#3}(a, b, c, heap);
+constraint has1Lock(a,b) * has1Lock(c,d)   -> a != c;
+constraint has1Lock(a,b) * has2Lock(c,d)   -> a != c && a != d;
+constraint has2Lock(a,b) * has2Lock(c,d)   -> a != c && a != d && b != c && b != d;
+constraint has1Lock(a,b) * hasNode(c)      -> a != c;
+constraint has2Lock(a,b) * hasNode(c)      -> a != c && b != c;
 
 // Could maybe replace some of the constraints above?
 constraint has2Lock(a,b) -> %{ heap #3; has1Lock(#1,_) * has1Lock(#2,_) }(a, b, heap);

--- a/Examples/WIP/lclist-starling.cvf
+++ b/Examples/WIP/lclist-starling.cvf
@@ -1,111 +1,118 @@
 /* Currently as close to lclist.cvf as Starling can get. */
 
-shared int heap; 
-shared int head; 
+shared int heap;
+shared int head;
 thread int lheap;
 thread int prev;
 thread int curr;
 
 thread int v;
+thread int cv;
 thread int val;
 
 thread int _;
 
+view isVal(int v, int node);
 view isHead(int prev);
 view false();
-view isList(); 
-view has1Lock(int x, int y); 
-view has2Lock(int x, int y); 
-view hasNode(int x); 
+view isList();
+view has1Lock(int x, int y);
+view has2Lock(int x, int y);
+view hasNode(int x);
 
-method deleteVal() { 
-  {| isList() |} 
+method deleteVal() {
+  {| isList() |}
     <lheap = heap>;
     v = (%{ heap #1; return getV() }(lheap));
-  {| isList() |} 
+  {| isList() |}
     <prev = head>;
   {| isList() * isHead(prev) |}
     <{
        lheap = heap;
        heap  = (%{ heap #1; lock(#2); return heap; }(lheap, prev));
-     }>; 
+     }>;
     prev = (%{ heap #1; return lock(#2); }(lheap, prev));
-  {| has1Lock(prev, _) * isHead(prev) |} 
+  {| has1Lock(prev, _) * isHead(prev) |}
     <lheap = heap>;
-    curr = (%{ heap #1; return next(#2); }(lheap, curr)); 
-  {| has1Lock(prev, curr) * isHead(prev) |} 
+    curr = (%{ heap #1; return next(#2); }(lheap, curr));
+  {| has1Lock(prev, curr) * isHead(prev) |}
     // The 0+ forces the symbol to be read as an int.
     // Otherwise, the type is ambiguous.
-    // (We could probably do better than this, since v is known to be an
-    // int at this point.)
-    while (0 + %{val(#1)}(curr) < v) { 
-      {| has1Lock(prev, curr) |} 
+    // (We could probably do better than this.)
+    <lheap = heap>;
+    cv = (%{ heap #1; return val(#1); }(lheap, curr));
+  {| has1Lock(prev,curr) * isVal(cv, curr) |}
+    while (cv < v) {
+      {| has1Lock(prev, curr) * isVal(cv, curr) |}
         <{
            lheap = heap;
            heap  = (%{ heap #1; lock(#2); return heap; }(lheap, curr));
-         }>; 
+         }>;
         curr = (%{ heap #1; return lock(#2); }(lheap, curr));
-      {| has2Lock(prev, curr) |} 
+      {| has2Lock(prev, curr) * isVal(cv, curr) |}
         <{
            lheap = heap;
            heap  = (%{ heap #1; unlock(#2); return heap; }(lheap, prev));
-         }>; 
+         }>;
         prev = (%{ heap #1; return unlock(#2); }(lheap, prev));
-      {| has1Lock(curr, _) |} 
-        prev = curr; 
-      {| has1Lock(prev, _) |} 
+      {| has1Lock(curr, _) * isVal(cv, curr) |}
+        prev = curr;
+      {| has1Lock(prev, _) * isVal(cv, prev) |}
         <lheap = heap>;
         curr = (%{ heap #1; return next(#2); }(lheap, curr));
-      {| has1Lock(prev, curr) |} 
-    } 
-  {| has1Lock(prev, curr) |} 
+      {| has1Lock(prev, curr) * isVal(cv, prev) |}
+        <lheap = heap>;
+        cv = (%{ heap #1; return val(#1); }(lheap, curr));
+      {| has1Lock(prev, curr) * isVal(cv, curr) |}
+    }
+  {| has1Lock(prev, curr) |}
      <lheap = heap>;
      val = (%{ heap #1; return val(#2); }(lheap, curr));
-  {| has1Lock(prev, curr) |} 
-    if (val == v) { 
-      {| has1Lock(prev, curr) |} 
+  {| has1Lock(prev, curr) |}
+    if (val == v) {
+      {| has1Lock(prev, curr) |}
         <{
            lheap = heap;
            heap  = (%{ heap #1; lock(#2); return heap; }(lheap, curr));
-         }>; 
+         }>;
         curr = (%{ heap #1; return lock(#2); }(lheap, curr));
-      {| has2Lock(prev, curr) |} 
+      {| has2Lock(prev, curr) |}
         <{
            lheap = heap;
            heap  = (%{ heap #1; set_next(#2, next(#3)); return heap; }(lheap, prev, curr));
-         }>; 
+         }>;
         prev = (%{ heap #1; return set_next(#2, next(#3)); }(lheap, prev, curr));
-      {| has1Lock(prev, _) * hasNode(curr) |} 
+      {| has1Lock(prev, _) * hasNode(curr) |}
         <{
            lheap = heap;
            heap  = (%{ heap #1; dispose(#2); return heap; }(lheap, curr));
-         }>; 
-        curr = (%{ heap #1; return dispose(#2); }(lheap, curr));  
-      {| has1Lock(prev, _) |} 
+         }>;
+        curr = (%{ heap #1; return dispose(#2); }(lheap, curr));
+      {| has1Lock(prev, _) |}
     } else {
-      {| has1Lock(prev, curr) |} 
+      {| has1Lock(prev, curr) |}
       ;
-      {| has1Lock(prev, _) |} 
+      {| has1Lock(prev, _) |}
     }
-  {| has1Lock(prev, _) |} 
+  {| has1Lock(prev, _) |}
     <{
        lheap = heap;
        heap  = (%{ heap #1; unlock(#2); return heap; }(lheap, prev));
-     }>; 
+     }>;
     prev = (%{ heap #1; return unlock(#2); }(lheap, prev));
-  {| isList() |} 
+  {| isList() |}
 }
 
 constraint isHead(x) -> x == head;
 
-// Define list properties 
+// Define list properties
 // The (true &&) device is necessary to prevent type ambiguity.
 
 constraint isList() ->
   true &&
   %{ heap #2;
      exists e . lseg(#1, e)
-              * endNode(e) }(head, heap); 
+              * endNode(e) }(head, heap);
 
 constraint has1Lock(a,b) ->
   true &&
@@ -115,18 +122,18 @@ constraint has1Lock(a,b) ->
               * lseg(#3, e)
               * endNode(e) }(head, a, b, heap);
 
-constraint has2Lock(a,b)  ->  
+constraint has2Lock(a,b)  ->
   true &&
   %{ heap #4;
      exists c, e . lseg(#1, #2)
                  * nodeLocked(#2, #3)
-                 * nodeLocked(#3, c) 
-                 * lseg(c, e) * endNode(e) }(head, a, b, heap); 
+                 * nodeLocked(#3, c)
+                 * lseg(c, e) * endNode(e) }(head, a, b, heap);
 
-constraint hasNode(a) -> true && %{ heap #2; nodeLocked(#1) }(a, heap); 
+constraint hasNode(a) -> true && %{ heap #2; nodeLocked(#1) }(a, heap);
 
 
-// Constraints on views 
+// Constraints on views
 constraint has1Lock(a,_) * has1Lock(c,__)  -> true && %{ heap #3; #1!=#2 }(a, c, heap);
 constraint has1Lock(a,_) * has2Lock(c,d)   -> true && %{ heap #4; #1!=#2 * #1!=#3 }(a, c, d, heap);
 constraint has2Lock(a,b) * has2Lock(c,d)   -> true && %{ heap #5; #1!=#2 * #1!=#4 * #2!=#3 * #2!=#4 }(a, b, c, d, heap);
@@ -135,3 +142,5 @@ constraint has2Lock(a,b) * hasNode(c)      -> true && %{ heap #3; #1!=#2 * #2!=#
 
 // Could maybe replace some of the constraints above?
 constraint has2Lock(a,b) -> %{ heap #3; has1Lock(#1,_) * has1Lock(#2,_) }(a, b, heap);
+
+constraint isVal(v, node) -> true && %{ heap #3; #2.val = #1 }(v, node, heap);

--- a/Examples/WIP/lclist.cvf
+++ b/Examples/WIP/lclist.cvf
@@ -1,74 +1,74 @@
-/* 
- * Viktor's lock-coupling example from his thesis. 
- * Sketched up in Starling syntax from WB discussion, 12/4/2016.
- *  
- * Some issues: 
- *   - don't define the low level domain anywhere, eg. endNode() 
- *   - not clear what the right set of constraints is. 
- *   - calls to lock / unlock are abstract, not clear what they mean.
- * / 
+/*
+ * Viktor's lock-coupling example from his thesis.
+ * Sketched up in Starling syntax from WB discussion, 12/4/2016
+ *
+ * Some issues:
+ *   - don't define the low level domain anywhere, eg. endNode()
+ *   - not clear what the right set of constraints is.
+ *   - calls to lock / unlock are abstract, not clear what they mean
+ */
 
-shared node *head; 
+shared node *head;
 
-view isList(); 
-view has1Lock(node *x, node *y); 
-view has2Lock(node *x, node *y); 
-view hasNode(node *x); 
+view isList();
+view has1Lock(node *x, node *y);
+view has2Lock(node *x, node *y);
+view hasNode(node *x);
 
-method deleteVal(int v) { 
-  {| isList() |} 
-    prev = x; 
-    <lock(prev.lk)>; 
-  {| has1Lock(prev, _) * prev = x |} 
-    <curr = prev.nxt>; 
-  {| has1Lock(prev, curr) * prev = x |} 
-    while (curr.val < v) { 
-      {| has1Lock(prev, curr) |} 
-        <lock(curr.lk)>; 
-      {| has2Lock(prev, curr) |} 
-        unlock(prev.lk); 
-      {| has1Lock(curr, _ ) |} 
-        prev = curr; 
-      {| has1Lock(prev, _ ) |} 
+method deleteVal(int v) {
+  {| isList() |}
+    prev = x;
+    <lock(prev.lk)>;
+  {| has1Lock(prev, _) * prev = x |}
+    <curr = prev.nxt>;
+  {| has1Lock(prev, curr) * prev = x |}
+    while (curr.val < v)
+      {| has1Lock(prev, curr) |}
+        <lock(curr.lk)>;
+      {| has2Lock(prev, curr) |}
+        unlock(prev.lk);
+      {| has1Lock(curr, _ ) |}
+        prev = curr;
+      {| has1Lock(prev, _ ) |}
         curr = prev.nxt;
-      {| has1Lock(prev, curr ) |} 
-    } 
-  {| has1Lock(prev, curr) |} 
-    if (curr.val == v) { 
-      {| has1Lock(prev, curr) |} 
-        lock(curr.lk); 
-      {| has2Lock(prev, curr) |} 
-        <prev.nxt = curr.nxt>; 
-      {| has1Lock(prev, _) * hasNode(curr) |} 
-        <disp(curr)>;  
-      {| has1Lock(prev, _) |} 
-    } 
-  {| has1Lock(prev, _) |} 
-    unlock(prev); 
-  {| isList() |} 
+      {| has1Lock(prev, curr ) |}
+    }
+  {| has1Lock(prev, curr) |}
+    if (curr.val == v) {
+      {| has1Lock(prev, curr) |}
+        lock(curr.lk);
+      {| has2Lock(prev, curr) |}
+        <prev.nxt = curr.nxt>;
+      {| has1Lock(prev, _) * hasNode(curr) |}
+        <disp(curr)>;
+      {| has1Lock(prev, _) |}
+    }
+  {| has1Lock(prev, _) |}
+    unlock(prev);
+  {| isList() |}
 }
 
 
-// Define list properties 
+// Define list properties
 
-constraint isList()  ->  lseg(head, e) * endNode(e); 
+constraint isList()  ->  lseg(head, e) * endNode(e);
 
-constraint has1Lock(a,b)  ->  
-  lseg(head, a) * nodeLocked(a,b) * lseg(b, e) * endNode(e); 
+constraint has1Lock(a,b)  ->
+  lseg(head, a) * nodeLocked(a,b) * lseg(b, e) * endNode(e);
 
-constraint has2Lock(a,b)  ->  
-  lseg(head, a) * nodeLocked(a,b) * nodeLocked(b,c) 
-     * lseg(c, e) * endNode(e); 
+constraint has2Lock(a,b)  ->
+  lseg(head, a) * nodeLocked(a,b) * nodeLocked(b,c)
+     * lseg(c, e) * endNode(e);
 
-constraint hasNode(a)  ->  nodeLocked(a); 
+constraint hasNode(a)  ->  nodeLocked(a);
 
 
-// Constraints on views 
-constraint has1Lock(a,_) * has1Lock(c,_)  ->  a!=c 
-constraint has1Lock(a,_) * has2Lock(c,d)  ->  a!=c * a!=d 
-constraint has2Lock(a,b) * has2Lock(c,d)  ->  a!=c * a!=d * b!=c * b!=d 
-constraint has1Lock(a,_) * hasNode(c)     ->  a!=c 
+// Constraints on views
+constraint has1Lock(a,_) * has1Lock(c,_)  ->  a!=c
+constraint has1Lock(a,_) * has2Lock(c,d)  ->  a!=c * a!=d
+constraint has2Lock(a,b) * has2Lock(c,d)  ->  a!=c * a!=d * b!=c * b!=d
+constraint has1Lock(a,_) * hasNode(c)     ->  a!=c
 constraint has2Lock(a,b) * hasNode(c)     ->  a!=c * b!=c
 
 // Could maybe replace some of the constraints above?
-constraint has2Lock(a,b)   ->   has1Lock(a,_) * has1Lock(b,_) 
+constraint has2Lock(a,b)   ->   has1Lock(a,_) * has1Lock(b,_)

--- a/Expr.fs
+++ b/Expr.fs
@@ -3,7 +3,6 @@
 /// </summary>
 module Starling.Core.Expr
 
-open Starling.Collections
 open Starling.Utils
 open Starling.Core.TypeSystem
 
@@ -372,7 +371,6 @@ let rec (|ConstantIntFunction|_|) x =
 /// </summary>
 module Tests =
     open NUnit.Framework
-    open Starling.Utils.Testing
 
     /// <summary>
     ///     NUnit tests for <c>Expr</c>.

--- a/Expr.fs
+++ b/Expr.fs
@@ -55,6 +55,7 @@ module Types =
         | BLe of IntExpr<'var> * IntExpr<'var>
         | BLt of IntExpr<'var> * IntExpr<'var>
         | BNot of BoolExpr<'var>
+        override this.ToString () = sprintf "%A" this
 
     /// Type for fresh variable generators.
     type FreshGen = bigint ref

--- a/Expr.fs
+++ b/Expr.fs
@@ -290,49 +290,6 @@ let getFresh fg =
     result
 
 (*
- * Expression probing
- *)
-
-/// <summary>
-///     Returns a set of all variables used in an arithmetic expression,
-///     coupled with type.
-/// </summary>
-let rec varsInInt =
-    function
-    | AVar c -> Set.singleton (Typed.Int c)
-    | AInt _ -> Set.empty
-    | AAdd xs -> xs |> Seq.map varsInInt |> Set.unionMany
-    | ASub xs -> xs |> Seq.map varsInInt |> Set.unionMany
-    | AMul xs -> xs |> Seq.map varsInInt |> Set.unionMany
-    | ADiv (x, y) -> Set.union (varsInInt x) (varsInInt y)
-
-/// <summary>
-///     Returns a set of all variables used in a Boolean expression,
-///     coupled with type.
-/// </summary>
-and varsInBool =
-    function
-    | BVar c -> Set.singleton (Typed.Bool c)
-    | BTrue -> Set.empty
-    | BFalse -> Set.empty
-    | BAnd xs -> xs |> Seq.map varsInBool |> Set.unionMany
-    | BOr xs -> xs |> Seq.map varsInBool |> Set.unionMany
-    | BImplies (x, y) -> Set.union (varsInBool x) (varsInBool y)
-    | BEq (x, y) -> Set.union (varsIn x) (varsIn y)
-    | BGt (x, y) -> Set.union (varsInInt x) (varsInInt y)
-    | BGe (x, y) -> Set.union (varsInInt x) (varsInInt y)
-    | BLe (x, y) -> Set.union (varsInInt x) (varsInInt y)
-    | BLt (x, y) -> Set.union (varsInInt x) (varsInInt y)
-    | BNot x -> varsInBool x
-
-/// Returns a set of all variables used in an expression.
-and varsIn =
-    function
-    | Int a -> varsInInt a
-    | Bool b -> varsInBool b
-
-
-(*
  * Active patterns
  *)
 
@@ -354,17 +311,6 @@ let (|SimpleExpr|CompoundExpr|) =
     | Bool (SimpleBool) -> SimpleExpr
     | Int (SimpleInt) -> SimpleExpr
     | _ -> CompoundExpr
-
-/// Partial pattern that matches a Boolean expression in terms of exactly one /
-/// constant.
-let rec (|ConstantBoolFunction|_|) x =
-    x |> varsInBool |> Seq.map valueOf |> onlyOne
-
-/// Partial pattern that matches a Boolean expression in terms of exactly one /
-/// constant.
-let rec (|ConstantIntFunction|_|) x =
-    x |>varsInInt |> Seq.map valueOf |> onlyOne
-
 
 /// <summary>
 ///     Tests for <c>Expr</c>.

--- a/Expr.fs
+++ b/Expr.fs
@@ -34,6 +34,7 @@ module Types =
         | ASub of IntExpr<'var> list
         | AMul of IntExpr<'var> list
         | ADiv of IntExpr<'var> * IntExpr<'var>
+        override this.ToString () = sprintf "%A" this
 
     /// <summary>
     ///     A Boolean expression.

--- a/ExprEquiv.fs
+++ b/ExprEquiv.fs
@@ -18,6 +18,7 @@ open Starling.Core.Expr
 open Starling.Core.Var
 open Starling.Core.Z3
 
+
 /// <summary>
 ///     Type for equivalence checks.
 /// </summary>

--- a/Frontend.fs
+++ b/Frontend.fs
@@ -14,9 +14,7 @@ open Starling.Core.GuardedView.Pretty
 open Starling.Lang.AST.Pretty
 open Starling.Lang.Modeller
 open Starling.Lang.Modeller.Pretty
-open Starling.Lang.Parser
-open Starling.Lang.Grapher
-open Starling.Lang.Guarder
+
 
 (*
  * Request and response types

--- a/Grapher.fs
+++ b/Grapher.fs
@@ -60,7 +60,7 @@ let rec graphWhile vg cg oP oQ isDo (expr : SVBoolExpr) inner =
        This means we cast it into the pre-state, as it is diverging the
        program if its state _entering_ the loop condition makes expr go
        false. *)
-    let exprB = Mapper.mapBool before expr
+    let _, exprB = Mapper.mapBoolCtx before Positive expr
 
     (* If isDo:
      *   Translating [|oP|] do { [|iP|] [|iQ|] } while (C) [|oQ|].
@@ -134,7 +134,7 @@ and graphITE vg cg oP oQ expr inTrue inFalse =
        This means we cast it into the pre-state, as it is diverging the
        program if its state _entering_ the loop condition makes expr go
        false. *)
-    let exprB = Mapper.mapBool before expr
+    let _, exprB = Mapper.mapBoolCtx before Positive expr
 
     // Translating [|oP|] if (C) { [|tP|] [|tQ|] } else { [|fP|] [|fQ|] } [|oQ|].
     trial {

--- a/Grapher.fs
+++ b/Grapher.fs
@@ -60,7 +60,7 @@ let rec graphWhile vg cg oP oQ isDo (expr : SVBoolExpr) inner =
        This means we cast it into the pre-state, as it is diverging the
        program if its state _entering_ the loop condition makes expr go
        false. *)
-    let _, exprB = Mapper.mapBoolCtx before Positive expr
+    let _, exprB = Mapper.mapBoolCtx before NoCtx expr
 
     (* If isDo:
      *   Translating [|oP|] do { [|iP|] [|iQ|] } while (C) [|oQ|].
@@ -134,7 +134,7 @@ and graphITE vg cg oP oQ expr inTrue inFalse =
        This means we cast it into the pre-state, as it is diverging the
        program if its state _entering_ the loop condition makes expr go
        false. *)
-    let _, exprB = Mapper.mapBoolCtx before Positive expr
+    let _, exprB = Mapper.mapBoolCtx before NoCtx expr
 
     // Translating [|oP|] if (C) { [|tP|] [|tQ|] } else { [|fP|] [|fQ|] } [|oQ|].
     trial {

--- a/GrapherTests.fs
+++ b/GrapherTests.fs
@@ -6,7 +6,6 @@ module Starling.Tests.Lang.Grapher
 open Chessie.ErrorHandling
 open NUnit.Framework
 
-open Starling.Collections
 open Starling.Utils
 open Starling.Core.Graph
 open Starling.Core.Graph.Tests.Studies

--- a/GuardedView.fs
+++ b/GuardedView.fs
@@ -19,10 +19,8 @@ open Starling.Collections
 open Starling.Utils
 open Starling.Core.TypeSystem
 open Starling.Core.Expr
-open Starling.Core.ExprEquiv
 open Starling.Core.Var
 open Starling.Core.Symbolic
-open Starling.Core.Sub
 open Starling.Core.Model
 open Starling.Core.Model.Sub
 

--- a/GuardedView.fs
+++ b/GuardedView.fs
@@ -575,7 +575,7 @@ module Sub =
       : (SubCtx * GFunc<'dstVar>) =
         let contextC, cond' =
             Position.changePos
-                id
+                Position.negate
                 (Mapper.mapBoolCtx sub)
                 context
                 cond
@@ -716,7 +716,7 @@ module Sub =
       : (SubCtx * Result<GFunc<'dstVar>, 'err> ) =
         let contextC, cond' =
             Position.changePos
-                id
+                Position.negate
                 (Mapper.mapBoolCtx sub)
                 context
                 cond

--- a/GuardedView.fs
+++ b/GuardedView.fs
@@ -567,7 +567,9 @@ module Sub =
       (sub : SubFun<'srcVar, 'dstVar>)
       ( { Cond = cond ; Item = item } : GFunc<'srcVar> )
       : GFunc<'dstVar> =
-        { Cond = Mapper.mapBool sub cond
+        // TODO(CaptainHayashi): properly use context?
+        // TODO(CaptainHayashi): is Negative correct here
+        { Cond = cond |> Mapper.mapBoolCtx sub Negative |> snd
           Item = subExprInVFunc sub item }
 
     /// <summary>
@@ -630,9 +632,13 @@ module Sub =
       (sub : SubFun<'srcVar, 'dstVar>)
       (term : Term<BoolExpr<'srcVar>, GView<'srcVar>, VFunc<'srcVar>>)
       : Term<BoolExpr<'dstVar>, GView<'dstVar>, VFunc<'dstVar>> =
+        // TODO(CaptainHayashi): properly use context?
+        // TODO(CaptainHayashi): is Negative correct here?
         mapTerm
-            (Mapper.mapBool sub)
+            (Mapper.mapBoolCtx sub Negative >> snd)
+            // TODO(CaptainHayashi): this should be Negative
             (subExprInGView sub)
+            // TODO(CaptainHayashi): this should be Positive
             (subExprInVFunc sub)
             term
 
@@ -666,7 +672,7 @@ module Sub =
       : Result<GFunc<'dstVar>, 'err> =
         lift2
             (fun cond' item' -> { Cond = cond' ; Item = item' } )
-            (Mapper.mapBool sub cond)
+            (Mapper.mapBoolCtx sub Positive cond |> snd)
             (trySubExprInVFunc sub item)
 
     /// <summary>
@@ -740,7 +746,8 @@ module Sub =
       : Term<BoolExpr<'srcVar>, GView<'srcVar>, VFunc<'srcVar>>
       -> Result<Term<BoolExpr<'dstVar>, GView<'dstVar>, VFunc<'dstVar>>, 'err> =
         tryMapTerm
-            (Mapper.mapBool sub)
+            // TODO(CaptainHayashi): also fix up this use of context.
+            (Mapper.mapBoolCtx sub Positive >> snd)
             (trySubExprInGView sub)
             (trySubExprInVFunc sub)
 

--- a/GuardedView.fs
+++ b/GuardedView.fs
@@ -578,13 +578,15 @@ module Sub =
         let contextC, cond' =
             Position.changePos
                 id
-                (flip (Mapper.mapBoolCtx sub) cond)
+                (Mapper.mapBoolCtx sub)
                 context
+                cond
         let context', item' =
             Position.changePos
                 id
-                (flip (subExprInVFunc sub) item)
+                (subExprInVFunc sub)
                 context
+                item
 
         (context', { Cond = cond'; Item = item' } )
 
@@ -623,8 +625,9 @@ module Sub =
             (fun ctx f _ ->
                  Position.changePos
                      id
-                     (flip (subExprInGFunc sub) f)
-                     ctx)
+                     (subExprInGFunc sub)
+                     ctx
+                     f)
             context
 
     /// <summary>
@@ -664,18 +667,21 @@ module Sub =
         let contextT, cmd' =
             Position.changePos
                 Position.negate
-                (flip (Mapper.mapBoolCtx sub) term.Cmd)
+                (Mapper.mapBoolCtx sub)
                 context
+                term.Cmd
         let contextW, wpre' =
             Position.changePos
                 Position.negate
-                (flip (subExprInGView sub) term.WPre)
+                (subExprInGView sub)
                 contextT
+                term.WPre
         let context', goal' =
             Position.changePos
                 id
-                (flip (subExprInVFunc sub) term.Goal)
+                (subExprInVFunc sub)
                 contextW
+                term.Goal
         (context', { Cmd = cmd'; WPre = wpre'; Goal = goal' } )
 
     /// <summary>
@@ -713,13 +719,15 @@ module Sub =
         let contextC, cond' =
             Position.changePos
                 id
-                (flip (Mapper.mapBoolCtx sub) cond)
+                (Mapper.mapBoolCtx sub)
                 context
+                cond
         let context', item' =
             Position.changePos
                 id
-                (flip (trySubExprInVFunc sub) item)
+                (trySubExprInVFunc sub)
                 context
+                item
 
         (context',
          lift2
@@ -766,8 +774,8 @@ module Sub =
             (fun ctx f _ ->
                  Position.changePos
                      id
-                     (flip (trySubExprInGFunc sub) f)
-                     ctx)
+                     (trySubExprInGFunc sub)
+                     ctx f)
             context
         >> pairMap id Multiset.collect
 
@@ -812,18 +820,21 @@ module Sub =
         let contextT, cmd' =
             Position.changePos
                 Position.negate
-                (flip (Mapper.mapBoolCtx sub) term.Cmd)
+                (Mapper.mapBoolCtx sub)
                 context
+                term.Cmd
         let contextW, wpre' =
             Position.changePos
                 Position.negate
-                (flip (trySubExprInGView sub) term.WPre)
+                (trySubExprInGView sub)
                 contextT
+                term.WPre
         let context', goal' =
             Position.changePos
                 id
-                (flip (trySubExprInVFunc sub) term.Goal)
+                (trySubExprInVFunc sub)
                 contextW
+                term.Goal
         (context',
          lift3
              (fun c w g -> { Cmd = c; WPre = w; Goal = g } )

--- a/GuardedView.fs
+++ b/GuardedView.fs
@@ -20,6 +20,7 @@ open Starling.Utils
 open Starling.Core.TypeSystem
 open Starling.Core.Expr
 open Starling.Core.Var
+open Starling.Core.Sub
 open Starling.Core.Symbolic
 open Starling.Core.Model
 open Starling.Core.Model.Sub

--- a/GuardedView.fs
+++ b/GuardedView.fs
@@ -233,27 +233,6 @@ let (|Always|_|) { Cond = c ; Item = i } =
 let (|Never|_|) { Cond = c ; Item = i } =
     if isFalse c then Some i else None
 
-(*
- * Variable querying.
- *)
-
-/// <summary>
-///     Extracts a sequence of all variables in a <c>GFunc</c>.
-/// </summary>
-/// <param name="_arg1">
-///     The <c>GFunc</c> to query.
-/// </param>
-/// <returns>
-///     A sequence of (<c>Const</c>, <c>Type</c>) pairs that represent all of
-///     the variables used in the <c>GFunc</c>.
-/// </returns>
-let varsInGFunc { Cond = guard ; Item = func } =
-    seq {
-        yield! (varsInBool guard)
-        for param in func.Params do
-            yield! (varsIn param)
-    }
-
 
 (*
  * Destructuring and mapping.
@@ -873,31 +852,6 @@ module Tests =
     ///     NUnit tests for guarded views.
     /// </summary>
     type NUnit () =
-        /// <summary>
-        ///     Test cases for extracting variables from <c>GFunc</c>s.
-        /// </summary>
-        static member VarsInGFuncCases =
-            [ TestCaseData(mgfunc BTrue "foo" [])
-                  .Returns(Set.empty : Set<CTyped<MarkedVar>>)
-                  .SetName("GFunc with no guard and no parameters has no variables")
-              TestCaseData(mgfunc (bBefore "bar") "foo" [])
-                  .Returns((Set.singleton (Typed.Bool (Before "bar"))) : Set<CTyped<MarkedVar>>)
-                  .SetName("Variables in a GFunc's guard are returned by varsInGFunc")
-              TestCaseData(mgfunc BTrue "foo"
-                               [ Typed.Bool (bAfter "x")
-                                 Typed.Int (iBefore "y") ] )
-                  .Returns((Set.ofArray
-                                [| (Typed.Bool (After "x"))
-                                   (Typed.Int (Before "y")) |]): Set<CTyped<MarkedVar>>)
-                  .SetName("Variables in a GFunc's parameters are returned by varsInGFunc") ]
-
-        /// <summary>
-        ///     Tests <c>varsInGFunc</c>.
-        /// </summary>
-        [<TestCaseSource("VarsInGFuncCases")>]
-        member this.testVarsInGFunc (gf : MGFunc) =
-            gf |> varsInGFunc |> Set.ofSeq
-
         /// <summary>
         ///     Case studies for <c>testPositionSubExprInGFunc</c>.
         /// </summary>

--- a/GuardedView.fs
+++ b/GuardedView.fs
@@ -935,3 +935,195 @@ module Tests =
                 positionTestSub
                 pos
                 gf
+
+        /// <summary>
+        ///     Case studies for <c>testPositionSubExprInGView</c>.
+        /// </summary>
+        static member PositionSubExprInGViewCases =
+            [ (tcd
+                   [| (Multiset.empty : GView<Var>)
+                      Position.positive |] )
+                  .Returns(
+                      (Position.positive,
+                       (Multiset.empty : GView<Var>)))
+                  .SetName("+ve empty GView substitution is a no-op")
+              (tcd
+                   [| (Multiset.empty : GView<Var>)
+                      Position.negative |] )
+                  .Returns(
+                      (Position.negative,
+                       (Multiset.empty : GView<Var>)))
+                  .SetName("-ve empty GView substitution is a no-op")
+              (tcd
+                   [| Multiset.singleton
+                          (gfunc (BVar "foo") "bar"
+                               [ Typed.Int (AVar "baz")
+                                 Typed.Bool (BVar "fizz") ] )
+                      Position.positive |] )
+                  .Returns(
+                      (Position.positive,
+                       (Multiset.singleton
+                            (gfunc BFalse "bar"
+                                 [ Typed.Int (AInt 1L)
+                                   Typed.Bool BTrue ] ) : GView<Var> )))
+                  .SetName("Singleton GView substitution in +ve case works properly")
+              (tcd
+                   [| Multiset.singleton
+                          (gfunc (BVar "foo") "bar"
+                               [ Typed.Int (AVar "baz")
+                                 Typed.Bool (BVar "fizz") ] )
+                      Position.negative |] )
+                  .Returns(
+                      (Position.negative,
+                       (Multiset.singleton
+                            (gfunc BTrue "bar"
+                                 [ Typed.Int (AInt 0L)
+                                   Typed.Bool BFalse ] ) : GView<Var> )))
+                  .SetName("Singleton GView substitution in -ve case works properly")
+              (tcd
+                   [| Multiset.ofFlatList
+                          [ gfunc (BVar "foo") "bar"
+                                [ Typed.Int (AVar "baz")
+                                  Typed.Bool (BVar "fizz") ]
+                            gfunc (BGt (AVar "foobar", AVar "barbar")) "barbaz"
+                                [ Typed.Int
+                                      (AAdd [ AVar "foobaz"; AVar "bazbaz" ]) ] ]
+                      Position.positive |] )
+                  .Returns(
+                      (Position.positive,
+                       (Multiset.ofFlatList
+                            [ gfunc BFalse "bar"
+                                  [ Typed.Int (AInt 1L)
+                                    Typed.Bool BTrue ]
+                              gfunc (BGt (AInt 0L, AInt 0L)) "barbaz"
+                                  [ Typed.Int
+                                        (AAdd [ AInt 1L; AInt 1L ]) ] ]
+                        : GView<Var>)))
+                  .SetName("Multi GView substitution in +ve case works properly")
+              (tcd
+                   [| Multiset.ofFlatList
+                          [ gfunc (BVar "foo") "bar"
+                                [ Typed.Int (AVar "baz")
+                                  Typed.Bool (BVar "fizz") ]
+                            gfunc (BGt (AVar "foobar", AVar "barbar")) "barbaz"
+                                [ Typed.Int
+                                      (AAdd [ AVar "foobaz"; AVar "bazbaz" ]) ] ]
+                      Position.negative |] )
+                  .Returns(
+                      (Position.negative,
+                       (Multiset.ofFlatList
+                            [ gfunc BTrue "bar"
+                                  [ Typed.Int (AInt 0L)
+                                    Typed.Bool BFalse ]
+                              gfunc (BGt (AInt 1L, AInt 1L)) "barbaz"
+                                  [ Typed.Int
+                                        (AAdd [ AInt 0L; AInt 0L ]) ] ]
+                        : GView<Var>)))
+                  .SetName("Multi GView substitution in -ve case works properly") ]
+
+        /// <summary>
+        ///     Tests <c>subExprInGView</c> on positional substitutions.
+        /// </summary>
+        [<TestCaseSource("PositionSubExprInGViewCases")>]
+        member this.testPositionSubExprInGView
+          (gv : GView<Var>)
+          (pos : SubCtx) =
+            Sub.subExprInGView
+                positionTestSub
+                pos
+                gv
+
+        /// <summary>
+        ///     Case studies for <c>testPositionSubExprInDTerm</c>.
+        /// </summary>
+        static member PositionSubExprInDTermCases =
+            [ (tcd
+                   [| ( { Cmd =
+                              BAnd
+                                  [ bEq (BVar "foo") (BVar "bar")
+                                    bEq (BVar "baz") (BNot (BVar "baz")) ]
+                          WPre =
+                              Multiset.ofFlatList
+                                  [ gfunc (BVar "foo") "bar"
+                                        [ Typed.Int (AVar "baz")
+                                          Typed.Bool (BVar "fizz") ]
+                                    gfunc (BGt (AVar "foobar", AVar "barbar")) "barbaz"
+                                        [ Typed.Int
+                                              (AAdd [ AVar "foobaz"; AVar "bazbaz" ]) ] ]
+                          Goal =
+                              (vfunc "bar"
+                                   [ Typed.Int (AVar "baz")
+                                     Typed.Bool (BVar "barbaz") ] : VFunc<Var> ) }
+                       : Term<BoolExpr<Var>, GView<Var>, VFunc<Var>> )
+                      Position.positive |] )
+                  .Returns(
+                      (Position.positive,
+                       ( { Cmd =
+                               BAnd
+                                   [ bEq BFalse BFalse
+                                     bEq BFalse (BNot BTrue) ]
+                           WPre =
+                               Multiset.ofFlatList
+                                   [ gfunc BTrue "bar"
+                                         [ Typed.Int (AInt 0L)
+                                           Typed.Bool BFalse ]
+                                     gfunc (BGt (AInt 1L, AInt 1L)) "barbaz"
+                                         [ Typed.Int
+                                               (AAdd [ AInt 0L; AInt 0L ]) ] ]
+                           Goal =
+                               (vfunc "bar"
+                                    [ Typed.Int (AInt 1L)
+                                      Typed.Bool BTrue ] : VFunc<Var> ) }
+                        : Term<BoolExpr<Var>, GView<Var>, VFunc<Var>> )))
+                  .SetName("Successfully translate a positive DTerm")
+              (tcd
+                   [| ( { Cmd =
+                              BAnd
+                                  [ bEq (BVar "foo") (BVar "bar")
+                                    bEq (BVar "baz") (BNot (BVar "baz")) ]
+                          WPre =
+                              Multiset.ofFlatList
+                                  [ gfunc (BVar "foo") "bar"
+                                        [ Typed.Int (AVar "baz")
+                                          Typed.Bool (BVar "fizz") ]
+                                    gfunc (BGt (AVar "foobar", AVar "barbar")) "barbaz"
+                                        [ Typed.Int
+                                              (AAdd [ AVar "foobaz"; AVar "bazbaz" ]) ] ]
+                          Goal =
+                              (vfunc "bar"
+                                   [ Typed.Int (AVar "baz")
+                                     Typed.Bool (BVar "barbaz") ] : VFunc<Var> ) }
+                       : Term<BoolExpr<Var>, GView<Var>, VFunc<Var>> )
+                      Position.negative |] )
+                  .Returns(
+                      (Position.negative,
+                       ( { Cmd =
+                               BAnd
+                                   [ bEq BTrue BTrue
+                                     bEq BTrue (BNot BFalse) ]
+                           WPre =
+                               Multiset.ofFlatList
+                                   [ gfunc BFalse "bar"
+                                         [ Typed.Int (AInt 1L)
+                                           Typed.Bool BTrue ]
+                                     gfunc (BGt (AInt 0L, AInt 0L)) "barbaz"
+                                         [ Typed.Int
+                                               (AAdd [ AInt 1L; AInt 1L ]) ] ]
+                           Goal =
+                               (vfunc "bar"
+                                    [ Typed.Int (AInt 0L)
+                                      Typed.Bool BFalse ] : VFunc<Var> ) }
+                        : Term<BoolExpr<Var>, GView<Var>, VFunc<Var>> )))
+                  .SetName("Successfully translate a negative DTerm") ]
+
+        /// <summary>
+        ///     Tests <c>subExprInDTerm</c> on positional substitutions.
+        /// </summary>
+        [<TestCaseSource("PositionSubExprInDTermCases")>]
+        member this.testPositionSubExprInDTerm
+          (t : Term<BoolExpr<Var>, GView<Var>, VFunc<Var>>)
+          (pos : SubCtx) =
+            Sub.subExprInDTerm
+                positionTestSub
+                pos
+                t

--- a/Guarder.fs
+++ b/Guarder.fs
@@ -7,7 +7,6 @@ module Starling.Lang.Guarder
 open Starling.Collections
 open Starling.Utils
 open Starling.Core.Expr
-open Starling.Core.Var
 open Starling.Core.Symbolic
 open Starling.Core.Model
 open Starling.Core.GuardedView

--- a/Horn.fs
+++ b/Horn.fs
@@ -13,7 +13,7 @@ open Starling.Core.Sub
 open Starling.Core.Model
 open Starling.Core.Instantiate
 open Starling.Core.GuardedView
-open Starling.Reifier
+
 
 /// <summary>
 ///     Types for the Horn clause backend, including errors.
@@ -72,7 +72,6 @@ module Types =
 module Pretty =
     open Starling.Core.Pretty
     open Starling.Core.Model.Pretty
-    open Starling.Core.Expr.Pretty
     open Starling.Core.Var.Pretty
 
     /// Decides whether to put brackets over the expression emission x,

--- a/Horn.fs
+++ b/Horn.fs
@@ -256,7 +256,8 @@ let boolExpr
         | x ->
             x
             |> Expr.Bool
-            |> Mapper.map (liftCToSub (Mapper.cmake toVar))
+            |> Mapper.mapCtx (liftCToSub (Mapper.cmake toVar)) Positive
+            |> snd
             |> UnsupportedExpr
             |> fail
     be
@@ -271,7 +272,8 @@ let boolExpr
 ///     Boolean.
 /// </summary>
 let tryIntExpr : MExpr -> Result<VIntExpr, Error> =
-    Mapper.map (liftCToSub (Mapper.cmake unmarkVar))
+    Mapper.mapCtx (liftCToSub (Mapper.cmake unmarkVar)) Positive
+    >> snd
     >> function
        | Expr.Int x -> ok x
        | e -> e |> UnsupportedExpr |> fail

--- a/Horn.fs
+++ b/Horn.fs
@@ -256,7 +256,7 @@ let boolExpr
         | x ->
             x
             |> Expr.Bool
-            |> Mapper.map (onVars (liftVSubFun (Mapper.cmake toVar)))
+            |> Mapper.map (liftCToSub (Mapper.cmake toVar))
             |> UnsupportedExpr
             |> fail
     be
@@ -271,7 +271,7 @@ let boolExpr
 ///     Boolean.
 /// </summary>
 let tryIntExpr : MExpr -> Result<VIntExpr, Error> =
-    Mapper.map (onVars (liftVSubFun (Mapper.cmake unmarkVar)))
+    Mapper.map (liftCToSub (Mapper.cmake unmarkVar))
     >> function
        | Expr.Int x -> ok x
        | e -> e |> UnsupportedExpr |> fail

--- a/Horn.fs
+++ b/Horn.fs
@@ -256,7 +256,7 @@ let boolExpr
         | x ->
             x
             |> Expr.Bool
-            |> Mapper.mapCtx (liftCToSub (Mapper.cmake toVar)) Positive
+            |> Mapper.mapCtx (liftCToSub (Mapper.cmake toVar)) NoCtx
             |> snd
             |> UnsupportedExpr
             |> fail
@@ -272,7 +272,7 @@ let boolExpr
 ///     Boolean.
 /// </summary>
 let tryIntExpr : MExpr -> Result<VIntExpr, Error> =
-    Mapper.mapCtx (liftCToSub (Mapper.cmake unmarkVar)) Positive
+    Mapper.mapCtx (liftCToSub (Mapper.cmake unmarkVar)) NoCtx
     >> snd
     >> function
        | Expr.Int x -> ok x

--- a/Instantiate.fs
+++ b/Instantiate.fs
@@ -421,7 +421,7 @@ let instantiate
     |> lift
            (Option.map
                 (fun (dfunc, defn) ->
-                     Mapper.mapBool (onVars (psf vfunc dfunc)) defn))
+                     Mapper.mapBoolCtx (onVars (psf vfunc dfunc)) Positive defn |> snd))
 
 /// <summary>
 ///     Functions for view definition filtering.
@@ -439,7 +439,8 @@ module ViewDefFilter =
         |> List.map
                (fun (f, d) ->
                     d
-                    |> Mapper.mapBool (tsfRemoveSym UnwantedSym)
+                    |> Mapper.mapBoolCtx (tsfRemoveSym UnwantedSym) Positive
+                    |> snd
                     |> lift (mkPair f))
         |> collect
 

--- a/Instantiate.fs
+++ b/Instantiate.fs
@@ -421,7 +421,7 @@ let instantiate
     |> lift
            (Option.map
                 (fun (dfunc, defn) ->
-                     Mapper.mapBoolCtx (onVars (psf vfunc dfunc)) Positive defn |> snd))
+                     Mapper.mapBoolCtx (onVars (psf vfunc dfunc)) NoCtx defn |> snd))
 
 /// <summary>
 ///     Functions for view definition filtering.
@@ -439,7 +439,7 @@ module ViewDefFilter =
         |> List.map
                (fun (f, d) ->
                     d
-                    |> Mapper.mapBoolCtx (tsfRemoveSym UnwantedSym) Positive
+                    |> Mapper.mapBoolCtx (tsfRemoveSym UnwantedSym) NoCtx
                     |> snd
                     |> lift (mkPair f))
         |> collect

--- a/Instantiate.fs
+++ b/Instantiate.fs
@@ -525,3 +525,97 @@ module ViewDefFilter =
         model
         |> tryMapAxioms (trySubExprInDTerm (tsfRemoveSym UnwantedSym) NoCtx >> snd)
         |> bind (tryMapViewDefs filterDefiniteViewDefs)
+
+
+/// <summary>
+///     The instantiation phase.
+///
+///     <para>
+///         This stage, which is used before predicate-based solvers
+///         such as Z3, instantiates all views in the model, substituting
+///         definitions for definite views and symbols for indefinite views.
+///     </para>
+/// </summary>
+module Phase =
+    /// Produces the reification of an unguarded func.
+    /// This corresponds to D^ in the theory.
+    let interpretVFunc (ft : FuncTable<SVBoolExpr>) func =
+        instantiate smvParamSubFun ft func
+        |> lift (withDefault BTrue)  // Undefined views go to True by metatheory
+
+    let interpretGFunc (ft : FuncTable<SVBoolExpr>) {Cond = c; Item = i} =
+        interpretVFunc ft i
+        |> lift (mkImplies c)
+
+    /// Interprets an entire view application over the given functable.
+    let interpretGView (ft : FuncTable<SVBoolExpr>) =
+        Multiset.toFlatSeq
+        >> Seq.map (interpretGFunc ft)
+        >> collect
+        >> lift Seq.toList
+        >> lift mkAnd
+
+    /// Interprets all of the views in a term over the given functable.
+    let interpretTerm
+      (ft : FuncTable<SVBoolExpr>)
+      : Term<SMBoolExpr, SMGView, SMVFunc> -> Result<SFTerm, Error> =
+        tryMapTerm ok (interpretGView ft) (interpretVFunc ft)
+
+
+    /// <summary>
+    ///     Converts all indefinite viewdefs to symbols.
+    /// </summary>
+    /// <param name="vs">
+    ///     The view definitions to convert.
+    /// </param>
+    /// <returns>
+    ///     A <c>FuncTable</c> mapping each view func to a
+    ///     <c>SVBoolExpr</c> giving its definition.  Indefinite
+    ///     viewdefs are represented by symbols.
+    /// </returns>
+    let symboliseIndefinites vs =
+        // First, get the functable of all definite views.
+        let def, indef = funcTableFromViewDefs vs
+
+        // Then, convert the indefs to symbols.
+        let symconv =
+            Mapper.make (Reg >> AVar) (Reg >> BVar)
+
+        let idsym : FuncTable<SVBoolExpr> =
+            List.map
+                (fun { Name = n ; Params = ps } ->
+                    (func n ps,
+                     BVar
+                         (Sym
+                              (func
+                                   (sprintf "!UNDEF:%A" n)
+                                   (List.map
+                                       (Mapper.mapCtx symconv NoCtx >> snd)
+                                       ps)))))
+                indef
+
+        // TODO(CaptainHayashi): use functables properly.
+        def @ idsym
+
+
+    /// <summary>
+    ///     Run the instantiation phase.
+    ///
+    ///     <para>
+    ///         This consumes the view definitions.
+    ///     </para>
+    /// </summary>
+    /// <param name="model">
+    ///     The model to instantiate.
+    /// </param>
+    /// <returns>
+    ///     The model with all views instantiated.
+    /// </returns>
+    let run
+      (model : UFModel<STerm<SMGView, SMVFunc>>)
+      : Result<Model<SFTerm, unit>, Error> =
+      let vs = symboliseIndefinites model.ViewDefs
+
+      model
+      |> tryMapAxioms (interpretTerm vs)
+      |> lift (withViewDefs ())

--- a/Instantiate.fs
+++ b/Instantiate.fs
@@ -503,7 +503,7 @@ module ViewDefFilter =
       (model : UFModel<Term<SMBoolExpr, SMGView, SMVFunc>> )
       : Result<IFModel<Term<MBoolExpr, MGView, MVFunc>>, Error> =
         model
-        |> tryMapAxioms (trySubExprInDTerm (tsfRemoveSym UnwantedSym))
+        |> tryMapAxioms (trySubExprInDTerm (tsfRemoveSym UnwantedSym) NoCtx >> snd)
         |> bind (tryMapViewDefs filterIndefiniteViewDefs)
 
     /// <summary>
@@ -523,5 +523,5 @@ module ViewDefFilter =
       (model : UFModel<Term<SMBoolExpr, SMGView, SMVFunc>> )
       : Result<DFModel<Term<MBoolExpr, MGView, MVFunc>>, Error> =
         model
-        |> tryMapAxioms (trySubExprInDTerm (tsfRemoveSym UnwantedSym))
+        |> tryMapAxioms (trySubExprInDTerm (tsfRemoveSym UnwantedSym) NoCtx >> snd)
         |> bind (tryMapViewDefs filterDefiniteViewDefs)

--- a/Instantiate.fs
+++ b/Instantiate.fs
@@ -506,26 +506,6 @@ module ViewDefFilter =
         |> tryMapAxioms (trySubExprInDTerm (tsfRemoveSym UnwantedSym) NoCtx >> snd)
         |> bind (tryMapViewDefs filterIndefiniteViewDefs)
 
-    /// <summary>
-    ///     Tries to convert a <c>ViewDef</C> based model into a
-    ///     definite one.  The conversion fails if the model has any
-    ///     indefinite constraints.
-    /// </summary>
-    /// <param name="model">
-    ///     A model over <c>ViewDef</c>s.
-    /// </param>
-    /// <returns>
-    ///     A <c>Result</c> over <c>Error</c> containing the
-    ///     new model if the original contained only definite view
-    ///     definitions.  The new model is a <c>DFModel</c>.
-    /// </returns>
-    let filterModelDefinite
-      (model : UFModel<Term<SMBoolExpr, SMGView, SMVFunc>> )
-      : Result<DFModel<Term<MBoolExpr, MGView, MVFunc>>, Error> =
-        model
-        |> tryMapAxioms (trySubExprInDTerm (tsfRemoveSym UnwantedSym) NoCtx >> snd)
-        |> bind (tryMapViewDefs filterDefiniteViewDefs)
-
 
 /// <summary>
 ///     The instantiation phase.

--- a/Main.fs
+++ b/Main.fs
@@ -191,7 +191,7 @@ let printResponse mview =
                  Core.Var.Pretty.printMBoolExpr)
             (fun _ -> Seq.empty)
             mview
-            m       
+            m
     | Z3 z -> Backends.Z3.Pretty.printResponse mview z
     | MuZ3 z -> Backends.MuZ3.Pretty.printResponse mview z
     | HSF h -> Backends.Horn.Pretty.printHorns h
@@ -277,15 +277,15 @@ let proof approx v =
             >> snd
         else id
 
-    let sub = 
+    let sub =
         Core.TypeSystem.Mapper.mapBoolCtx
             (tsfRemoveSym Core.Instantiate.Types.UnwantedSym)
             Core.Sub.Types.SubCtx.NoCtx
         >> snd
-    
+
     let pos = Starling.Core.Sub.Position.positive
     let neg = Starling.Core.Sub.Position.negative
-    
+
     bind
         (tryMapAxioms
              (tryMapTerm

--- a/Main.fs
+++ b/Main.fs
@@ -336,9 +336,9 @@ let proof approx v =
     bind
         (tryMapAxioms
              (tryMapTerm
-                  (aprC >> (apr neg) >> sub)
-                  ((apr neg) >> sub)
-                  ((apr pos) >> sub))
+                  (aprC >> (apr neg) >> sub >> lift Starling.Core.Expr.simp)
+                  ((apr neg) >> sub >> lift Starling.Core.Expr.simp)
+                  ((apr pos) >> sub >> lift Starling.Core.Expr.simp))
          >> mapMessages Error.ModelFilterError)
         v
 

--- a/Main.fs
+++ b/Main.fs
@@ -340,13 +340,6 @@ let filterIndefinite =
           >> mapMessages ModelFilterError)
 
 /// <summary>
-///     Shorthand for the stage filtering a model to definite views only.
-/// </summary>
-let filterDefinite =
-    bind (Core.Instantiate.ViewDefFilter.filterModelDefinite
-          >> mapMessages ModelFilterError)
-
-/// <summary>
 ///     Runs a Starling request.
 /// </summary>
 /// <param name="optS">

--- a/Main.fs
+++ b/Main.fs
@@ -52,7 +52,7 @@ type Options =
       [<Option('m', HelpText = "Show full model in term-refinement stages.")>]
       showModel : bool
       [<Option('O', HelpText = "Switches given optimisations on or off.")>]
-      optimisers : string seq
+      optimisers : string option
       [<Option("times", HelpText = "Print times for each phase.")>]
       times : bool
       [<Option('v', HelpText = "Increases verbosity.")>]
@@ -363,7 +363,12 @@ let filterIndefinite =
 ///     <c>Result</c> over <c>Response</c> and <c>Error</c>.
 /// </returns>
 let runStarling times optS reals approx verbose request =
-    let optR, optA = Optimiser.Utils.parseOptString optS
+    let optR, optA =
+        optS
+        |> Option.map Utils.parseOptionString
+        |> withDefault (Seq.empty)
+        |> Seq.toList
+        |> Optimiser.Utils.parseOptString
 
     let backend m =
         let phase op response =
@@ -429,7 +434,7 @@ let runStarling times optS reals approx verbose request =
 
 /// Runs Starling with the given options, and outputs the results.
 let mainWithOptions opts =
-    let optS = Seq.toList opts.optimisers
+    let optS = opts.optimisers
     let verbose = opts.verbose
     let reals = opts.reals
     let times = opts.times

--- a/Main.fs
+++ b/Main.fs
@@ -329,8 +329,8 @@ let runStarling times optS reals approx verbose request =
                                id
                                id)
                           >> (Sub.subExprInDTerm
-                              Starling.Core.Symbolic.Queries.approx
-                              Starling.Core.Sub.Position.positive)
+                                  Starling.Core.Symbolic.Queries.approx
+                                  Starling.Core.Sub.Position.positive)
                           >> snd)
                  else id)
 

--- a/Main.fs
+++ b/Main.fs
@@ -322,13 +322,17 @@ let runStarling times optS reals approx verbose request =
         let maybeApprox =
             lift
                 (if approx
-                 then id
-                 else
+                 then
                      mapAxioms
-                         (Sub.subExprInDTerm
+                         ((mapTerm
+                               Starling.Core.Command.SymRemove.removeSym
+                               id
+                               id)
+                          >> (Sub.subExprInDTerm
                               Starling.Core.Symbolic.Queries.approx
-                              Starling.Core.Sub.Position.positive
-                          >> snd))
+                              Starling.Core.Sub.Position.positive)
+                          >> snd)
+                 else id)
 
         match request with
         | Request.HSF     -> phase (filterIndefinite >> hsf) Response.HSF

--- a/Model.fs
+++ b/Model.fs
@@ -618,6 +618,9 @@ module Sub =
     /// <param name="sub">
     ///   The <c>SubFun</c> to map over all expressions in the <c>VFunc</c>.
     /// </param>
+    /// <param name="context">
+    ///     The context to pass to the <c>SubFun</c>.
+    /// </param>
     /// <param name="_arg1">
     ///   The <c>VFunc</c> over which whose expressions are to be mapped.
     /// </param>
@@ -637,10 +640,11 @@ module Sub =
     /// </remarks>
     let subExprInVFunc
       (sub : SubFun<'srcVar, 'dstVar>)
+      (context : Position)
       ( { Name = n ; Params = ps } : VFunc<'srcVar> )
-      : VFunc<'dstVar> =
-        // TODO(CaptainHayashi): properly use context?
-        { Name = n ; Params = List.map (Mapper.mapCtx sub Positive >> snd) ps }
+      : (Position * VFunc<'dstVar> ) =
+        let context', ps' = mapAccumL (Mapper.mapCtx sub) context ps
+        (context', { Name = n; Params = ps' } )
 
     /// <summary>
     ///     Maps a <c>TrySubFun</c> over all expressions in a <c>VFunc</c>.

--- a/Model.fs
+++ b/Model.fs
@@ -645,11 +645,7 @@ module Sub =
       : (SubCtx * VFunc<'dstVar> ) =
         let context', ps' =
             mapAccumL
-                (fun acc p ->
-                     Position.changePos
-                         id
-                         (flip (Mapper.mapCtx sub) p)
-                         acc)
+                (Position.changePos id (Mapper.mapCtx sub))
                 context
                 ps
         (context', { Name = n; Params = ps' } )
@@ -690,11 +686,7 @@ module Sub =
       : (SubCtx * Result<VFunc<'dstVar>, 'err>) =
         let context', ps' =
             mapAccumL
-                (fun acc p ->
-                     Position.changePos
-                         id
-                         (flip (Mapper.tryMapCtx sub) p)
-                         acc)
+                (Position.changePos id (Mapper.tryMapCtx sub))
                 context
                 ps
         (context',

--- a/Model.fs
+++ b/Model.fs
@@ -191,6 +191,9 @@ module Types =
     /// A term over semantic-relation commands.
     type STerm<'wpre, 'goal> = Term<SMBoolExpr, 'wpre, 'goal>
 
+    /// A term using only internal symbolic boolean expressions.
+    type SFTerm = Term<SMBoolExpr, SMBoolExpr, SMBoolExpr>
+
     /// A term using only internal boolean expressions.
     type FTerm = Term<MBoolExpr, MBoolExpr, MBoolExpr>
 

--- a/Model.fs
+++ b/Model.fs
@@ -640,10 +640,12 @@ module Sub =
     /// </remarks>
     let subExprInVFunc
       (sub : SubFun<'srcVar, 'dstVar>)
-      (context : Position)
+      (context : SubCtx)
       ( { Name = n ; Params = ps } : VFunc<'srcVar> )
-      : (Position * VFunc<'dstVar> ) =
-        let context', ps' = mapAccumL (Mapper.mapCtx sub) context ps
+      : (SubCtx * VFunc<'dstVar> ) =
+        let context', ps'
+            = mapAccumL
+                  (fun acc -> Mapper.mapCtx sub (Position.push id acc)) context ps
         (context', { Name = n; Params = ps' } )
 
     /// <summary>
@@ -678,6 +680,6 @@ module Sub =
       : Result<VFunc<'dstVar>, 'err> =
         // TODO(CaptainHayashi): properly use context?
         ps
-        |> List.map (Mapper.tryMapCtx sub Positive >> snd)
+        |> List.map (Mapper.tryMapCtx sub NoCtx >> snd)
         |> collect
         |> lift (fun ps' -> { Name = n ; Params = ps' } )

--- a/Model.fs
+++ b/Model.fs
@@ -191,11 +191,14 @@ module Types =
     /// A term over semantic-relation commands.
     type STerm<'wpre, 'goal> = Term<SMBoolExpr, 'wpre, 'goal>
 
+    /// A term using the same representation for all parts.
+    type CTerm<'repr> = Term<'repr, 'repr, 'repr>
+
     /// A term using only internal symbolic boolean expressions.
-    type SFTerm = Term<SMBoolExpr, SMBoolExpr, SMBoolExpr>
+    type SFTerm = CTerm<SMBoolExpr>
 
     /// A term using only internal boolean expressions.
-    type FTerm = Term<MBoolExpr, MBoolExpr, MBoolExpr>
+    type FTerm = CTerm<MBoolExpr>
 
     (*
      * Models

--- a/Model.fs
+++ b/Model.fs
@@ -643,9 +643,9 @@ module Sub =
       (context : SubCtx)
       ( { Name = n ; Params = ps } : VFunc<'srcVar> )
       : (SubCtx * VFunc<'dstVar> ) =
-        let context', ps'
-            = mapAccumL
-                  (fun acc -> Mapper.mapCtx sub (Position.push id acc)) context ps
+        let context', ps' =
+            mapAccumL
+                (fun acc -> Mapper.mapCtx sub (Position.push id acc)) context ps
         (context', { Name = n; Params = ps' } )
 
     /// <summary>
@@ -653,6 +653,9 @@ module Sub =
     /// </summary>
     /// <param name="sub">
     ///     The <c>TrySubFun</c> to map over all expressions in the <c>VFunc</c>.
+    /// </param>
+    /// <param name="context">
+    ///     The context to pass to the <c>SubFun</c>.
     /// </param>
     /// <param name="_arg1">
     ///     The <c>VFunc</c> over which whose expressions are to be mapped.
@@ -676,10 +679,13 @@ module Sub =
     /// </remarks>
     let trySubExprInVFunc
       (sub : TrySubFun<'srcVar, 'dstVar, 'err>)
+      (context : SubCtx)
       ( { Name = n ; Params = ps } : VFunc<'srcVar> )
-      : Result<VFunc<'dstVar>, 'err> =
-        // TODO(CaptainHayashi): properly use context?
-        ps
-        |> List.map (Mapper.tryMapCtx sub NoCtx >> snd)
-        |> collect
-        |> lift (fun ps' -> { Name = n ; Params = ps' } )
+      : (SubCtx * Result<VFunc<'dstVar>, 'err>) =
+        let context', ps' =
+            mapAccumL
+                (fun acc -> Mapper.tryMapCtx sub (Position.push id acc)) context ps
+        (context',
+         ps'
+         |> collect
+         |> lift (fun ps' -> { Name = n ; Params = ps' } ))

--- a/Model.fs
+++ b/Model.fs
@@ -594,24 +594,6 @@ let isAdvisory =
     | Mandatory _ -> false
 
 
-(*
- * Variable querying.
- *)
-
-/// <summary>
-///     Extracts a sequence of all variables in a <c>VFunc</c>.
-/// </summary>
-/// <param name="_arg1">
-///     The <c>VFunc</c> to query.
-/// </param>
-/// <returns>
-///     A sequence of (<c>Const</c>, <c>Type</c>) pairs that represent all of
-///     the variables used in the <c>VFunc</c>.
-/// </returns>
-let varsInVFunc { Params = ps } =
-    ps |> Seq.map varsIn |> Seq.concat
-
-
 /// <summary>
 ///     Functions for substituting over model elements.
 /// </summary>

--- a/Model.fs
+++ b/Model.fs
@@ -645,7 +645,13 @@ module Sub =
       : (SubCtx * VFunc<'dstVar> ) =
         let context', ps' =
             mapAccumL
-                (fun acc -> Mapper.mapCtx sub (Position.push id acc)) context ps
+                (fun acc p ->
+                     Position.changePos
+                         id
+                         (flip (Mapper.mapCtx sub) p)
+                         acc)
+                context
+                ps
         (context', { Name = n; Params = ps' } )
 
     /// <summary>
@@ -684,7 +690,13 @@ module Sub =
       : (SubCtx * Result<VFunc<'dstVar>, 'err>) =
         let context', ps' =
             mapAccumL
-                (fun acc -> Mapper.tryMapCtx sub (Position.push id acc)) context ps
+                (fun acc p ->
+                     Position.changePos
+                         id
+                         (flip (Mapper.tryMapCtx sub) p)
+                         acc)
+                context
+                ps
         (context',
          ps'
          |> collect

--- a/Model.fs
+++ b/Model.fs
@@ -639,7 +639,8 @@ module Sub =
       (sub : SubFun<'srcVar, 'dstVar>)
       ( { Name = n ; Params = ps } : VFunc<'srcVar> )
       : VFunc<'dstVar> =
-        { Name = n ; Params = List.map (Mapper.map sub) ps }
+        // TODO(CaptainHayashi): properly use context?
+        { Name = n ; Params = List.map (Mapper.mapCtx sub Positive >> snd) ps }
 
     /// <summary>
     ///     Maps a <c>TrySubFun</c> over all expressions in a <c>VFunc</c>.
@@ -671,7 +672,8 @@ module Sub =
       (sub : TrySubFun<'srcVar, 'dstVar, 'err>)
       ( { Name = n ; Params = ps } : VFunc<'srcVar> )
       : Result<VFunc<'dstVar>, 'err> =
+        // TODO(CaptainHayashi): properly use context?
         ps
-        |> List.map (Mapper.tryMap sub)
+        |> List.map (Mapper.tryMapCtx sub Positive >> snd)
         |> collect
         |> lift (fun ps' -> { Name = n ; Params = ps' } )

--- a/Model.fs
+++ b/Model.fs
@@ -185,8 +185,8 @@ module Types =
           /// The weakest precondition of the Term.
           WPre : 'wpre
           /// The intended goal of the Term, ie the frame to preserve.
-          Goal : 'goal
-        }
+          Goal : 'goal }
+        override this.ToString() = sprintf "%A" this
 
     /// A term over semantic-relation commands.
     type STerm<'wpre, 'goal> = Term<SMBoolExpr, 'wpre, 'goal>

--- a/MuZ3Backend.fs
+++ b/MuZ3Backend.fs
@@ -505,7 +505,7 @@ module Translator =
       (bodyView : GView<'var>)
       (head : VFunc<'var>)
       : Z3.BoolExpr option =
-        let vsub = onVars (liftVSubFun (Mapper.cmake toVar))
+        let vsub = (liftCToSub (Mapper.cmake toVar))
 
         // First, make everything use string variables.
         let bodyExpr' = Mapper.mapBool vsub bodyExpr

--- a/MuZ3Backend.fs
+++ b/MuZ3Backend.fs
@@ -514,12 +514,12 @@ module Translator =
 
         let vars =
             seq {
-                yield! (varsInBool bodyExpr')
+                yield! (mapOverVars Mapper.mapBoolCtx findVars bodyExpr')
 
                 for gfunc in Multiset.toFlatList bodyView' do
-                    yield! (varsInGFunc gfunc)
+                    yield! (mapOverVars Sub.subExprInGFunc findVars gfunc)
 
-                yield! (varsInVFunc head')
+                yield! (mapOverVars Sub.subExprInVFunc findVars head')
             }
             // Make sure we don't quantify over a variable twice.
             |> Set.ofSeq
@@ -692,9 +692,9 @@ module Run =
                  // TODO(CaptainHayashi): de-duplicate this with mkRule.
                  let vars =
                      seq {
-                         yield! (varsInBool def)
+                         yield! (mapOverVars Mapper.mapBoolCtx findVars def)
                          for param in view.Params do
-                             yield! (varsIn param)
+                             yield! (mapOverVars Mapper.mapCtx findVars param)
                      }
                      |> Set.ofSeq
                      |> Set.map

--- a/MuZ3Backend.fs
+++ b/MuZ3Backend.fs
@@ -509,8 +509,8 @@ module Translator =
 
         // First, make everything use string variables.
         let _, bodyExpr' = Mapper.mapBoolCtx vsub Positive bodyExpr
-        let bodyView' = subExprInGView vsub bodyView
-        let head' = subExprInVFunc vsub head
+        let _, bodyView' = subExprInGView vsub Positive bodyView
+        let _, head' = subExprInVFunc vsub Positive head
 
         let vars =
             seq {

--- a/MuZ3Backend.fs
+++ b/MuZ3Backend.fs
@@ -508,9 +508,9 @@ module Translator =
         let vsub = (liftCToSub (Mapper.cmake toVar))
 
         // First, make everything use string variables.
-        let _, bodyExpr' = Mapper.mapBoolCtx vsub Positive bodyExpr
-        let _, bodyView' = subExprInGView vsub Positive bodyView
-        let _, head' = subExprInVFunc vsub Positive head
+        let _, bodyExpr' = Mapper.mapBoolCtx vsub NoCtx bodyExpr
+        let _, bodyView' = subExprInGView vsub NoCtx bodyView
+        let _, head' = subExprInVFunc vsub NoCtx head
 
         let vars =
             seq {

--- a/MuZ3Backend.fs
+++ b/MuZ3Backend.fs
@@ -508,7 +508,7 @@ module Translator =
         let vsub = (liftCToSub (Mapper.cmake toVar))
 
         // First, make everything use string variables.
-        let bodyExpr' = Mapper.mapBool vsub bodyExpr
+        let _, bodyExpr' = Mapper.mapBoolCtx vsub Positive bodyExpr
         let bodyView' = subExprInGView vsub bodyView
         let head' = subExprInVFunc vsub head
 

--- a/Optimiser.fs
+++ b/Optimiser.fs
@@ -481,13 +481,13 @@ module Graph =
     ///     Partial active pattern matching <c>Sym</c>-less expressions.
     /// </summary>
     let (|VNoSym|_|) : BoolExpr<Sym<Var>> -> BoolExpr<Var> option =
-        Mapper.mapBoolCtx (tsfRemoveSym (fun _ -> ())) Positive >> snd >> okOption
+        Mapper.mapBoolCtx (tsfRemoveSym (fun _ -> ())) NoCtx >> snd >> okOption
 
     /// <summary>
     ///     Partial active pattern matching <c>Sym</c>-less expressions.
     /// </summary>
     let (|MNoSym|_|) : BoolExpr<Sym<MarkedVar>> -> BoolExpr<MarkedVar> option =
-        Mapper.mapBoolCtx (tsfRemoveSym (fun _ -> ())) Positive >> snd >> okOption
+        Mapper.mapBoolCtx (tsfRemoveSym (fun _ -> ())) NoCtx >> snd >> okOption
 
 
     /// <summary>
@@ -542,8 +542,8 @@ module Graph =
                 | InnerView(ITEGuards (xc, xv, yc, yv)) ->
                     (* Translate xc and yc to pre-state, to match the
                        commands. *)
-                    let _, xcPre = Mapper.mapBoolCtx vBefore Positive xc
-                    let _, ycPre = Mapper.mapBoolCtx vBefore Positive yc
+                    let _, xcPre = Mapper.mapBoolCtx vBefore NoCtx xc
+                    let _, ycPre = Mapper.mapBoolCtx vBefore NoCtx yc
 
                     match (Set.toList outEdges, Set.toList inEdges) with
                     (* Are there only two out edges, and only one in edge?
@@ -782,7 +782,7 @@ module Term =
          * f(x!before) = f(x!before).
          * We assume we can eliminate it later.
          *)
-        subExprInDTerm sub Positive term |> snd
+        subExprInDTerm sub NoCtx term |> snd
 
     (*
      * Guard reduction
@@ -824,7 +824,7 @@ module Term =
     let simpTerm
       : STerm<SMGView, SMVFunc>
         -> STerm<SMGView, SMVFunc> =
-        subExprInDTerm (Mapper.make id simp) Positive >> snd
+        subExprInDTerm (Mapper.make id simp) NoCtx >> snd
 
     (*
      * Frontend

--- a/Optimiser.fs
+++ b/Optimiser.fs
@@ -481,13 +481,13 @@ module Graph =
     ///     Partial active pattern matching <c>Sym</c>-less expressions.
     /// </summary>
     let (|VNoSym|_|) : BoolExpr<Sym<Var>> -> BoolExpr<Var> option =
-        Mapper.mapBool (tsfRemoveSym (fun _ -> ())) >> okOption
+        Mapper.mapBoolCtx (tsfRemoveSym (fun _ -> ())) Positive >> snd >> okOption
 
     /// <summary>
     ///     Partial active pattern matching <c>Sym</c>-less expressions.
     /// </summary>
     let (|MNoSym|_|) : BoolExpr<Sym<MarkedVar>> -> BoolExpr<MarkedVar> option =
-        Mapper.mapBool (tsfRemoveSym (fun _ -> ())) >> okOption
+        Mapper.mapBoolCtx (tsfRemoveSym (fun _ -> ())) Positive >> snd >> okOption
 
 
     /// <summary>
@@ -542,8 +542,8 @@ module Graph =
                 | InnerView(ITEGuards (xc, xv, yc, yv)) ->
                     (* Translate xc and yc to pre-state, to match the
                        commands. *)
-                    let xcPre = Mapper.mapBool vBefore xc
-                    let ycPre = Mapper.mapBool vBefore yc
+                    let _, xcPre = Mapper.mapBoolCtx vBefore Positive xc
+                    let _, ycPre = Mapper.mapBoolCtx vBefore Positive yc
 
                     match (Set.toList outEdges, Set.toList inEdges) with
                     (* Are there only two out edges, and only one in edge?

--- a/Optimiser.fs
+++ b/Optimiser.fs
@@ -782,7 +782,7 @@ module Term =
          * f(x!before) = f(x!before).
          * We assume we can eliminate it later.
          *)
-        subExprInDTerm sub term
+        subExprInDTerm sub Positive term |> snd
 
     (*
      * Guard reduction
@@ -824,7 +824,7 @@ module Term =
     let simpTerm
       : STerm<SMGView, SMVFunc>
         -> STerm<SMGView, SMVFunc> =
-        subExprInDTerm (Mapper.make id simp)
+        subExprInDTerm (Mapper.make id simp) Positive >> snd
 
     (*
      * Frontend

--- a/OptimiserTests.fs
+++ b/OptimiserTests.fs
@@ -94,9 +94,11 @@ type OptimiserTests() =
     /// Test after-elimination of Booleans.
     [<TestCaseSource("AfterBools")>]
     member x.``After-elimination of Booleans should operate correctly`` b =
-        Mapper.mapBool
-            (afterSubs OptimiserTests.AfterArithSubs OptimiserTests.AfterBoolSubs)
-            b
+        b
+        |> Mapper.mapBoolCtx
+              (afterSubs OptimiserTests.AfterArithSubs OptimiserTests.AfterBoolSubs)
+              Positive
+        |> snd
 
     /// Test cases for discovering Boolean after-before pairs.
     static member BoolAfterDiscoveries =

--- a/OptimiserTests.fs
+++ b/OptimiserTests.fs
@@ -97,7 +97,7 @@ type OptimiserTests() =
         b
         |> Mapper.mapBoolCtx
               (afterSubs OptimiserTests.AfterArithSubs OptimiserTests.AfterBoolSubs)
-              Positive
+              NoCtx
         |> snd
 
     /// Test cases for discovering Boolean after-before pairs.
@@ -142,7 +142,7 @@ type OptimiserTests() =
     member x.``Afters in func params should be substituted correctly`` f =
         let sub = afterSubs OptimiserTests.AfterArithSubs
                             OptimiserTests.AfterBoolSubs
-        subExprInVFunc sub f
+        f |> subExprInVFunc sub NoCtx |> snd
 
     /// Test cases for simplification.
     static member ObviousBools =

--- a/Parser.fs
+++ b/Parser.fs
@@ -15,6 +15,7 @@ open Starling.Core.Model
 open Starling.Core.Var
 open Starling.Lang.AST
 
+
 // Manually re-overload some FParsec operators Chessie overloaded.
 let (>>=) = FParsec.Primitives.(>>=)
 

--- a/Pretty.fs
+++ b/Pretty.fs
@@ -6,6 +6,7 @@ module Starling.Core.Pretty
 open Starling.Collections
 open Starling.Utils
 
+
 /// Type of pretty-printer commands.
 [<NoComparison>]
 type Command =

--- a/Reifier.fs
+++ b/Reifier.fs
@@ -10,9 +10,9 @@ open Starling.Core.Model
 open Starling.Core.Command
 open Starling.Core.GuardedView
 
+
 /// Calculate the multiset of ways that this View matches the pattern in dv and add to the assumulator.
 let reifySingleDef view accumulator (dv : SVBViewDef<DView>) =
-
     let rec matchMultipleViews
       (pattern : DFunc list)
       (view : SMGFunc list) accumulator result =

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -115,8 +115,8 @@ let composeBools x y =
         |> onVars
 
     mkAnd
-        [ Mapper.mapBoolCtx xRewrite Positive x |> snd
-          Mapper.mapBoolCtx yRewrite Positive y |> snd ]
+        [ Mapper.mapBoolCtx xRewrite NoCtx x |> snd
+          Mapper.mapBoolCtx yRewrite NoCtx y |> snd ]
 
 
 /// Generates a framing relation for a given variable.

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -115,8 +115,8 @@ let composeBools x y =
         |> onVars
 
     mkAnd
-        [ Mapper.mapBool xRewrite x
-          Mapper.mapBool yRewrite y ]
+        [ Mapper.mapBoolCtx xRewrite Positive x |> snd
+          Mapper.mapBoolCtx yRewrite Positive y |> snd ]
 
 
 /// Generates a framing relation for a given variable.

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -129,9 +129,8 @@ let frame svars tvars expr =
     // Find all the bound post-variables in the expression...
     let evars =
         expr
-        |> varsInBool
-        |> Seq.map (valueOf >> varsInSym)
-        |> Seq.concat
+        |> mapOverSMVars Mapper.mapBoolCtx findSMVars
+        |> Seq.map valueOf
         |> Seq.choose (function After x -> Some x | _ -> None)
         |> Set.ofSeq
 

--- a/Sub.fs
+++ b/Sub.fs
@@ -163,8 +163,8 @@ module Position =
     /// </typeparam>
     let underapprox : Position -> BoolExpr<'var> =
         function
-        | Positive -> BTrue
-        | Negative -> BFalse
+        | Positive -> BFalse
+        | Negative -> BTrue
 
     /// <summary>
     ///     If the context is position-based, push a new position onto

--- a/Sub.fs
+++ b/Sub.fs
@@ -56,6 +56,7 @@ module Types =
         ///     </para>
         /// </summary>
         | Positions of Position list
+        override this.ToString () = sprintf "%A" this
 
     /// <summary>
     ///     A <c>Mapper</c> mapping between forms of <c>Expr</c>s.

--- a/Sub.fs
+++ b/Sub.fs
@@ -475,8 +475,7 @@ module Var =
     ///     Substitution function for accumulating the <c>Var</c>s of an
     ///     expression.
     /// <summary>
-    let findVars
-      : SubFun<Var, Var> =
+    let findVars : SubFun<Var, Var> =
         Mapper.makeCtx
             (fun ctx x ->
                  match ctx with

--- a/Sub.fs
+++ b/Sub.fs
@@ -31,6 +31,7 @@ module Types =
     [<NoEquality>]
     type SubFun<'srcVar, 'dstVar> =
         Mapper<
+            unit,
             IntExpr<'srcVar>, BoolExpr<'srcVar>,
             IntExpr<'dstVar>, BoolExpr<'dstVar>>
 
@@ -50,6 +51,7 @@ module Types =
     [<NoEquality>]
     type TrySubFun<'srcVar, 'dstVar, 'err> =
         Mapper<
+            unit,
             IntExpr<'srcVar>, BoolExpr<'srcVar>,
             Result<IntExpr<'dstVar>, 'err>,
             Result<BoolExpr<'dstVar>, 'err>>
@@ -66,7 +68,7 @@ module Types =
     [<NoComparison>]
     [<NoEquality>]
     type VSubFun<'srcVar, 'dstVar> =
-        Mapper<'srcVar, 'srcVar, IntExpr<'dstVar>, BoolExpr<'dstVar>>
+        Mapper<unit, 'srcVar, 'srcVar, IntExpr<'dstVar>, BoolExpr<'dstVar>>
 
     /// <summary>
     ///     A <c>TypeMap</c> partially mapping between forms of <c>Var</c>s.
@@ -84,6 +86,7 @@ module Types =
     [<NoEquality>]
     type VTrySubFun<'srcVar, 'dstVar, 'err> =
         Mapper<
+            unit,
             'srcVar, 'srcVar,
             Result<IntExpr<'dstVar>, 'err>,
             Result<BoolExpr<'dstVar>, 'err>>
@@ -227,7 +230,7 @@ module Var =
     ///     <paramref name="mapper">, lifted into a <C>VSubFun</c>.
     /// </returns>
     let liftCToVSub
-      (mapper : CMapper<'srcVar, 'dstVar>)
+      (mapper : CMapper<unit, 'srcVar, 'dstVar>)
       : VSubFun<'srcVar, 'dstVar> =
         Mapper.compose mapper (Mapper.make AVar BVar)
 
@@ -247,7 +250,7 @@ module Var =
     ///     <paramref name="mapper">, lifted into a <C>SubFun</c>.
     /// </returns>
     let liftCToSub
-      (mapper : CMapper<'srcVar, 'dstVar>)
+      (mapper : CMapper<unit, 'srcVar, 'dstVar>)
       : SubFun<'srcVar, 'dstVar> =
         mapper |> liftCToVSub |> onVars
 

--- a/Sub.fs
+++ b/Sub.fs
@@ -60,6 +60,10 @@ module Types =
         ///     A context for searching for <c>Var</c>s.
         /// </summary>
         | Vars of CTyped<Var> list
+        /// <summary>
+        ///     A context for searching for <c>MarkedVar</c>s.
+        /// </summary>
+        | MarkedVars of CTyped<MarkedVar> list
         override this.ToString () = sprintf "%A" this
 
     /// <summary>

--- a/Sub.fs
+++ b/Sub.fs
@@ -89,151 +89,181 @@ module Types =
             Result<BoolExpr<'dstVar>, 'err>>
 
 
-(*
- * Variable substitution (special case of substitution)
- *)
-
-/// Substitutes all variables with the given substitution function set
-/// for the given Boolean expression.
-let rec boolSubVars (vfun : VSubFun<'srcVar, 'dstVar>) =
-    function
-    | BVar x -> Mapper.mapBool vfun x
-    | BTrue -> BTrue
-    | BFalse -> BFalse
-    | BAnd xs -> BAnd (List.map (boolSubVars vfun) xs)
-    | BOr xs -> BOr (List.map (boolSubVars vfun) xs)
-    | BImplies (x, y) -> BImplies (boolSubVars vfun x,
-                                   boolSubVars vfun y)
-    | BEq (x, y) -> BEq (Mapper.map (onVars vfun) x,
-                         Mapper.map (onVars vfun) y)
-    | BGt (x, y) -> BGt (intSubVars vfun x,
-                         intSubVars vfun y)
-    | BGe (x, y) -> BGe (intSubVars vfun x,
-                         intSubVars vfun y)
-    | BLe (x, y) -> BLe (intSubVars vfun x,
-                         intSubVars vfun y)
-    | BLt (x, y) -> BLt (intSubVars vfun x,
-                         intSubVars vfun y)
-    | BNot x -> BNot (boolSubVars vfun x)
-
-/// Substitutes all variables with the given substitution function
-/// for the given arithmetic expression.
-and intSubVars (vfun : VSubFun<'srcVar, 'dstVar>) =
-    function
-    | AVar x -> Mapper.mapInt vfun x
-    | AInt i -> AInt i
-    | AAdd xs -> AAdd (List.map (intSubVars vfun) xs)
-    | ASub xs -> ASub (List.map (intSubVars vfun) xs)
-    | AMul xs -> AMul (List.map (intSubVars vfun) xs)
-    | ADiv (x, y) -> ADiv (intSubVars vfun x,
-                           intSubVars vfun y)
-
 /// <summary>
-///   Creates a <c>SubFun</c> from a <c>VSubFun</c>.
+///     Functions for variable substitution.
 /// </summary>
-and onVars vsub =
-    Mapper.make (intSubVars vsub) (boolSubVars vsub)
+[<AutoOpen>]
+module Var =
+    /// Substitutes all variables with the given substitution function set
+    /// for the given Boolean expression.
+    let rec boolSubVars (vfun : VSubFun<'srcVar, 'dstVar>) =
+        function
+        | BVar x -> Mapper.mapBool vfun x
+        | BTrue -> BTrue
+        | BFalse -> BFalse
+        | BAnd xs -> BAnd (List.map (boolSubVars vfun) xs)
+        | BOr xs -> BOr (List.map (boolSubVars vfun) xs)
+        | BImplies (x, y) -> BImplies (boolSubVars vfun x,
+                                       boolSubVars vfun y)
+        | BEq (x, y) -> BEq (Mapper.map (onVars vfun) x,
+                             Mapper.map (onVars vfun) y)
+        | BGt (x, y) -> BGt (intSubVars vfun x,
+                             intSubVars vfun y)
+        | BGe (x, y) -> BGe (intSubVars vfun x,
+                             intSubVars vfun y)
+        | BLe (x, y) -> BLe (intSubVars vfun x,
+                             intSubVars vfun y)
+        | BLt (x, y) -> BLt (intSubVars vfun x,
+                             intSubVars vfun y)
+        | BNot x -> BNot (boolSubVars vfun x)
 
-/// Failing form of boolSubVars.
-let rec tryBoolSubVars (vfun : VTrySubFun<'srcVar, 'dstVar, 'err>) =
-    function
-    | BVar x -> Mapper.mapBool vfun x
-    | BTrue -> ok BTrue
-    | BFalse -> ok BFalse
-    | BAnd xs ->
-        xs |> List.map (tryBoolSubVars vfun) |> collect |> lift BAnd
-    | BOr xs ->
-        xs |> List.map (tryBoolSubVars vfun) |> collect |> lift BOr
-    | BImplies (x, y) ->
-        lift2
-            (curry BImplies)
-            (tryBoolSubVars vfun x)
-            (tryBoolSubVars vfun y)
-    | BEq (x, y) ->
-        lift2
-            (curry BEq)
-            (Mapper.tryMap (tryOnVars vfun) x)
-            (Mapper.tryMap (tryOnVars vfun) y)
-    | BGt (x, y) ->
-        lift2
-            (curry BGt)
-            (tryIntSubVars vfun x)
-            (tryIntSubVars vfun y)
-    | BGe (x, y) ->
-        lift2
-            (curry BGe)
-            (tryIntSubVars vfun x)
-            (tryIntSubVars vfun y)
-    | BLe (x, y) ->
-        lift2
-            (curry BLe)
-            (tryIntSubVars vfun x)
-            (tryIntSubVars vfun y)
-    | BLt (x, y) ->
-        lift2
-            (curry BLt)
-            (tryIntSubVars vfun x)
-            (tryIntSubVars vfun y)
-    | BNot x ->
-        x |> tryBoolSubVars vfun |> lift BNot
+    /// Substitutes all variables with the given substitution function
+    /// for the given arithmetic expression.
+    and intSubVars (vfun : VSubFun<'srcVar, 'dstVar>) =
+        function
+        | AVar x -> Mapper.mapInt vfun x
+        | AInt i -> AInt i
+        | AAdd xs -> AAdd (List.map (intSubVars vfun) xs)
+        | ASub xs -> ASub (List.map (intSubVars vfun) xs)
+        | AMul xs -> AMul (List.map (intSubVars vfun) xs)
+        | ADiv (x, y) -> ADiv (intSubVars vfun x,
+                               intSubVars vfun y)
 
-/// Failing version of intSubVars.
-and tryIntSubVars (vfun : VTrySubFun<'srcVar, 'dstVar, 'err>) =
-    function
-    | AVar x -> Mapper.mapInt vfun x
-    | AInt i -> i |> AInt |> ok
-    | AAdd xs ->
-        xs
-        |> List.map (tryIntSubVars vfun)
-        |> collect
-        |> lift AAdd
-    | ASub xs ->
-        xs
-        |> List.map (tryIntSubVars vfun)
-        |> collect
-        |> lift ASub
-    | AMul xs ->
-        xs
-        |> List.map (tryIntSubVars vfun)
-        |> collect
-        |> lift AMul
-    | ADiv (x, y) ->
-        lift2
-            (curry ADiv)
-            (tryIntSubVars vfun x)
-            (tryIntSubVars vfun y)
+    /// <summary>
+    ///   Creates a <c>SubFun</c> from a <c>VSubFun</c>.
+    /// </summary>
+    and onVars vsub =
+        Mapper.make (intSubVars vsub) (boolSubVars vsub)
 
-/// <summary>
-///   Creates a <c>TrySubFun</c> from a <c>VTrySubFun</c>.
-/// </summary>
-and tryOnVars
-  (vsub : VTrySubFun<'srcVar, 'dstVar, 'err>) =
-    Mapper.make (tryIntSubVars vsub) (tryBoolSubVars vsub)
+    /// Failing form of boolSubVars.
+    let rec tryBoolSubVars (vfun : VTrySubFun<'srcVar, 'dstVar, 'err>) =
+        function
+        | BVar x -> Mapper.mapBool vfun x
+        | BTrue -> ok BTrue
+        | BFalse -> ok BFalse
+        | BAnd xs ->
+            xs |> List.map (tryBoolSubVars vfun) |> collect |> lift BAnd
+        | BOr xs ->
+            xs |> List.map (tryBoolSubVars vfun) |> collect |> lift BOr
+        | BImplies (x, y) ->
+            lift2
+                (curry BImplies)
+                (tryBoolSubVars vfun x)
+                (tryBoolSubVars vfun y)
+        | BEq (x, y) ->
+            lift2
+                (curry BEq)
+                (Mapper.tryMap (tryOnVars vfun) x)
+                (Mapper.tryMap (tryOnVars vfun) y)
+        | BGt (x, y) ->
+            lift2
+                (curry BGt)
+                (tryIntSubVars vfun x)
+                (tryIntSubVars vfun y)
+        | BGe (x, y) ->
+            lift2
+                (curry BGe)
+                (tryIntSubVars vfun x)
+                (tryIntSubVars vfun y)
+        | BLe (x, y) ->
+            lift2
+                (curry BLe)
+                (tryIntSubVars vfun x)
+                (tryIntSubVars vfun y)
+        | BLt (x, y) ->
+            lift2
+                (curry BLt)
+                (tryIntSubVars vfun x)
+                (tryIntSubVars vfun y)
+        | BNot x ->
+            x |> tryBoolSubVars vfun |> lift BNot
 
+    /// Failing version of intSubVars.
+    and tryIntSubVars (vfun : VTrySubFun<'srcVar, 'dstVar, 'err>) =
+        function
+        | AVar x -> Mapper.mapInt vfun x
+        | AInt i -> i |> AInt |> ok
+        | AAdd xs ->
+            xs
+            |> List.map (tryIntSubVars vfun)
+            |> collect
+            |> lift AAdd
+        | ASub xs ->
+            xs
+            |> List.map (tryIntSubVars vfun)
+            |> collect
+            |> lift ASub
+        | AMul xs ->
+            xs
+            |> List.map (tryIntSubVars vfun)
+            |> collect
+            |> lift AMul
+        | ADiv (x, y) ->
+            lift2
+                (curry ADiv)
+                (tryIntSubVars vfun x)
+                (tryIntSubVars vfun y)
 
-(*
- * Variable marking (special case of variable substitution)
- *)
+    /// <summary>
+    ///   Creates a <c>TrySubFun</c> from a <c>VTrySubFun</c>.
+    /// </summary>
+    and tryOnVars
+      (vsub : VTrySubFun<'srcVar, 'dstVar, 'err>) =
+        Mapper.make (tryIntSubVars vsub) (tryBoolSubVars vsub)
 
-/// Lifts a VSubFun so it returns expressions.
-let liftVSubFun vsf =
-    Mapper.compose vsf (Mapper.make AVar BVar)
+    /// <summary>
+    ///     Converts a <c>CMapper</c> on variables to a <c>VSubFun</c>.
+    /// </summary>
+    /// <param name="mapper">
+    ///     The variable <c>CMapper</c> to lift.
+    /// </param>
+    /// <typeparam name="srcVar">
+    ///     The type of variables entering the map.
+    /// </typeparam>
+    /// <typeparam name="dstVar">
+    ///     The type of variables leaving the map.
+    /// </typeparam>
+    /// <returns>
+    ///     <paramref name="mapper">, lifted into a <C>VSubFun</c>.
+    /// </returns>
+    let liftCToVSub
+      (mapper : CMapper<'srcVar, 'dstVar>)
+      : VSubFun<'srcVar, 'dstVar> =
+        Mapper.compose mapper (Mapper.make AVar BVar)
 
-/// Converts a non-symbolic expression to its pre-state.
-let vBefore
-  : SubFun<Var, MarkedVar> =
-    Before
-    |> Mapper.cmake
-    |> liftVSubFun
-    |> onVars
+    /// <summary>
+    ///     Converts a <c>CMapper</c> on variables to a <c>SubFun</c>.
+    /// </summary>
+    /// <param name="mapper">
+    ///     The variable <c>CMapper</c> to lift.
+    /// </param>
+    /// <typeparam name="srcVar">
+    ///     The type of variables entering the map.
+    /// </typeparam>
+    /// <typeparam name="dstVar">
+    ///     The type of variables leaving the map.
+    /// </typeparam>
+    /// <returns>
+    ///     <paramref name="mapper">, lifted into a <C>SubFun</c>.
+    /// </returns>
+    let liftCToSub
+      (mapper : CMapper<'srcVar, 'dstVar>)
+      : SubFun<'srcVar, 'dstVar> =
+        mapper |> liftCToVSub |> onVars
 
-/// Converts a non-symbolic expression to its post-state.
-let vAfter
-  : SubFun<Var, MarkedVar> =
-    After
-    |> Mapper.cmake
-    |> liftVSubFun
-    |> onVars
+    /// <summary>
+    ///     Converts a non-symbolic expression to its pre-state.
+    /// </summary>
+    let vBefore
+      : SubFun<Var, MarkedVar> =
+        Before |> Mapper.cmake |> liftCToSub
+
+    /// <summary>
+    ///     Converts a non-symbolic expression to its post-state.
+    /// </summary>
+    let vAfter
+      : SubFun<Var, MarkedVar> =
+        After |> Mapper.cmake |> liftCToSub
 
 
 /// <summary>

--- a/Symbolic.fs
+++ b/Symbolic.fs
@@ -20,7 +20,7 @@
 ///         or replaced with some other Starling construct.  The typemap
 ///         <c>tryRemoveSym</c> tries to remove all <c>Sym</c>s from
 ///         expressions, failing if any exist.  The function
-///         <c>approxSym</c> substitutes <c>true</c> and <c>false</c> for
+///         <c>approx</c> substitutes <c>true</c> and <c>false</c> for
 ///         symbols in Boolean positions, depending on whether they arise
 ///         in a positive or negative position.
 ///     </para>

--- a/Symbolic.fs
+++ b/Symbolic.fs
@@ -221,23 +221,41 @@ module Queries =
      * Common substitutions
      *)
 
+    /// <summary>
+    ///     Converts a marking <c>CMapper</c> to a <c>SubFun</c> over
+    ///     symbolic variables.
+    /// </summary>
+    /// <param name="mapper">
+    ///     The variable <c>CMapper</c> to lift.
+    /// </param>
+    /// <typeparam name="srcVar">
+    ///     The type of variables entering the map.
+    /// </typeparam>
+    /// <typeparam name="dstVar">
+    ///     The type of variables leaving the map.
+    /// </typeparam>
+    /// <returns>
+    ///     <paramref name="mapper">, lifted into a <C>SubFun</c>
+    ///     over symbolic variables.
+    /// </returns>
+    let liftCToSymSub
+      (mapper : CMapper<'srcVar, 'dstVar>)
+      : SubFun<Sym<'srcVar>, Sym<'dstVar>> =
+        Mapper.compose mapper (Mapper.cmake Reg)
+        |> liftCToVSub
+        |> liftVToSym
+        |> onVars
+
+
     /// Converts an expression to its pre-state.
     let before
       : SubFun<Sym<Var>, Sym<MarkedVar>> =
-        (Before >> Reg)
-        |> Mapper.cmake
-        |> liftVSubFun
-        |> liftVToSym
-        |> onVars
+        liftCToSymSub (Mapper.cmake Before)
 
     /// Converts an expression to its post-state.
     let after
       : SubFun<Sym<Var>, Sym<MarkedVar>> =
-        (After >> Reg)
-        |> Mapper.cmake
-        |> liftVSubFun
-        |> liftVToSym
-        |> onVars
+        liftCToSymSub (Mapper.cmake After)
 
 
 /// <summary>

--- a/Symbolic.fs
+++ b/Symbolic.fs
@@ -139,31 +139,6 @@ module Create =
 /// </summary>
 [<AutoOpen>]
 module Queries =
-    /// <summary>
-    ///     Extracts all of the regular variables in a symbolic variable.
-    /// </summary>
-    /// <param name="sym">
-    ///     The symbolic variable to destructure.
-    /// </param>
-    /// <typeparam name="var">
-    ///     The type of regular variables in the symbolic variable.
-    /// </typeparam>
-    /// <returns>
-    ///     A list of regular variables bound in a symbolic variable.
-    /// </returns>
-    let rec varsInSym
-      (sym : Sym<'var>)
-      : 'var list =
-        match sym with
-        | Reg x -> [x]
-        | Sym { Params = xs } ->
-            xs
-            |> List.map (varsIn
-                         >> Set.toList
-                         >> List.map (valueOf >> varsInSym)
-                         >> List.concat)
-            |> List.concat
-
     /// Lifts a VSubFun over MarkedVars to deal with symbolic vars.
     let rec liftVToSym
       (sf : VSubFun<'srcVar, Sym<'dstVar>>)

--- a/Symbolic.fs
+++ b/Symbolic.fs
@@ -65,7 +65,6 @@ module Types =
         | Reg of 'var
 
 
-
 /// <summary>
 ///     Type synonyms for expressions over various forms of symbolic
 ///     variable.
@@ -243,7 +242,6 @@ module Queries =
         |> liftCToVSub
         |> liftVToSym
         |> onVars
-
 
     /// Converts an expression to its pre-state.
     let before

--- a/Symbolic.fs
+++ b/Symbolic.fs
@@ -169,7 +169,9 @@ module Queries =
     let rec liftVToSym
       (sf : VSubFun<'srcVar, Sym<'dstVar>>)
       : VSubFun<Sym<'srcVar>, Sym<'dstVar>> =
-        let rmap ctx = (sf |> liftVToSym |> onVars |> Mapper.mapCtx) ctx
+        let rmap ctx =
+            (sf |> liftVToSym |> onVars |> Mapper.mapCtx) ctx
+
         Mapper.makeCtx
             (fun pos v ->
                  match v with

--- a/Symbolic.fs
+++ b/Symbolic.fs
@@ -235,7 +235,7 @@ module Queries =
     ///     over symbolic variables.
     /// </returns>
     let liftCToSymSub
-      (mapper : CMapper<Position, 'srcVar, 'dstVar>)
+      (mapper : CMapper<SubCtx, 'srcVar, 'dstVar>)
       : SubFun<Sym<'srcVar>, Sym<'dstVar>> =
         Mapper.compose mapper (Mapper.cmake Reg)
         |> liftCToVSub
@@ -317,4 +317,4 @@ module Tests =
         [<TestCaseSource("IntConstantPostStates")>]
         /// Tests whether rewriting constants in arithmetic expressions to post-state works.
         member x.``constants in arithmetic expressions can be rewritten to post-state`` expr =
-            expr |> Mapper.mapIntCtx after Positive |> snd
+            expr |> Mapper.mapIntCtx after NoCtx |> snd

--- a/Symbolic.fs
+++ b/Symbolic.fs
@@ -239,7 +239,7 @@ module Queries =
     ///     over symbolic variables.
     /// </returns>
     let liftCToSymSub
-      (mapper : CMapper<'srcVar, 'dstVar>)
+      (mapper : CMapper<unit, 'srcVar, 'dstVar>)
       : SubFun<Sym<'srcVar>, Sym<'dstVar>> =
         Mapper.compose mapper (Mapper.cmake Reg)
         |> liftCToVSub

--- a/TermGen.fs
+++ b/TermGen.fs
@@ -7,7 +7,6 @@ module Starling.TermGen
 open Starling.Collections
 open Starling.Core.TypeSystem
 open Starling.Core.Expr
-open Starling.Core.Var
 open Starling.Core.GuardedView
 open Starling.Core.GuardedView.Sub
 open Starling.Core.Sub

--- a/TermGen.fs
+++ b/TermGen.fs
@@ -94,8 +94,8 @@ let termGenPre
      * stage, both sides only contain local variables.
      *)
     // TODO(CaptainHayashi): use something better than lists.
-    let pre = subExprInGView before gax.Axiom.Pre
-    let post = subExprInGView after gax.Axiom.Post
+    let _, pre = subExprInGView before Positive gax.Axiom.Pre
+    let _, post = subExprInGView after Positive gax.Axiom.Post
     let goal = gax.Goal
 
     Multiset.append pre (termGenFrame goal post)

--- a/TermGen.fs
+++ b/TermGen.fs
@@ -94,8 +94,8 @@ let termGenPre
      * stage, both sides only contain local variables.
      *)
     // TODO(CaptainHayashi): use something better than lists.
-    let _, pre = subExprInGView before Positive gax.Axiom.Pre
-    let _, post = subExprInGView after Positive gax.Axiom.Post
+    let _, pre = subExprInGView before NoCtx gax.Axiom.Pre
+    let _, post = subExprInGView after NoCtx gax.Axiom.Post
     let goal = gax.Goal
 
     Multiset.append pre (termGenFrame goal post)

--- a/TestStudies.fs
+++ b/TestStudies.fs
@@ -7,15 +7,14 @@ open Starling
 open Starling.Collections
 open Starling.Core.TypeSystem
 open Starling.Core.Expr
-open Starling.Core.Graph
 open Starling.Core.Symbolic
 open Starling.Core.Var
 open Starling.Core.Model
-open Starling.Core.Axiom
 open Starling.Core.GuardedView
 open Starling.Lang.AST
 open Starling.Lang.Collator
 open Starling.Lang.Modeller
+
 
 /// The raw form of the ticket lock.
 let ticketLock = """

--- a/TypeSystem.fs
+++ b/TypeSystem.fs
@@ -37,6 +37,10 @@ type Typed<'int, 'bool> =
     /// </summary>
     | Int of 'int
     | Bool of 'bool
+    override this.ToString() =
+        match this with
+        | Int x -> sprintf "I(%A)" x
+        | Bool x -> sprintf "B(%A)" x
 
 /// <summary>
 ///     A typed item where every type leads to the same meta-type.
@@ -450,6 +454,29 @@ module Mapper =
       (bFun : 'srcBool -> 'dstBool)
       : Mapper<'context, 'srcInt, 'srcBool, 'dstInt, 'dstBool> =
         makeCtx (fun c i -> (c, iFun i)) (fun c b -> (c, bFun b))
+
+    /// <summary>
+    ///     Constructs a <c>Mapper</c> over <c>CTyped</c> that uses context.
+    /// </summary>
+    /// <param name="f">
+    ///     The function to apply on all values.
+    /// </param>
+    /// <typeparam name="context">
+    ///     The type of the context.  Context may be changed.
+    /// </typeparam>
+    /// <typeparam name="src">
+    ///     The type of values entering the map.
+    /// </typeparam>
+    /// <typeparam name="dst">
+    ///     The type of values leaving the map.
+    /// </typeparam>
+    /// <returns>
+    ///     A <c>CMapper</c> using <paramref name="f"/>, passing
+    ///     through the context unused.
+    /// </returns>
+    let cmakeCtx (f : 'context -> 'src -> ('context * 'dst))
+      : CMapper<'context, 'src, 'dst> =
+        makeCtx f f
 
     /// <summary>
     ///     Constructs a <c>Mapper</c> over <c>CTyped</c>.

--- a/TypeSystem.fs
+++ b/TypeSystem.fs
@@ -77,6 +77,19 @@ type Mapper<'srcInt, 'srcBool, 'dstInt, 'dstBool> =
           /// </summary>
           B: 'srcBool -> 'dstBool }
 
+/// <summary>
+///     A table of mapping functions from one <c>CTyped</c> type to another.
+/// </summary>
+/// <typeparam name="src">
+///     The type of values entering the map.
+/// </typeparam>
+/// <typeparam name="dst">
+///     The type of typed values leaving the map.
+/// </typeparam>
+[<NoComparison>]
+[<NoEquality>]
+type CMapper<'src, 'dst> = Mapper<'src, 'src, 'dst, 'dst>
+
 
 /// <summary>
 ///     The Starling type checker.
@@ -253,11 +266,9 @@ module Mapper =
     ///     The type of values leaving the map.
     /// </typeparam>
     /// <returns>
-    ///     A <c>Mapper</c> using <paramref name="f"/>.
+    ///     A <c>CMapper</c> using <paramref name="f"/>.
     /// </returns>
-    let cmake
-      (f : 'src -> 'dst)
-      : Mapper<'src, 'src, 'dst, 'dst> =
+    let cmake (f : 'src -> 'dst) : CMapper<'src, 'dst> =
         make f f
 
     /// <summary>

--- a/TypeSystem.fs
+++ b/TypeSystem.fs
@@ -21,6 +21,7 @@ module Starling.Core.TypeSystem
 open Chessie.ErrorHandling
 open Starling.Utils
 
+
 /// <summary>
 ///     A typed item.
 /// </summary>

--- a/Utils.fs
+++ b/Utils.fs
@@ -12,6 +12,28 @@ module Starling.Utils
 open Chessie.ErrorHandling
 
 
+/// <summary>
+///     Parses an delimited option string.
+/// </summary>
+/// <param name="str">
+///     A string containing a comma or semicolon-separated list of words.
+/// </param>
+/// <returns>
+///     The sequence of split words, downcased and trimmed.
+///     A tuple of two sets of optimisation names.  The first is the
+///     set of optimisations force-disabled (-).  The second is the set of
+///     optimisations force-enabled (+ or no sign).  Each optimisation
+///     name is downcased.  The optimisation name 'all' is special, as it
+///     force-enables (or force-disables) all optimisations.
+/// </returns>
+let parseOptionString (str : string) =
+    str.ToLower()
+        .Split([| "," ; ";" |],
+               System.StringSplitOptions.RemoveEmptyEntries)
+    |> Seq.toList
+    |> Seq.map (fun x -> x.Trim())
+
+
 /// Converts a list to an option that is Some iff it has exactly one item.
 let onlyOne s =
     s

--- a/Utils.fs
+++ b/Utils.fs
@@ -105,6 +105,44 @@ let keys mp =
 let keyDuplicates a b =
     findDuplicates (Seq.append (keys a) (keys b))
 
+/// <summary>
+///     Behaves like a combination of <c>List.map</c> and
+///     <c>List.fold</c>.
+/// </summary>
+/// <param name="f">
+///     The mapping function.
+/// </param>
+/// <param name="init">
+///     The initial accumulator.
+/// </param>
+/// <param name="lst">
+///     The list to map.
+/// </param>
+/// <returns>
+///     A tuple of the final accumulator and mapped list.
+/// </returns>
+/// <typeparam name="acc">
+///     The type of the accumulator.
+/// </typeparam>
+/// <typeparam name="src">
+///     The type of variables in the list to map.
+/// </typeparam>
+/// <typeparam name="dst">
+///     The type of variables in the list after mapping.
+/// </typeparam>
+let mapAccumL
+  (f : 'acc -> 'src -> ('acc * 'dst))
+  (init : 'acc)
+  (lst : 'src list)
+  : ('acc * 'dst list) =
+    let rec it acc srcs dsts =
+        match srcs with
+        | [] -> (acc, List.rev dsts)
+        | x::xs ->
+            let acc', x' = f acc x
+            it acc' xs (x'::dsts)
+    it init lst []
+
 /// Joins two maps together.
 let mapAppend a b =
     Map.ofSeq (Seq.append (Map.toSeq a) (Map.toSeq b))

--- a/Utils.fs
+++ b/Utils.fs
@@ -11,6 +11,7 @@ module Starling.Utils
 
 open Chessie.ErrorHandling
 
+
 /// Converts a list to an option that is Some iff it has exactly one item.
 let onlyOne s =
     s

--- a/Utils.fs
+++ b/Utils.fs
@@ -118,9 +118,6 @@ let keyDuplicates a b =
 /// <param name="lst">
 ///     The list to map.
 /// </param>
-/// <returns>
-///     A tuple of the final accumulator and mapped list.
-/// </returns>
 /// <typeparam name="acc">
 ///     The type of the accumulator.
 /// </typeparam>
@@ -130,6 +127,9 @@ let keyDuplicates a b =
 /// <typeparam name="dst">
 ///     The type of variables in the list after mapping.
 /// </typeparam>
+/// <returns>
+///     A tuple of the final accumulator and mapped list.
+/// </returns>
 let mapAccumL
   (f : 'acc -> 'src -> ('acc * 'dst))
   (init : 'acc)

--- a/Var.fs
+++ b/Var.fs
@@ -5,7 +5,6 @@ module Starling.Core.Var
 
 open Chessie.ErrorHandling
 
-open Starling.Collections
 open Starling.Utils
 open Starling.Core.TypeSystem
 open Starling.Core.Expr
@@ -256,7 +255,6 @@ let bInter i c = (i, c) |> Intermediate |> BVar
 /// </summary>
 module Tests =
     open NUnit.Framework
-    open Starling.Utils.Testing
 
     /// <summary>
     ///     NUnit tests for <c>Var</c>.

--- a/Z3.fs
+++ b/Z3.fs
@@ -4,11 +4,7 @@
 module Starling.Core.Z3
 
 open Microsoft
-open Chessie.ErrorHandling
-open Starling
-open Starling.Collections
 open Starling.Core.Expr
-open Starling.Core.Var
 
 
 /// <summary>

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -44,14 +44,22 @@ module Types =
         /// Translate, combine, and run term Z3 expressions; return `Response.Sat`.
         | Sat
 
-    /// Type of responses from the Z3 backend.
+    /// <summary>
+    ///     Type of responses from the Z3 backend.
+    /// </summary>
     [<NoComparison>]
     type Response =
-        /// Output of the term translation step only.
+        /// <summary>
+        ///     Output of the term translation step only.
+        /// </summary>
         | Translate of Model<ZTerm, unit>
-        /// Output of the final Z3 terms only.
+        /// <summary>
+        ///     Output of the final Z3 terms only.
+        /// </summary>
         | Combine of Model<Z3.BoolExpr, unit>
-        /// Output of satisfiability reports for the Z3 terms.
+        /// <summary>
+        ///     Output of satisfiability reports for the Z3 terms.
+        /// </summary>
         | Sat of Map<string, Z3.Status>
 
 

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -24,11 +24,7 @@ open Starling.Core.Var
 open Starling.Core.Model
 open Starling.Core.GuardedView
 open Starling.Core.Instantiate
-open Starling.Core.Instantiate.ViewDefFilter
-open Starling.Core.Sub
 open Starling.Core.Z3
-open Starling.Reifier
-open Starling.Optimiser
 
 
 /// <summary>


### PR DESCRIPTION
This (once again huge :/) pull request does some major surgery to the typemapper functions to allow them to thread through a context (a bit like a `mapAccumL` over parts of an expression).  It then uses these to allow tracking the position of a Boolean expression, and thus allow approximation of Boolean symbols.

We also eliminate command symbols by removing things looking like assignments to or from commands (this is quite conservative at the moment).  Finally, I've reorganised the way the Z3 backend works so it instantiates viewdefs early, and can then approximate symbols in those too.

A lot of this PRQ can be simplified, cleaned up or generally played with, but I've run out of time to do so before I leave York for a while.
