### PR TITLE
Refactor Pipeline (Pushing AST/Command information down pipeline)

### DIFF
--- a/AST.fs
+++ b/AST.fs
@@ -6,9 +6,7 @@ module Starling.Lang.AST
 open Starling
 open Starling.Collections
 open Starling.Core.TypeSystem
-open Starling.Core.Model
 open Starling.Core.Var.Types
-open Starling.Core.View
 
 
 /// <summary>
@@ -168,7 +166,6 @@ module Pretty =
     open Starling.Core.Pretty
     open Starling.Collections.Func.Pretty
     open Starling.Core.TypeSystem.Pretty
-    open Starling.Core.Model.Pretty
     open Starling.Core.Var.Pretty
 
     /// Pretty-prints lvalues.

--- a/Command.fs
+++ b/Command.fs
@@ -5,6 +5,7 @@ module Starling.Core.Command
 
 open Starling.Utils
 open Starling.Collections
+open Starling.Lang
 open Starling.Core.TypeSystem
 open Starling.Core.Expr
 open Starling.Core.Var
@@ -32,7 +33,10 @@ module Types =
     ///         for example <x = y++> is translated approximately to { Name = "!ILoad++"; Results = [ siVar "x"; siVar "y" ]; Args = [ siVar "y" ] }
     ///     </para>
     /// </remarks>
-    type PrimCommand = { Name : string; Results : TypedVar list; Args : SMExpr list }
+    type PrimCommand = { Name : string
+                         Results : TypedVar list
+                         Args : SMExpr list }
+
     type Command = PrimCommand list
 
 /// <summary>

--- a/Command.fs
+++ b/Command.fs
@@ -35,7 +35,8 @@ module Types =
     /// </remarks>
     type PrimCommand = { Name : string
                          Results : TypedVar list
-                         Args : SMExpr list }
+                         Args : SMExpr list
+                         Node : AST.Types.Atomic option }
 
     type Command = PrimCommand list
 
@@ -248,9 +249,9 @@ module SymRemove =
         | x -> x
 
 
-module Create = 
+module Create =
     let command : string -> TypedVar list -> SMExpr list -> PrimCommand =
-        fun name results args -> { Name = name; Results = results; Args = args }
+        fun name results args -> { Name = name; Results = results; Args = args; Node = None }
 
 /// <summary>
 ///     Pretty printers for commands.

--- a/Command.fs
+++ b/Command.fs
@@ -33,10 +33,12 @@ module Types =
     ///         for example <x = y++> is translated approximately to { Name = "!ILoad++"; Results = [ siVar "x"; siVar "y" ]; Args = [ siVar "y" ] }
     ///     </para>
     /// </remarks>
-    type PrimCommand = { Name : string
-                         Results : TypedVar list
-                         Args : SMExpr list
-                         Node : AST.Types.Atomic option }
+    type PrimCommand =
+        { Name : string
+          Results : TypedVar list
+          Args : SMExpr list
+          Node : AST.Types.Atomic option }
+        override this.ToString() = sprintf "%A" this
 
     type Command = PrimCommand list
 
@@ -252,6 +254,9 @@ module SymRemove =
 module Create =
     let command : string -> TypedVar list -> SMExpr list -> PrimCommand =
         fun name results args -> { Name = name; Results = results; Args = args; Node = None }
+
+    let command' : string -> AST.Types.Atomic -> TypedVar list -> SMExpr list -> PrimCommand =
+        fun name ast results args -> { Name = name; Results = results; Args = args; Node = Some ast }
 
 /// <summary>
 ///     Pretty printers for commands.

--- a/Command.fs
+++ b/Command.fs
@@ -42,6 +42,12 @@ module Types =
 
     type Command = PrimCommand list
 
