### PR TITLE
Re-order frame insertion

### DIFF
--- a/Expr.fs
+++ b/Expr.fs
@@ -243,6 +243,9 @@ let mkEq a b = BEq (a, b)
 
 /// Makes an arithmetic equality.
 let iEq a b = BEq (Int a, Int b)
+///
+/// Makes an arithmetic addition
+let iAdd a b = AAdd [a ; b]
 
 /// Makes a Boolean equality.
 let bEq a b = BEq (Bool a, Bool b)

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -173,7 +173,10 @@ let semanticsOfCommand
     >> collect
 
     // Compose them together with intermediates
-    >> lift (Seq.reduce composeBools)
+    >> lift (
+        function
+        | [] -> BTrue
+        | xs -> Seq.reduce composeBools xs)
 
     // Add the frame
     >> lift (

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -121,6 +121,7 @@ let seqComposition xs =
 
     let mapper x =
         let dict2 = System.Collections.Generic.Dictionary<Var, bigint>(dict)
+        let isSet = System.Collections.Generic.HashSet<Var>()
 
         let xRewrite =
             function
@@ -131,14 +132,20 @@ let seqComposition xs =
                 else
                     Reg v'
             | After v ->
-                if dict.ContainsKey(v) then
-                    let nLevel = dict2.[v] + 1I
-                    ignore <| dict2.Remove(v)
-                    dict2.Add(v, nLevel)
-                    Reg (Intermediate (nLevel, v))
+                /// Have not set After v to a new Intermediate yet
+                if not (isSet.Contains(v)) then
+                    ignore <| isSet.Add(v)
+
+                    if dict2.ContainsKey(v) then
+                        let nLevel = dict2.[v] + 1I
+                        ignore <| dict2.Remove(v)
+                        dict2.Add(v, nLevel)
+                        Reg (Intermediate (nLevel, v))
+                    else
+                        dict2.Add(v, 0I)
+                        Reg (Intermediate (0I, v))
                 else
-                    dict2.Add(v, 0I)
-                    Reg (Intermediate (0I, v))
+                    Reg (Intermediate (dict2.[v], v))
             | v -> Reg v
             |> (fun f ->
                     Mapper.compose

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -131,8 +131,8 @@ let seqComposition xs =
                 else
                     Reg v'
             | After v ->
-                if dict2.ContainsKey(v) then
-                    let nLevel = dict2.[v]
+                if dict.ContainsKey(v) then
+                    let nLevel = dict2.[v] + 1I
                     ignore <| dict2.Remove(v)
                     dict2.Add(v, nLevel)
                     Reg (Intermediate (nLevel, v))

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -120,7 +120,6 @@ let seqComposition xs =
     let mutable dict = System.Collections.Generic.Dictionary<Var, bigint>()
 
     let mapper x =
-        let nLevel = nextBoolIntermediate x
         let dict2 = System.Collections.Generic.Dictionary<Var, bigint>(dict)
 
         let xRewrite =
@@ -133,10 +132,13 @@ let seqComposition xs =
                     Reg v'
             | After v ->
                 if dict2.ContainsKey(v) then
+                    let nLevel = dict2.[v]
                     ignore <| dict2.Remove(v)
-
-                dict2.Add(v, nLevel)
-                Reg (Intermediate (nLevel, v))
+                    dict2.Add(v, nLevel)
+                    Reg (Intermediate (nLevel, v))
+                else
+                    dict2.Add(v, 0I)
+                    Reg (Intermediate (0I, v))
             | v -> Reg v
             |> (fun f ->
                     Mapper.compose

--- a/SemanticsTests.fs
+++ b/SemanticsTests.fs
@@ -67,6 +67,17 @@ module Compositions =
             <| [ iEq (siInter 0I "t") (iAdd (siBefore "t") (AInt 1L))
                  iEq (siInter 1I "t") (iAdd (siInter 0I "t") (AInt 1L))
                  iEq (siInter 2I "t") (iAdd (siInter 1I "t") (AInt 1L)) ]
+    [<Test>]
+    let ``Compose multi after`` () =
+        check
+            <| [ BAnd
+                    [ (iEq (siAfter "t") (iAdd (siBefore "t") (AInt 1L)))
+                      (iEq (siAfter "t") (iAdd (siBefore "t") (AInt 3L))) ]
+                 iEq (siAfter "t") (iAdd (siBefore "t") (AInt 1L)) ]
+            <| [ iEq (siInter 0I "t") (iAdd (siBefore "t") (AInt 1L))
+                 iEq (siInter 0I "t") (iAdd (siBefore "t" )(AInt 3L))
+                 iEq (siInter 1I "t") (iAdd (siInter 0I "t") (AInt 1L)) ]
+
 
 module Frames =
     let check var expectedFramedExpr =

--- a/SemanticsTests.fs
+++ b/SemanticsTests.fs
@@ -78,6 +78,19 @@ module Compositions =
                  iEq (siInter 0I "t") (iAdd (siBefore "t" )(AInt 3L))
                  iEq (siInter 1I "t") (iAdd (siInter 0I "t") (AInt 1L)) ]
 
+    [<Test>]
+    let ``Compose multiCmd list`` () =
+        check
+            <| [ BAnd
+                    [ (iEq (siAfter "t") (iAdd (siBefore "t") (AInt 1L)))
+                      (iEq (siAfter "t") (iAdd (siBefore "t") (AInt 2L))) ]
+                 iEq (siAfter "t") (iAdd (siBefore "t") (AInt 3L))
+                 iEq (siAfter "g") (siBefore "t") ]
+            <| [ iEq (siInter 0I "t") (iAdd (siBefore "t") (AInt 1L))
+                 iEq (siInter 0I "t") (iAdd (siBefore "t" )(AInt 2L))
+                 iEq (siInter 1I "t") (iAdd (siInter 0I "t" )(AInt 3L))
+                 iEq (siInter 0I "g") (siInter 1I "t") ]
+
 
 module Frames =
     let check var expectedFramedExpr =

--- a/SemanticsTests.fs
+++ b/SemanticsTests.fs
@@ -58,6 +58,16 @@ module Compositions =
             <| [ bEq (sbInter 0I "t") (sbBefore "t")
                  bEq (sbInter 0I "g") (sbInter 0I "t") ]
 
+    [<Test>]
+    let ``Compose multi`` () =
+        check
+            <| [ iEq (siAfter "t") (iAdd (siBefore "t") (AInt 1L))
+                 iEq (siAfter "t") (iAdd (siBefore "t") (AInt 1L))
+                 iEq (siAfter "t") (iAdd (siBefore "t") (AInt 1L)) ]
+            <| [ iEq (siInter 0I "t") (iAdd (siBefore "t") (AInt 1L))
+                 iEq (siInter 1I "t") (iAdd (siInter 0I "t") (AInt 1L))
+                 iEq (siInter 2I "t") (iAdd (siInter 1I "t") (AInt 1L)) ]
+
 module Frames =
     let check var expectedFramedExpr =
         Assert.AreEqual(expectedFramedExpr, frameVar Before var)


### PR DESCRIPTION
Swaps instantiation and frame generation steps to try generate less clauses.

A better solution would be to drop the frame entirely, but at the moment the command representation is needed and it must be done at termGen stage. It'd be useful to push the command further down, but that is not implemented yet and this works well enough.
