### PR TITLE
Run z3 in parallel in a naive way 

### DIFF
--- a/Examples/WIP/spinLockStress.cvf
+++ b/Examples/WIP/spinLockStress.cvf
@@ -1,0 +1,2393 @@
+shared bool lock;  // True iff the lock is taken.
+thread bool test;  // Used when trying to take the lock.
+
+/*
+ * Locks the CAS lock.
+ */
+method lock() {
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+
+  /******************************************/ 
+  {| emp |}
+    do {
+      {| emp |}
+        test = false;
+      {| if test == false then emp else False() |}
+        <CAS(lock, test, true)>;
+      {| if test == false then holdLock() else emp |}
+    } while (test == true);
+  {| holdLock() |}
+  <lock = (false)>;
+  {| emp |}
+}
+
+
+// False is a hack to implement local variable reasoning.
+view False();
+constraint False() -> false;
+
+view holdLock();
+constraint holdLock() -> lock == true;  // Identity of lock.
+constraint holdLock() * holdLock() -> false;  // Mutual exclusion

--- a/Main.fs
+++ b/Main.fs
@@ -129,7 +129,10 @@ let requestMap =
           ("sat",
            ("Executes a definite proof using Z3 and reports the result.",
             Request.Z3 Backends.Z3.Types.Request.Sat))
-          ("symsat",
+          ("satpar",
+           ("Executes a definite proof using Z3 in parallel and reports the result.",
+            Request.Z3 Backends.Z3.Types.Request.SatPar))
+          ("satsym",
            ("Executes a symbolic proof using Z3 and reports failing clauses.",
             Request.SymZ3 Backends.Z3.Types.Request.Sat))
           ("mutranslate",

--- a/Main.fs
+++ b/Main.fs
@@ -133,7 +133,10 @@ let requestMap : Map<string, string * Request> =
           ("sat",
            ("Executes a definite proof using Z3 and reports the result.",
             Request.Z3 Backends.Z3.Types.Request.Sat))
-          ("symsat",
+          ("satpar",
+           ("Executes a definite proof using Z3 in parallel and reports the result.",
+            Request.Z3 Backends.Z3.Types.Request.SatPar))
+          ("satsym",
            ("Executes a symbolic proof using Z3 and reports failing clauses.",
             Request.SymZ3 Backends.Z3.Types.Request.Sat))
           ("mutranslate",

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -135,13 +135,13 @@ module Run =
     let runPar (ctx : Z3.Context) (xs: Model<Z3.BoolExpr,'b>) 
              : Map<string, Z3.Status>  = 
        let quer = Map.toSeq (axioms xs) in 
-       seq { for (x,y) in quer -> async {
-                let newctx = new Z3.Context() in 
-                let copy = ((y.Translate(newctx)) :?> Z3.BoolExpr) in 
-                let res = (x,runTerm newctx x copy) in 
-                newctx.Dispose();  
-                return res 
-         } }
+       seq { for (x,y) in quer -> 
+               async {
+                 let newctx = new Z3.Context() in 
+                 let copy = (y.Translate(newctx)) :?> Z3.BoolExpr in 
+                 return (x, runTerm newctx x copy) 
+               } 
+       }
        |> Async.Parallel 
        |> Async.RunSynchronously 
        |> Map.ofSeq 


### PR DESCRIPTION
This change adds a 'satpar' stage which tries to run z3 in parallel using a work-pool model. It works but doesn't run any faster. I suspect what's going on is that the overhead of recreating the contexts is drowning out any advantage from parallelism. 

I also added a file spinLockStress.cvf which just generates lots of z3 clauses. It's just a sequence of lock / unlocks, derived from spinLock.cvf. 

Not sure if this is worth merging at this point, but it might be worth putting in and then coming back to at some point in the future. 