+    /// The Semantics of a Command is a pair of the original command and its boolean expr
+    type CommandSemantics<'Semantics> =
+        { Cmd : Command; Semantics : 'Semantics }
+        override this.ToString() = sprintf "%A" this
+
+
 /// <summary>
 ///     Queries on commands.
 /// </summary>
@@ -272,3 +278,8 @@ module Pretty =
         hjoin [ commaSep <| Seq.map (printCTyped String) ys; " <- " |> String; name |> String; String " "; commaSep <| Seq.map printSMExpr xs ]
 
     let printCommand : Command -> Doc = List.map printPrimCommand >> semiSep
+
+    /// Printing a CommandSemantics prints just the semantic boolexpr associated with it
+    let printCommandSemantics pSem sem =
+        pSem sem.Semantics
+

--- a/Horn.fs
+++ b/Horn.fs
@@ -5,6 +5,7 @@ module Starling.Backends.Horn
 
 open Chessie.ErrorHandling
 open Starling.Collections
+open Starling.Semantics
 open Starling.Utils
 open Starling.Core.TypeSystem
 open Starling.Core.Var
@@ -436,18 +437,18 @@ let hsfTerm
   (definer : FuncDefiner<BoolExpr<Var> option>)
   (name : string,
    {Cmd = c; WPre = w ; Goal = g}
-     : Term<MBoolExpr, GView<MarkedVar>, MVFunc>)
+     : CmdTerm<MBoolExpr, GView<MarkedVar>, MVFunc>)
   : Result<Horn list, Error> =
     lift2 (fun head body ->
            [ Comment (sprintf "term %s" name)
              Clause (Option.get head, body) ])
           (hsfFunc definer g)
-          (hsfConditionBody definer w c)
+          (hsfConditionBody definer w c.Semantics) // TODO: keep around Command?
 
 /// Constructs a HSF script for a model.
 let hsfModel
   ({ Globals = sharedVars; ViewDefs = definer; Axioms = xs }
-     : Model<Term<MBoolExpr, GView<MarkedVar>, MVFunc>,
+     : Model<CmdTerm<MBoolExpr, GView<MarkedVar>, MVFunc>,
              FuncDefiner<BoolExpr<Var> option>>)
   : Result<Horn list, Error> =
     let uniquify = Set.ofList >> Set.toList

--- a/InstantiateTests.fs
+++ b/InstantiateTests.fs
@@ -15,7 +15,7 @@ open Starling.Core.Symbolic
 open Starling.Core.Instantiate
 
 /// Tests for the func instantiation functions.
