### PR TITLE
Added a symsat phase which runs z3 + gives symbolic proofs

### DIFF
--- a/Main.fs
+++ b/Main.fs
@@ -192,6 +192,7 @@ type Response =
     /// The result of HSF processing.
     | HSF of Backends.Horn.Types.Horn list
 
+
 /// Pretty-prints a response.
 let printResponse mview =
     function
@@ -242,14 +243,15 @@ let printResponse mview =
             m
     | Z3 z -> Backends.Z3.Pretty.printResponse mview z
     | SymZ3 (z, m) ->
-       headed "SymZ3 result:" [ Backends.Z3.Pretty.printResponse mview z ;  
-                      (printModelView
-                        (printTerm printSMBoolExpr printSMBoolExpr printSMBoolExpr)
-                        (fun _ -> Seq.empty)
-                        mview
-                        m) ] 
+       vmerge (Backends.Z3.Pretty.printResponse mview z)
+              (printModelView
+                (printTerm printSMBoolExpr printSMBoolExpr printSMBoolExpr)
+                (fun _ -> Seq.empty)
+                mview
+                m) 
     | MuZ3 z -> Backends.MuZ3.Pretty.printResponse mview z
     | HSF h -> Backends.Horn.Pretty.printHorns h
+
 
 /// A top-level program error.
 type Error =
@@ -502,7 +504,8 @@ let runStarling request =
                  else id)
 
 
-        // TODO: make less horrible, i.e. by using some non-result-wrapped type from z3 
+        // Magic function for unwrapping / wrapping Result types 
+        // TODO: make less horrible, e.g. by using some non-result-wrapped type from z3 
         let tuplize f y = (y >>= fun x -> (lift (fun a -> (a,x)) (f y)) ) 
 
         match request with

--- a/Pretty.fs
+++ b/Pretty.fs
@@ -150,6 +150,21 @@ let print = if config().color then printStyled else printUnstyled
  * Shortcuts
  *)
 
+
+// Hacky merge between two VSep sequences 
+let vmerge a b = 
+  let rec interleave = function //same as: let rec interleave (xs, ys) = match xs, ys with
+    |([], ys) -> ys
+    |(xs, []) -> xs
+    |(x::xs, y::ys) -> x :: y :: interleave (xs,ys)
+
+  match a, b with 
+    | (VSep (xs, i), VSep (ys, j))  -> 
+           let xy = interleave (List.ofSeq xs, List.ofSeq ys) in 
+           VSep (Seq.ofList xy, Nop)
+    | _ -> Nop
+
+
 let fmt fstr xs =
     (* This weird casting dance is how we tell Format to use the obj[] overload.
      * Otherwise, it might try to print xss as if it's one argument!


### PR DESCRIPTION
The result is an interleaving between pass / fail for z3 given approximated proofs, and the unapproximated proof terms themselves. Useful for understanding what z3 isn't able to do. 