-module Tests =
+module FuncInstantiate =
     /// Environment of test funcs.
     let TestFuncs =
         [ (dfunc "foo" [],

--- a/Model.fs
+++ b/Model.fs
@@ -92,8 +92,7 @@ module Types =
     /// A term using the same representation for all parts.
     type CTerm<'repr> = Term<'repr, 'repr, 'repr>
 
-    /// A term using only internal symbolic boolean expressions.
-    type SFTerm = CTerm<SMBoolExpr>
+    type CmdTerm<'Semantics, 'WPre, 'Goal> = Term<CommandSemantics<'Semantics>, 'WPre, 'Goal>
 
     /// A term using only internal boolean expressions.
     type FTerm = CTerm<MBoolExpr>
@@ -320,6 +319,10 @@ module Pretty =
             |> Option.map pAxiom
             |> withDefault (termstr |> sprintf "no term '%s'" |> String)
 
+
+    /// Prints a Term<CommandSemantics, 'WPre, 'Goal> using the WPre and Goal printers provided
+    let printCmdTerm pSemantics pWPre pGoal =
+        printTerm (printCommandSemantics pSemantics) pWPre pGoal
 
 /// <summary>
 ///     Type-constrained version of <c>func</c> for <c>DFunc</c>s.

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -31,6 +31,7 @@ module Types =
     type CFunc =
         | ITE of SVBoolExpr * Multiset<CFunc> * Multiset<CFunc>
         | Func of SVFunc
+        override this.ToString() = sprintf "CFunc(%A)" this
 
     /// A conditional view, or multiset of CFuncs.
     type CView = Multiset<CFunc>
@@ -46,6 +47,7 @@ module Types =
             expr : SVBoolExpr
             * inTrue : Block<'view, PartCmd<'view>>
             * inFalse : Block<'view, PartCmd<'view>>
+        override this.ToString() = sprintf "PartCmd(%A)" this
 
     /// <summary>
     ///     Internal context for the method modeller.

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -1082,35 +1082,37 @@ let modelFetch : MethodContext -> LValue -> Expression -> FetchMode -> Result<Pr
 /// Converts a single atomic command from AST to part-commands.
 let rec modelAtomic : MethodContext -> Atomic -> Result<PrimCommand, PrimError> = 
     fun ctx a ->
-    match a.Node with
-    | CompareAndSwap(dest, test, set) -> modelCAS ctx dest test set
-    | Fetch(dest, src, mode) -> modelFetch ctx dest src mode
-    | Postfix(operand, mode) ->
-        (* A Postfix is basically a Fetch with no destination, at this point.
-         * Thus, the source must be SHARED.
-         * We don't allow the Direct fetch mode, as it is useless.
-         *)
-        trial {
-            let! stype = wrapMessages BadSVar (lookupVar ctx.SharedVars) operand
-            // TODO(CaptainHayashi): sort out lvalues...
-            let op = flattenLV operand
-            match mode, stype with
-            | Direct, _ ->
-                return! fail Useless
-            | Increment, Typed.Bool _ ->
-                return! fail (IncBool (freshNode <| LV operand))
-            | Decrement, Typed.Bool _ ->
-                return! fail (DecBool (freshNode <| LV operand))
-            | Increment, Typed.Int _ ->
-                return command "!I++" [ Int op ] [op |> Before |> Reg |> AVar |> Expr.Int ]
-            | Decrement, Typed.Int _ ->
-                return command "!I--" [ Int op ] [op |> Before |> Reg |> AVar |> Expr.Int ]
-        }
-    | Id -> ok (command "Id" [] [])
-    | Assume e ->
-        e 
-        |> wrapMessages BadExpr (modelBoolExpr ctx.ThreadVars MarkedVar.Before)
-        |> lift (Expr.Bool >> List.singleton >> command "Assume" [])
+    let prim = 
+        match a.Node with
+        | CompareAndSwap(dest, test, set) -> modelCAS ctx dest test set
+        | Fetch(dest, src, mode) -> modelFetch ctx dest src mode
+        | Postfix(operand, mode) ->
+            (* A Postfix is basically a Fetch with no destination, at this point.
+             * Thus, the source must be SHARED.
+             * We don't allow the Direct fetch mode, as it is useless.
+             *)
+            trial {
+                let! stype = wrapMessages BadSVar (lookupVar ctx.SharedVars) operand
+                // TODO(CaptainHayashi): sort out lvalues...
+                let op = flattenLV operand
+                match mode, stype with
+                | Direct, _ ->
+                    return! fail Useless
+                | Increment, Typed.Bool _ ->
+                    return! fail (IncBool (freshNode <| LV operand))
+                | Decrement, Typed.Bool _ ->
+                    return! fail (DecBool (freshNode <| LV operand))
+                | Increment, Typed.Int _ ->
+                    return command "!I++" [ Int op ] [op |> Before |> Reg |> AVar |> Expr.Int ]
+                | Decrement, Typed.Int _ ->
+                    return command "!I--" [ Int op ] [op |> Before |> Reg |> AVar |> Expr.Int ]
+            }
+        | Id -> ok (command "Id" [] [])
+        | Assume e ->
+            e 
+            |> wrapMessages BadExpr (modelBoolExpr ctx.ThreadVars MarkedVar.Before)
+            |> lift (Expr.Bool >> List.singleton >> command "Assume" [])
+    lift (fun cmd -> { cmd with Node = Some a }) prim
 
 /// Converts a local variable assignment to a Prim.
 and modelAssign : MethodContext -> LValue -> Expression -> Result<PrimCommand, PrimError> = 

--- a/ModellerTests.fs
+++ b/ModellerTests.fs
@@ -251,8 +251,3 @@ module ViewDefs =
                   [ func "holdTick" [ Int "t0" ] ]
                   [ func "holdTick" [ Int "t0" ]
                     func "holdTick" [ Int "t1" ] ] ] )
-
-module TicketLockModel =
-    [<Test>]
-    let ``ticket lock models to correct model``() =
-        AssertAreEqual(okOption <| model ticketLockCollated, Some ticketLockModel)

--- a/MuZ3Backend.fs
+++ b/MuZ3Backend.fs
@@ -28,6 +28,7 @@ module Starling.Backends.MuZ3
 open Microsoft
 open Starling
 open Starling.Collections
+open Starling.Semantics
 open Starling.Core.TypeSystem
 open Starling.Core.Expr
 open Starling.Core.Var
@@ -633,9 +634,9 @@ module Translator =
       (reals : bool)
       (ctx : Z3.Context)
       (funcDecls : Map<string, Z3.FuncDecl>)
-      (name : string, {Cmd = c ; WPre = w ; Goal = g})
+      (name : string, {Cmd = c ; WPre = w ; Goal = g} : CmdTerm<MBoolExpr, GView<MarkedVar>, MVFunc>)
       : (string * Z3.BoolExpr) option =
-        mkRule reals unmarkVar ctx funcDecls c w g |> Option.map (mkPair name)
+        mkRule reals unmarkVar ctx funcDecls c.Semantics w g |> Option.map (mkPair name)  // TODO: keep around Command?
 
     /// <summary>
     ///     Constructs muZ3 rules and goals for a model.
@@ -658,7 +659,7 @@ module Translator =
       (reals : bool)
       (ctx : Z3.Context)
       ({ Globals = svars ; ViewDefs = ds ; Axioms = xs }
-         : Model<Term<MBoolExpr, GView<MarkedVar>, MVFunc>,
+         : Model<CmdTerm<MBoolExpr, GView<MarkedVar>, MVFunc>,
                  FuncDefiner<BoolExpr<Var> option>> ) =
         let funcDecls, definites = translateViewDefs reals ctx ds
         let vrules = translateVariables reals ctx funcDecls svars
@@ -779,7 +780,7 @@ module Run =
 ///     A function implementing the chosen MuZ3 backend process.
 /// </returns>
 let run (reals : bool) (req : Request)
-  : Model<Term<MBoolExpr, GView<MarkedVar>, MVFunc>,
+  : Model<CmdTerm<MBoolExpr, GView<MarkedVar>, MVFunc>,
           FuncDefiner<BoolExpr<Var> option>>
     -> Response =
     use ctx = new Z3.Context()

--- a/Parser.fs
+++ b/Parser.fs
@@ -12,7 +12,6 @@ open Starling
 open Starling.Collections
 open Starling.Core.TypeSystem
 open Starling.Core.Var
-open Starling.Core.View
 open Starling.Lang.AST
 
 

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -16,6 +16,7 @@ module Starling.Semantics
 open Chessie.ErrorHandling
 open Starling.Collections
 open Starling.Core.TypeSystem
+open Starling.Core.TypeSystem.Check
 open Starling.Core.Command
 open Starling.Core.Command.Compose
 open Starling.Core.GuardedView
@@ -24,7 +25,6 @@ open Starling.Core.Var
 open Starling.Core.Symbolic
 open Starling.Core.Model
 open Starling.Core.Sub
-open Starling.Core.Instantiate
 
 
 /// <summary>
@@ -36,9 +36,12 @@ module Types =
     type Error =
         /// There was an error instantiating a semantic definition.
         | Instantiate of prim: PrimCommand
-                       * error: Starling.Core.Instantiate.Types.Error
+                       * error: Error
         /// A primitive has a missing semantic definition.
         | MissingDef of prim: PrimCommand
+        /// Got unexpected number of arguments
+        | CountMismatch of expected: int * actual: int
+        | TypeMismatch of param: TypedVar * atype: Type
 
 
 /// <summary>
@@ -46,21 +49,29 @@ module Types =
 /// </summary>
 module Pretty =
     open Starling.Core.Pretty
+    open Starling.Core.TypeSystem.Pretty
+    open Starling.Core.Var.Pretty
     open Starling.Core.Command.Pretty
+    open Starling.Core.Symbolic.Pretty
     open Starling.Core.Model.Pretty
-    open Starling.Core.Instantiate.Pretty
 
     /// Pretty-prints semantics errors.
-    let printSemanticsError =
+    let rec printSemanticsError =
         function
         | Instantiate (prim, error) ->
           colonSep
               [ fmt "couldn't instantiate primitive '{0}'"
                     [ printPrimCommand prim ]
-                Starling.Core.Instantiate.Pretty.printError error ]
+                printSemanticsError error ]
         | MissingDef prim ->
             fmt "primitive '{0}' has no semantic definition"
                 [ printPrimCommand prim ]
+        | TypeMismatch (par, atype) ->
+            fmt "parameter '{0}' conflicts with argument of type '{1}'"
+                [ printTypedVar par; printType atype ]
+        | CountMismatch (fn, dn) ->
+            fmt "view usage has {0} parameter(s), but its definition has {1}"
+                [ fn |> sprintf "%d" |> String; dn |> sprintf "%d" |> String ]
 
 /// Generates a framing relation for a given variable.
 let frameVar ctor par : SMBoolExpr =
@@ -88,6 +99,82 @@ let frame svars tvars expr =
         | Some i -> Some (name, ty, (fun x -> (Intermediate(i, x)))))
     |> Seq.map (fun (name, ty, ctor) -> frameVar ctor (withType ty name))
 
+let paramToMExpr : TypedVar -> SMExpr =
+    function
+    | Int  i -> After i |> Reg |> AVar |> Int
+    | Bool b -> After b |> Reg |> BVar |> Bool
+
+let primParamSubFun
+  ( cmd : PrimCommand )
+  ( sem : PrimSemantics )
+  : VSubFun<Var, Sym<MarkedVar>> =
+    /// merge the pre + post conditions
+    let fres = List.map paramToMExpr cmd.Results
+    let fpars = cmd.Args @ fres
+    let dpars = sem.Args @ sem.Results
+
+    let pmap =
+        Seq.map2 (fun par up -> valueOf par, up) dpars fpars
+        |> Map.ofSeq
+
+    Mapper.make
+        (fun srcV ->
+             match (pmap.TryFind srcV) with
+             | Some (Typed.Int expr) -> expr
+             | Some _ -> failwith "param substitution type error"
+             | None -> failwith "free variable in substitution")
+        (fun srcV ->
+             match (pmap.TryFind srcV) with
+             | Some (Typed.Bool expr) -> expr
+             | Some _ -> failwith "param substitution type error"
+             | None -> failwith "free variable in substitution")
+
+let checkParamCountPrim : PrimCommand -> PrimSemantics option -> Result<PrimSemantics option, Error> =
+    fun prim opt ->
+    match opt with
+    | None -> ok None
+    | Some def ->
+        let fn = List.length prim.Args
+        let dn = List.length def.Args
+        if fn = dn then ok (Some def) else CountMismatch (fn, dn) |> fail
+
+let lookupPrim : PrimCommand -> PrimSemanticsMap -> Result<PrimSemantics option, Error>  =
+    fun prim map ->
+    checkParamCountPrim prim
+    <| Map.tryFind prim.Name map
+
+let checkParamTypesPrim : PrimCommand -> PrimSemantics -> Result<PrimCommand, Error> =
+    fun prim sem ->
+    List.map2
+        (curry
+             (function
+              | UnifyInt _ | UnifyBool _ -> ok ()
+              | UnifyFail (fp, dp) -> fail (TypeMismatch (dp, typeOf fp))))
+        prim.Args
+        sem.Args
+    |> collect
+    |> lift (fun _ -> prim)
+
+
+
+/// Instantiates a PrimCommand from a PrimSemantics instance
+let instantiatePrim
+  (smap : PrimSemanticsMap)
+  (prim : PrimCommand)
+  : Result<SMBoolExpr option, Error> =
+    lookupPrim prim smap
+    |> bind
+           (function
+            | None -> ok None
+            | Some sem ->
+                lift
+                    (fun _ -> Some sem)
+                    (checkParamTypesPrim prim sem))
+    |> lift
+           (Option.map
+                (fun sem ->
+                    let mapper = onVars (liftVToSym (primParamSubFun prim sem))
+                    Mapper.mapBoolCtx mapper NoCtx sem.Body |> snd))
 /// Translate a primitive command to an expression characterising it
 /// by instantiating the semantics from the core semantics map with
 /// the variables from the command
@@ -101,7 +188,7 @@ let instantiateSemanticsOfPrim
      * Since this is an error in this case, make it one.
      *)
     prim
-    |> wrapMessages Instantiate (instantiatePrim semantics)
+    |> wrapMessages Instantiate (instantiatePrim semantics)  // TODO: Remove this line? maybe not needed anymore.
     |> bind (failIfNone (MissingDef prim))
 
 /// Given a list of BoolExpr's it sequentially composes them together
@@ -174,22 +261,23 @@ let semanticsOfCommand
   (semantics : PrimSemanticsMap)
   (svars : VarMap)
   (tvars : VarMap)
-  : Command -> Result<SMBoolExpr, Error> =
+  (cmd : Command) : Result<CommandSemantics<SMBoolExpr>, Error> =
     // Instantiate the semantic function of each primitive
-    Seq.map (instantiateSemanticsOfPrim semantics)
-    >> collect
+    Seq.map (instantiateSemanticsOfPrim semantics) cmd
+    |> collect
 
     // Compose them together with intermediates
-    >> lift seqComposition
+    |> lift seqComposition
 
     // Add the frame
-    >> lift (addFrame svars tvars)
+    |> lift (addFrame svars tvars)
+    |> lift (fun bexpr -> { Cmd = cmd; Semantics = bexpr })
 
 open Starling.Core.Axiom.Types
 /// Translate a model over Prims to a model over semantic expressions.
 let translate
   (model : Model<GoalAxiom<Command>, 'viewdef>)
-  : Result<Model<GoalAxiom<SMBoolExpr>, 'viewdef>, Error> =
+  : Result<Model<GoalAxiom<CommandSemantics<SMBoolExpr>>, 'viewdef>, Error> =
     let modelSemantics = semanticsOfCommand model.Semantics model.Globals model.Locals
     let replaceCmd ga c = { Goal = ga.Goal; Axiom = {Pre = ga.Axiom.Pre; Post = ga.Axiom.Post; Cmd = c }}
     let transSem ga = bind (replaceCmd ga >> ok) (modelSemantics ga.Axiom.Cmd)

--- a/SemanticsTests.fs
+++ b/SemanticsTests.fs
@@ -143,7 +143,7 @@ module CommandTests =
                    (ticketLockModel.Locals)
             |> okOption
             |> Option.bind (function
-                            | BAnd xs -> xs |> Set.ofList |> Some
+                            | { Semantics = BAnd xs } -> xs |> Set.ofList |> Some
                             | _ -> None)
 
         Assert.AreEqual(expectedValues, actualValues)

--- a/Utils.fs
+++ b/Utils.fs
@@ -338,6 +338,9 @@ let fix f v =
 module Testing =
     open NUnit.Framework
 
+    let assertEqual (a : 'a) (b : 'a) = Assert.AreEqual(a, b)
+    let AssertAreEqual(a, b) = assertEqual a b
+
     /// <summary>
     ///     A more F#-friendly overload of <c>TestCaseData</c>.
     /// </summary>

--- a/starling.fsproj
+++ b/starling.fsproj
@@ -49,6 +49,8 @@
     <Compile Include="TypeSystem.fs" />
     <Compile Include="Expr.fs" />
     <Compile Include="Var.fs" />
+    <Compile Include="AST.fs" />
+    <Compile Include="Parser.fs" />
     <Compile Include="Sub.fs" />
     <Compile Include="Symbolic.fs" />
     <Compile Include="View.fs" />
@@ -60,13 +62,11 @@
     <Compile Include="Axiom.fs" />
     <Compile Include="Graph.fs" />
     <Compile Include="Instantiate.fs" />
-    <Compile Include="AST.fs" />
     <Compile Include="Collator.fs" />
     <Compile Include="ViewDesugar.fs" />
     <Compile Include="Modeller.fs" />
     <Compile Include="Guarder.fs" />
     <Compile Include="Grapher.fs" />
-    <Compile Include="Parser.fs" />
     <Compile Include="Semantics.fs" />
     <Compile Include="TermGen.fs" />
     <Compile Include="Reifier.fs" />

--- a/starling.fsproj
+++ b/starling.fsproj
@@ -61,9 +61,9 @@
     <Compile Include="GuardedView.fs" />
     <Compile Include="Axiom.fs" />
     <Compile Include="Graph.fs" />
-    <Compile Include="Instantiate.fs" />
     <Compile Include="Collator.fs" />
     <Compile Include="ViewDesugar.fs" />
+    <Compile Include="Instantiate.fs" />
     <Compile Include="Modeller.fs" />
     <Compile Include="Guarder.fs" />
     <Compile Include="Grapher.fs" />


### PR DESCRIPTION
Whilst Iterated Views has some exciting theory debates on the email, I decided to push some more of the first week's AST information down the pipeline.

Now the AST information goes further down the pipeline, up to the backend (HSF/Z3) and could theoretically be used at this point to create error messages telling the user which axiom command in the model (which edge in the graph [which command in the program]) caused the failure.

Actually writing those errors is still on the TODO list.

As a side note, It should also be possible to push down the Goal and the entire axiom (Including Pre/Post) down to this stage as well, using a similar technique perhaps, I'm sure @CaptainHayashi has more ideas about that.

Finally, the trick here has some new types that are very similar to some types lying about the program (especially the `CommandSemantics` type which is similar to the `PrimSemantics` type already there, perhaps some cleaner type separation could occur?)
