### PR TITLE
Add downclosure checks to HSF and MuZ3

### DIFF
--- a/AST.fs
+++ b/AST.fs
@@ -330,13 +330,12 @@ module Pretty =
             hsep [ "if" |> String |> syntax
                    c |> printExpression |> parened
                    t |> printBlock pView (printCommand pView)
-                   (withDefault Nop
-                        (Option.map
-                            (fun f ->
-                                hsep
-                                    [ "else" |> String |> syntax
-                                      printBlock pView (printCommand pView) f ])
-                            fo)) ]
+                   (maybe Nop
+                        (fun f ->
+                            hsep
+                                [ "else" |> String |> syntax
+                                  printBlock pView (printCommand pView) f ])
+                        fo) ]
         | Command'.While(c, b) ->
             hsep [ "while" |> String |> syntax
                    c |> printExpression |> parened

--- a/Axiom.fs
+++ b/Axiom.fs
@@ -12,6 +12,7 @@ module Starling.Core.Axiom
 
 open Starling.Collections
 open Starling.Utils
+open Starling.Core.Definer
 open Starling.Core.Expr
 open Starling.Core.Var
 open Starling.Core.View

--- a/Axiom.fs
+++ b/Axiom.fs
@@ -105,9 +105,7 @@ let instantiateGoal (fg : FreshGen)
     dvs |> List.map (function
         | { Iterator = i; Func = { Name = n; Params = ps } } ->
             { Iterator =
-                i
-                |> Option.map (AVar << Reg << goalVar fg << valueOf)
-                |> withDefault (AInt 1L)
+                maybe (AInt 1L) (AVar << Reg << goalVar fg << valueOf) i
               Func = { Name = n; Params = List.map instantiateParam ps } } )
 
 /// Converts an axiom into a list of framed axioms, by combining it with the

--- a/Definer.fs
+++ b/Definer.fs
@@ -11,7 +11,6 @@ open Starling.Core.Expr
 open Starling.Core.Var
 open Starling.Core.View
 open Starling.Core.TypeSystem
-open Starling.Core.TypeSystem.Check
 
 
 /// <summary>
@@ -148,10 +147,10 @@ module FuncDefiner =
     let checkParamTypes (func : Func<Expr<'Var>>) (defn : Func<TypedVar>)
        : Result<Func<Expr<'Var>>, Error> =
         List.map2
-            (curry
-                 (function
-                  | UnifyInt _ | UnifyBool _ -> ok ()
-                  | UnifyFail (fp, dp) -> fail (TypeMismatch (dp, typeOf fp))))
+            (fun fp dp ->
+                if typeOf fp = typeOf dp
+                then ok ()
+                else fail (TypeMismatch (dp, typeOf fp)))
             func.Params
             defn.Params
         |> collect

--- a/Definer.fs
+++ b/Definer.fs
@@ -1,0 +1,273 @@
+/// <summary>
+///     Module defining view (and func) definers.
+/// </summary>
+module Starling.Core.Definer
+
+open Chessie.ErrorHandling
+
+open Starling.Collections
+open Starling.Utils
+open Starling.Core.Expr
+open Starling.Core.Var
+open Starling.Core.View
+open Starling.Core.TypeSystem
+open Starling.Core.TypeSystem.Check
+
+
+/// <summary>
+///     A definer function mapping views to their meanings.
+/// </summary>
+/// <typeparam name="defn">
+///     Type of definitions of <c>View</c>s stored in the table.
+///     May be <c>unit</c>.
+/// </typeparam>
+type ViewDefiner<'defn> =
+    // TODO(CaptainHayashi): this should probably be a map,
+    // but translating it to one seems non-trivial.
+    // Would need to define equality on funcs very loosely.
+    (DView * 'defn) list
+
+/// <summary>
+///     A definer function mapping funcs to their meanings.
+/// </summary>
+/// <typeparam name="defn">
+///     Type of definitions of <c>Func</c>s stored in the table.
+///     May be <c>unit</c>.
+/// </typeparam>
+type FuncDefiner<'defn> =
+    // TODO(CaptainHayashi): this should probably be a map,
+    // but translating it to one seems non-trivial.
+    // Would need to define equality on funcs very loosely.
+    (DFunc * 'defn) list
+
+/// <summary>
+///     Type of errors encountered when using definers.
+/// </summary>
+type Error =
+    /// <summary>
+    ///     The func looked up has a parameter <c>param</c>, which
+    ///     has been assigned to an argument of the incorrect type
+    ///     <c>atype</c>.
+    /// </summary>
+    | TypeMismatch of param: TypedVar * atype: Type
+    /// <summary>
+    ///     The func looked up has <c>fn</c> arguments, but its
+    ///     definition has <c>dn</c> parameters.
+    /// </summary>
+    | CountMismatch of fn: int * dn: int
+
+
+module FuncDefiner =
+    /// <summary>
+    ///     Converts a <c>FuncDefiner</c> to a sequence of pairs of
+    ///     <c>Func</c> and definition.
+    /// </summary>
+    /// <param name="definer">
+    ///     A <see cref="FuncDefiner"/> to convert to a sequence.
+    /// </param>
+    /// <typeparam name="defn">
+    ///     The type of <c>Func</c> definitions.  May be <c>unit</c>.
+    /// </typeparam>
+    /// <returns>
+    ///     The sequence of (<c>Func</c>, <c>'defn</c>) pairs.
+    ///     A <c>FuncDefiner</c> allowing the <c>'defn</c>s of the given
+    ///     <c>Func</c> to be looked up.
+    /// </returns>
+    let toSeq (definer : FuncDefiner<'defn>) : (DFunc * 'defn) seq =
+        // This function exists to smooth over any changes in Definer
+        // representation we make later (eg. to maps).
+        List.toSeq definer
+
+    /// <summary>
+    ///     Builds a <c>FuncDefiner</c> from a sequence of pairs of
+    ///     <c>Func</c> and definition.
+    /// </summary>
+    /// <param name="fseq">
+    ///     The sequence of (<c>Func</c>, <c>'defn</c>) pairs.
+    /// </param>
+    /// <typeparam name="defn">
+    ///     The type of <c>Func</c> definitions.  May be <c>unit</c>.
+    /// </typeparam>
+    /// <returns>
+    ///     A <c>FuncDefiner</c> allowing the <c>'defn</c>s of the given
+    ///     <c>Func</c> to be looked up.
+    /// </returns>
+    let ofSeq (fseq : #((DFunc * 'defn) seq)) : FuncDefiner<'defn> =
+        // This function exists to smooth over any changes in Definer
+        // representation we make later (eg. to maps).
+        Seq.toList fseq
+
+    /// <summary>
+    ///     Checks whether <c>func</c> and <c>_arg1</c> agree on parameter
+    ///     count.
+    /// </summary>
+    /// <param name="func">
+    ///     The func being looked up, the process of which this check is part.
+    /// </param>
+    /// <param name="_arg1">
+    ///     An <c>Option</c>al pair of <c>DFunc</c> and its defining
+    ///     <c>BoolExpr</c>.
+    ///     The value <c>None</c> suggests that <c>func</c> has no definition,
+    ///     which can be ok (eg. if the <c>func</c> is a non-defining view).
+    /// </param>
+    /// <returns>
+    ///     A Chessie result, where the <c>ok</c> value is the optional pair of
+    ///     prototype func and definition, and the failure value is a
+    ///     <c>Starling.Core.Definer.Error</c>.
+    /// </returns>
+    let checkParamCount (func : Func<'a>) : (Func<'b> * 'c) option -> Result<(Func<'b> * 'c) option, Error> =
+        function
+        | None -> ok None
+        | Some def ->
+            let fn = List.length func.Params
+            let dn = List.length (fst def).Params
+            if fn = dn then ok (Some def) else CountMismatch (fn, dn) |> fail
+
+    /// <summary>
+    ///     Checks whether <c>func</c> and <c>_arg1</c> agree on parameter
+    ///     types.
+    /// </summary>
+    /// <param name="func">
+    ///     The func being looked up, the process of which this check is part.
+    /// </param>
+    /// <param name="def">
+    ///     The <c>DFunc</c> that <paramref name="func" /> has matched.
+    /// </param>
+    /// <returns>
+    ///     A Chessie result, where the <c>ok</c> value is
+    ///     <paramref name="func" />, and the failure value is a
+    ///     <c>Starling.Core.Definer.Error</c>.
+    /// </returns>
+    let checkParamTypes func def =
+        List.map2
+            (curry
+                 (function
+                  | UnifyInt _ | UnifyBool _ -> ok ()
+                  | UnifyFail (fp, dp) -> fail (TypeMismatch (dp, typeOf fp))))
+            func.Params
+            def.Params
+        |> collect
+        |> lift (fun _ -> func)
+
+    /// <summary>
+    ///     Look up <c>func</c> in <c>_arg1</c>.
+    ///
+    ///     <para>
+    ///         This checks that the use of <c>func</c> agrees on the number of
+    ///         parameters, but not necessarily types.  You will need to add
+    ///         type checking if needed.
+    ///     </para>
+    /// </summary>
+    /// <param name="func">The func to look up in <c>definer</c>.</param>
+    /// <param name="definer">
+    ///     A definer mapping <c>Func</c>s to some definition.
+    /// </param>
+    /// <typeparam name="Defn">The type of definer definitions.</typeparam>
+    /// <returns>
+    ///     A Chessie result, where the <c>ok</c> value is an <c>Option</c>
+    ///     containing the pair of
+    ///     prototype func and definition, and the failure value is a
+    ///     <c>Starling.Core.Definer.Error</c>.  If the <c>ok</c> value is
+    ///     <c>None</c>, it means no (valid or otherwise) definition exists.
+    /// </returns>
+    let lookup (func : Func<_>) (definer : FuncDefiner<'Defn>)
+      : Result<(DFunc * 'Defn) option, Error> =
+        // First, try to find a func whose name agrees with ours.
+        let defSeq = toSeq definer
+        let defn = Seq.tryFind (fun (dfunc, _) -> dfunc.Name = func.Name) defSeq
+        checkParamCount func defn
+
+    /// <summary>
+    ///     Look up <c>func</c> in <c>_arg1</c>, and, if it exists, typecheck
+    ///     it against its definition.
+    /// </summary>
+    /// <param name="func">
+    ///     The func to look up in <c>_arg1</c>.
+    /// </param>
+    /// <param name="definer">
+    ///     An associative sequence mapping <c>Func</c>s to some definition.
+    /// </param>
+    /// <typeparam name="Defn">The type of definer definitions.</typeparam>
+    /// <returns>
+    ///     A Chessie result, where the <c>ok</c> value is an <c>Option</c>
+    ///     containing the pair of
+    ///     prototype func and definition, and the failure value is a
+    ///     <c>Starling.Core.Definer.Error</c>.  If the <c>ok</c> value is
+    ///     <c>None</c>, it means no (valid or otherwise) definition exists.
+    /// </returns>
+    let lookupWithTypeCheck
+      (func : Func<Expr<_>>) (definer : FuncDefiner<'Defn>)
+      : Result<(DFunc * 'Defn) option, Error> =
+        let unchecked = lookup func definer
+
+        bind
+            (function
+             | None -> ok None
+             | Some (dfunc, defn) ->
+                 lift
+                     (fun _ -> Some (dfunc, defn))
+                     (checkParamTypes func dfunc))
+            unchecked
+
+
+module ViewDefiner =
+    /// <summary>
+    ///     Converts a <c>ViewDefiner</c> to a sequence of pairs of
+    ///     <c>View</c> and definition.
+    /// </summary>
+    /// <param name="definer">
+    ///     A <see cref="ViewDefiner"/> to convert to a sequence.
+    /// </param>
+    /// <typeparam name="defn">
+    ///     The type of <c>View</c> definitions.  May be <c>unit</c>.
+    /// </typeparam>
+    /// <returns>
+    ///     The sequence of (<c>View</c>, <c>'defn</c>) pairs.
+    ///     A <c>ViewDefiner</c> allowing the <c>'defn</c>s of the given
+    ///     <c>View</c> to be looked up.
+    /// </returns>
+    let toSeq (definer : ViewDefiner<'defn>) : (DView * 'defn) seq =
+        // This function exists to smooth over any changes in Definer
+        // representation we make later (eg. to maps).
+        List.toSeq definer
+
+    /// <summary>
+    ///     Builds a <c>ViewDefiner</c> from a sequence of pairs of
+    ///     <c>View</c> and definition.
+    /// </summary>
+    /// <param name="fseq">
+    ///     The sequence of (<c>Func</c>, <c>'defn</c>) pairs.
+    /// </param>
+    /// <typeparam name="defn">
+    ///     The type of <c>Func</c> definitions.  May be <c>unit</c>.
+    /// </typeparam>
+    /// <returns>
+    ///     A <c>ViewDefiner</c> allowing the <c>'defn</c>s of the given
+    ///     <c>View</c>s to be looked up.
+    /// </returns>
+    let ofSeq (fseq : #((DView * 'defn) seq)) : ViewDefiner<'defn> =
+        // This function exists to smooth over any changes in Definer
+        // representation we make later (eg. to maps).
+        Seq.toList fseq
+
+
+/// <summary>
+///     Pretty printers used for definers.
+/// </summary>
+module Pretty =
+    open Starling.Core.Pretty
+    open Starling.Core.TypeSystem.Pretty
+    open Starling.Core.Var.Pretty
+    open Starling.Core.Symbolic.Pretty
+    open Starling.Core.Expr.Pretty
+    open Starling.Core.View.Pretty
+
+    /// Pretty-prints instantiation errors.
+    let printError : Error -> Doc =
+        function
+        | TypeMismatch (par, atype) ->
+            fmt "parameter '{0}' conflicts with argument of type '{1}'"
+                [ printTypedVar par; printType atype ]
+        | CountMismatch (fn, dn) ->
+            fmt "view usage has {0} parameter(s), but its definition has {1}"
+                [ fn |> sprintf "%d" |> String; dn |> sprintf "%d" |> String ]

--- a/Examples/WIP/arcIndefinite.cvf
+++ b/Examples/WIP/arcIndefinite.cvf
@@ -1,12 +1,15 @@
-/* Indefinite atomic reference counter
+/* Atomic reference counter encoded with integers.
  * Example taken from Derek: http://www.mpi-sws.org/~dreyer/talks/talk-dagstuhl16.pdf
  */
 
-shared bool free;
-shared int count;
+shared int free, count;
+thread int f, c;
 
-thread bool f;
-thread int c;
+method init() {
+  {| noArc() |}
+    <{ free = (0); count = (1); }>;
+  {| arc() |}
+}
 
 // Assumption: clone() cannot be called when there are no references
 method clone() {
@@ -18,9 +21,9 @@ method clone() {
 method print() {
   {| arc() |}
     <f = free>;
-  {| arc() * specialViewForFree(f) |}
+  {| arc() * freeVal(f) |}
     // Test for disposal
-    if (f == true) {
+    if (f != 0) {
       {| error() |} ; {| error() |}
     }
   {| arc() |}
@@ -29,10 +32,10 @@ method print() {
 method drop() {
   {| arc() |}
     < c = count-- >;
-  {| specialViewForC(c) |}
+  {| countVal(c) |}
     if (c == 1) {
       {| noCnt() |}
-        <free = (true)>;
+        <free = (1)>;
       {| emp |}
     }
   {| emp |}
@@ -41,20 +44,31 @@ method drop() {
 view error();
 view iter[n] arc();
 view noCnt();
+view noArc();
 
 // These views just add free=f and count=c to the final proof predicates
-view specialViewForC(int c);
-view specialViewForFree(bool f);
+view countVal(int c);
+view freeVal(int f);
 
-constraint emp -> ?;
-constraint noCnt() -> ?;
-constraint specialViewForC(c) -> ?;
-constraint specialViewForFree(f) -> ?;
+
+constraint emp -> count >= 0 && free >= 0 && free <= 1;
+constraint noCnt() -> count == 0;
+
+constraint noArc() -> count == 0 && free == 1;
+// noArc has to have exclusivity over threads.
+constraint noArc() * noArc() -> false;
+constraint noArc() * noCnt() -> false;
+constraint noArc() * freeVal(f) -> false;
+constraint noArc() * countVal(f) -> false;
+
+constraint countVal(c) -> c == 1 => count == 0;
+
+// freeVal(f) * arc() -> f = free;
+constraint freeVal(f) -> count > 0 => f == free;
 
 // holds less than count arc()'s
 //  and if holding at least 1 then it can't have been freed
-constraint iter[n] arc() -> n <= count
-                            && (n > 0 => (free == false));
+constraint iter[n] arc() -> ?;
 
 // goal
 constraint error() -> false;

--- a/Examples/WIP/arcIndefinite.cvf
+++ b/Examples/WIP/arcIndefinite.cvf
@@ -1,0 +1,60 @@
+/* Indefinite atomic reference counter
+ * Example taken from Derek: http://www.mpi-sws.org/~dreyer/talks/talk-dagstuhl16.pdf
+ */
+
+shared bool free;
+shared int count;
+
+thread bool f;
+thread int c;
+
+// Assumption: clone() cannot be called when there are no references
+method clone() {
+  {| arc() |} < count++ >; {| arc() * arc() |}
+}
+
+// Try to prove that print() when holding a reference is always valid
+// i.e. free can never be true when {| arc() |} is held
+method print() {
+  {| arc() |}
+    <f = free>;
+  {| arc() * specialViewForFree(f) |}
+    // Test for disposal
+    if (f == true) {
+      {| error() |} ; {| error() |}
+    }
+  {| arc() |}
+}
+
+method drop() {
+  {| arc() |}
+    < c = count-- >;
+  {| specialViewForC(c) |}
+    if (c == 1) {
+      {| noCnt() |}
+        <free = (true)>;
+      {| emp |}
+    }
+  {| emp |}
+}
+
+view error();
+view iter[n] arc();
+view noCnt();
+
+// These views just add free=f and count=c to the final proof predicates
+view specialViewForC(int c);
+view specialViewForFree(bool f);
+
+constraint emp -> ?;
+constraint noCnt() -> ?;
+constraint specialViewForC(c) -> ?;
+constraint specialViewForFree(f) -> ?;
+
+// holds less than count arc()'s
+//  and if holding at least 1 then it can't have been freed
+constraint iter[n] arc() -> n <= count
+                            && (n > 0 => (free == false));
+
+// goal
+constraint error() -> false;

--- a/Expr.fs
+++ b/Expr.fs
@@ -348,6 +348,9 @@ let mkAdd2 (l : IntExpr<'var>) (r : IntExpr<'var>) : IntExpr<'var> =
     | (AInt x, AInt y)            -> AInt (x + y)
     | _                           -> AAdd [ l; r ]
 
+/// Makes a variable increment expression.
+let incVar (x : 'Var) : IntExpr<'Var> = mkAdd2 (AVar x) (AInt 1L)
+
 /// Makes an Add out of a sequence of expressions.
 let mkAdd (xs : IntExpr<'var> seq) : IntExpr<'var> =
     // TODO(CaptainHayashi): produce a trimmed list, instead of mkAdd2ing.

--- a/Flattener.fs
+++ b/Flattener.fs
@@ -38,9 +38,12 @@ let genFlatIteratedFuncName ifcs =
     let funcs = Seq.map (fun ifc -> ifc.Func) ifcs
     genFlatFuncSeqName funcs
 
-let paramsFromIteratedFunc funcContainer =
-    let funcParams = Seq.ofList funcContainer.Func.Params
-    maybe funcParams (flip scons funcParams) funcContainer.Iterator
+let paramsFromIteratedFunc
+  (funcContainer : IteratedContainer<Func<'Param>, 'Param option>)
+  : 'Param list =
+    let funcParams = funcContainer.Func.Params
+    let iterParams = maybe [] (fun i -> [i]) funcContainer.Iterator
+    iterParams @ funcParams
 
 /// <summary>
 ///     Constructs a Func from a DView

--- a/Flattener.fs
+++ b/Flattener.fs
@@ -114,7 +114,7 @@ let flatten
     let globalsF marker = varMapToExprs (marker >> Reg) model.SharedVars
 
     /// Build a list of global parameters, for view definitions.
-    let globalsP = toVarSeq model.SharedVars
+    let globalsP = VarMap.toTypedVarSeq model.SharedVars
 
     { SharedVars = model.SharedVars
       ThreadVars = model.ThreadVars

--- a/Flattener.fs
+++ b/Flattener.fs
@@ -4,6 +4,7 @@
 module Starling.Flattener
 
 open Starling.Collections
+open Starling.Core.Definer
 open Starling.Core.TypeSystem
 open Starling.Core.Expr
 open Starling.Core.View

--- a/Flattener.fs
+++ b/Flattener.fs
@@ -128,4 +128,5 @@ let flatten
           |> Seq.map (pairMap (flattenDView globalsP) id)
           |> FuncDefiner.ofSeq
       Semantics = model.Semantics
-      ViewProtos = model.ViewProtos }
+      ViewProtos = model.ViewProtos
+      DeferredChecks = model.DeferredChecks }

--- a/FlattenerTests.fs
+++ b/FlattenerTests.fs
@@ -23,7 +23,7 @@ module Tests =
     ///     The shared variables environment used in the tests.
     /// </summary>
     let svars : VarMap =
-        returnOrFail <| makeVarMap
+        returnOrFail <| VarMap.ofTypedVarSeq
             [ TypedVar.Int "serving"
               TypedVar.Int "ticket" ]
 

--- a/Frontend.fs
+++ b/Frontend.fs
@@ -6,6 +6,7 @@ module Starling.Lang.Frontend
 open Chessie.ErrorHandling
 open Starling
 open Starling.Core.Pretty
+open Starling.Core.Definer
 open Starling.Core.Expr
 open Starling.Core.Expr.Pretty
 open Starling.Core.Graph

--- a/Frontend.fs
+++ b/Frontend.fs
@@ -100,8 +100,7 @@ let printResponse (mview : ModelView) : Response -> Doc =
         printModelView
             paxiom
             (printViewDefiner
-                (Option.map (printBoolExpr (printSym printVar))
-                 >> withDefault (String "?")))
+                (maybe (String "?") (printBoolExpr (printSym printVar))))
             mview m
 
     function

--- a/Guarder.fs
+++ b/Guarder.fs
@@ -6,6 +6,7 @@ module Starling.Lang.Guarder
 
 open Starling.Collections
 open Starling.Utils
+open Starling.Core.Definer
 open Starling.Core.TypeSystem
 open Starling.Core.Expr
 open Starling.Core.Symbolic

--- a/Guarder.fs
+++ b/Guarder.fs
@@ -30,11 +30,10 @@ let guardCView (cview : CView) : GuarderView =
     let rec guardCFuncIn suffix cv =
         match cv.Func with
         | CFunc.Func v ->
-            let itVar = Option.map AVar cv.Iterator
             (* Treat non-iterated views as if they have the iterator [1].
                This means we don't need to special-case them elsewhere. *)
             [ { Func = { Cond = mkAnd (Set.toList suffix); Item = v };
-                Iterator = withDefault (AInt 1L) itVar } ]
+                Iterator = maybe (AInt 1L) AVar cv.Iterator } ]
         | CFunc.ITE(expr, tviews, fviews) ->
             List.concat
                 [ guardCViewIn (suffix.Add expr) (Multiset.toFlatList tviews)

--- a/Horn.fs
+++ b/Horn.fs
@@ -500,7 +500,7 @@ let hsfTerm
 /// </summary>
 let hsfModelDeferredCheck (svars : VarMap) (check : DeferredCheck)
   : Result<Horn list, Error> =
-    let svarSeq = toVarSeq svars
+    let svarSeq = VarMap.toTypedVarSeq svars
 
     let subIteratorInPred iterator f (pred : Func<VIntExpr>) =
         let fOnIter param =

--- a/Horn.fs
+++ b/Horn.fs
@@ -567,7 +567,7 @@ let hsfModelBaseDownclosure
     let hornR =
         lift2
             (fun funcPredZero empPred ->
-                Clause (Pred empPred, [Pred funcPredZero]))
+                Clause (Pred funcPredZero, [Pred empPred]))
             funcPredZeroR
             empPredR
 

--- a/Horn.fs
+++ b/Horn.fs
@@ -192,7 +192,7 @@ module Pretty =
     let printHorns (hs : Horn list) : Doc = hs |> List.map printHorn |> vsep
 
     /// <summary>
-    ///     Pretty-prints a MuZ3 backend error.
+    ///     Pretty-prints a HSF backend error.
     /// </summary>
     /// <param name="err">The error to print.</param>
     /// <returns>

--- a/Horn.fs
+++ b/Horn.fs
@@ -7,6 +7,7 @@ open Chessie.ErrorHandling
 open Starling.Collections
 open Starling.Semantics
 open Starling.Utils
+open Starling.Core.Definer
 open Starling.Core.TypeSystem
 open Starling.Core.Var
 open Starling.Core.Expr
@@ -54,9 +55,7 @@ module Types =
     /// An error caused when emitting a Horn clause.
     type Error =
         /// A Func is inconsistent with its definition.
-        | InconsistentFunc of
-              func : MVFunc
-              * err : Starling.Core.Instantiate.Types.Error
+        | InconsistentFunc of func : MVFunc * err : Starling.Core.Definer.Error
         /// A viewdef has a non-arithmetic param.
         | NonArithParam of TypedVar
         /// A model has a non-arithmetic variable.
@@ -180,7 +179,7 @@ module Pretty =
         | InconsistentFunc (func, err) ->
             wrapped "view func"
                     (printMVFunc func)
-                    (Starling.Core.Instantiate.Pretty.printError err)
+                    (Starling.Core.Definer.Pretty.printError err)
         | NonArithParam p ->
             fmt "invalid parameter '{0}': HSF only permits integers here"
                 [ printTypedVar p ]
@@ -406,7 +405,7 @@ let hsfFunc
     // defining views is to be held true.
     // Now that we're at the func level, finding the view is easy!
     definer
-    |> (lookup func >> mapMessages (curry InconsistentFunc func))
+    |> (FuncDefiner.lookup func >> mapMessages (curry InconsistentFunc func))
     |> bind (function
              | Some df -> lift Some (predOfFunc tryIntExpr func)
              | None -> ok None)

--- a/Horn.fs
+++ b/Horn.fs
@@ -47,8 +47,8 @@ module Types =
     type Horn =
         /// A normal Horn clause.
         | Clause of head: Literal * body: (Literal list)
-        /// A comment.
-        | Comment of string
+        /// A comment attached to a Horn clause.
+        | Comment of cmt: string
         /// A query-naming call.
         | QueryNaming of Func<string>
 
@@ -345,13 +345,16 @@ let hsfModelViewDef
  * Variables
  *)
 
-/// Constructs a Horn clause for initialising an integer variable.
-/// Returns an error if the variable is not an integer.
-/// Returns no clause if the variable is not initialised.
-/// Takes the environment of active global variables.
-let hsfModelVariables (sharedVars : VarMap) : Result<Horn, Error> =
+/// <summary>
+///     Generates the Horn uninterpreted function for emp.
+/// </summary>
+/// <param name="svars">The shared vars used as parameters to emp.</param>
+/// <returns>
+///     If successful, the Horn uninterpreted function for emp.
+/// </returns>
+let predOfEmp (svars : VarMap) : Result<Func<VIntExpr>, Error> =
     let vpars =
-        sharedVars
+        svars
         |> Map.toSeq
         |> Seq.map
             (function

--- a/Horn.fs
+++ b/Horn.fs
@@ -64,6 +64,8 @@ module Types =
         | UnsupportedExpr of VExpr
         /// The expression given is compound, but empty.
         | EmptyCompoundExpr of exptype : string
+        /// HSF can't check the given deferred check.
+        | CannotCheckDeferred of check : DeferredCheck * why : string
 
 
 /// <summary>
@@ -73,6 +75,7 @@ module Types =
 module Pretty =
     open Starling.Core.Pretty
     open Starling.Collections.Func.Pretty
+    open Starling.Core.Model.Pretty
     open Starling.Core.Var.Pretty
     open Starling.Core.View.Pretty
 
@@ -181,17 +184,31 @@ module Pretty =
                     (printMVFunc func)
                     (Starling.Core.Definer.Pretty.printError err)
         | NonArithParam p ->
-            fmt "invalid parameter '{0}': HSF only permits integers here"
-                [ printTypedVar p ]
+            error
+                (String "invalid parameter '"
+                 <-> printTypedVar p
+                 <-> String "': HSF only permits integers here")
         | NonArithVar p ->
-            fmt "invalid variable '{0}': HSF only permits integers here"
-                [ printTypedVar p ]
+            error
+                (String "invalid variable '"
+                 <-> printTypedVar p
+                 <-> String "': HSF only permits integers here")
         | UnsupportedExpr expr ->
-            fmt "expression '{0}' is not supported in the HSF backend"
-                [ printVExpr expr ]
+            error
+                (String "expression '"
+                 <-> printVExpr expr
+                 <-> String "' is not supported in the HSF backend")
         | EmptyCompoundExpr exptype ->
-            fmt "found an empty '{0}' expression"
-                [ String exptype ]
+            error
+                (String "found an empty '"
+                 <-> String exptype
+                 <-> String "' expression")
+        | CannotCheckDeferred (check, why) ->
+            error
+                (String "deferred sanity check '"
+                 <-> printDeferredCheck check
+                 <-> String "' failed:"
+                 <+> String why)
 
 
 (*
@@ -317,9 +334,10 @@ let ensureArith : TypedVar -> Result<IntExpr<Var>, Error> =
 let predOfFunc
   (parT : 'par -> Result<VIntExpr, Error>)
   ({ Name = n; Params = pars } : Func<'par>)
-  : Result<Literal, Error> =
-    lift (fun parR -> Pred { Name = n; Params = parR })
+  : Result<Func<VIntExpr>, Error> =
+    lift (fun parR -> { Name = n; Params = parR })
          (pars |> Seq.map parT |> collect)
+
 (*
  * View definitions
  *)
@@ -335,7 +353,9 @@ let hsfModelViewDef
   : (DFunc * VBoolExpr option) -> Result<Horn list, Error> =
     function
     | (vs, Some ex) ->
-        lift2 (fun hd bd -> [Clause (hd, [bd]); Clause (bd, [hd])])
+        lift2 (fun hd bdp ->
+                let bd = Pred bdp
+                [Clause (hd, [bd]); Clause (bd, [hd])])
               (boolExpr makeHSFVar ex)
               (predOfFunc ensureArith vs)
         |> lift (fun c -> queryNaming vs :: c)
@@ -362,20 +382,20 @@ let predOfEmp (svars : VarMap) : Result<Func<VIntExpr>, Error> =
              | (name, ty) -> name |> withType ty |> NonArithVar |> fail)
         |> collect
 
-    let head =
-        bind
-            (fun vp -> predOfFunc
-                           ok
-                           { Name = "emp"; Params = vp })
-            vpars
+    bind (fun vp -> predOfFunc ok { Name = "emp"; Params = vp }) vpars
 
-
+/// Constructs a Horn clause for initialising an integer variable.
+/// Returns an error if the variable is not an integer.
+/// Returns no clause if the variable is not initialised.
+/// Takes the environment of active global variables.
+let hsfModelVariables (svars : VarMap) : Result<Horn, Error> =
     // TODO(CaptainHayashi): actually get these initialisations from
     // somewhere instead of assuming everything to be 0L.
-    lift2 (fun hd vp -> Clause(hd,
-                               List.map (fun n -> Eq (n, AInt 0L)) vp ))
-          head
-          vpars
+    lift
+        (fun hd ->
+            let vps = hd.Params
+            Clause(Pred hd, List.map (fun n -> Eq (n, AInt 0L)) vps ))
+        (predOfEmp svars)
 
 (*
  * Terms
@@ -410,7 +430,7 @@ let hsfFunc
     definer
     |> (FuncDefiner.lookup func >> mapMessages (curry InconsistentFunc func))
     |> bind (function
-             | Some df -> lift Some (predOfFunc tryIntExpr func)
+             | Some df -> lift (Pred >> Some) (predOfFunc tryIntExpr func)
              | None -> ok None)
 
 /// Constructs a Horn literal for a GFunc.
@@ -454,17 +474,113 @@ let hsfTerm
           (hsfFunc definer g)
           (hsfConditionBody definer w c.Semantics) // TODO: keep around Command?
 
+/// <summary>
+///     Constructs a Horn clause for a deferred check, if possible.
+/// </summary>
+let hsfModelDeferredCheck (svars : VarMap) (check : DeferredCheck)
+  : Result<Horn list, Error> =
+    let svarSeq = toVarSeq svars
+
+    let subIteratorInPred iterator f (pred : Func<VIntExpr>) =
+        let fOnIter param =
+            match param with
+            | AVar var when AVar var = iterator -> f var
+            | x -> x
+        { pred with Params = List.map fOnIter pred.Params }
+
+    match check with
+    | NeedsBaseDownclosure (func, reason) ->
+        (* TODO(CaptainHayashi): We're given the func needing downclosure in
+           unflattened form.  This is kind-of messy, as we now have to flatten
+           it again. *)
+        let flatFunc = Starling.Flattener.flattenDView svarSeq [func]
+        let funcPredResult = predOfFunc ensureArith flatFunc
+
+        // TODO(CaptainHayashi): lots of duplication here.
+        let iterator = func.Iterator
+        let iterVarResult =
+            match iterator with
+            | Some x -> ensureArith x
+            | None -> fail (CannotCheckDeferred (check, "malformed iterator"))
+        let funcPredZeroResult =
+            lift2
+                (fun it pred ->
+                    subIteratorInPred it (fun _ -> AInt 0L) pred)
+                    iterVarResult
+                    funcPredResult
+
+        let empPredResult = predOfEmp svars
+
+        let hornResult =
+            lift2
+                (fun zero emp -> Clause (Pred emp, [Pred zero]))
+                funcPredZeroResult
+                empPredResult
+
+        lift
+            (fun h ->
+                [ Comment (sprintf "base downclosure on %s: %s" func.Func.Name reason)
+                  h ])
+            hornResult
+    | NeedsInductiveDownclosure (func, reason) ->
+        // See above for caveats.
+        let flatFunc = Starling.Flattener.flattenDView svarSeq [func]
+        let funcPredResult = predOfFunc ensureArith flatFunc
+
+        let iterator = func.Iterator
+        let iterVarResult =
+            match iterator with
+            | Some x -> ensureArith x
+            | None -> fail (CannotCheckDeferred (check, "malformed iterator"))
+
+        let funcPredSuccResult =
+            lift2
+                (fun it pred -> subIteratorInPred it (fun i -> mkAdd2 (AVar i) (AInt 1L)) pred)
+                iterVarResult
+                funcPredResult
+
+        let empPredResult = predOfEmp svars
+
+        let hornResult =
+            lift3
+                (fun it succ norm ->
+                    Clause (Pred norm, [Ge (it, AInt 0L); Pred succ]))
+                iterVarResult
+                funcPredSuccResult
+                funcPredResult
+
+        lift
+            (fun h ->
+                [ Comment (sprintf "ind downclosure on %s: %s" func.Func.Name reason)
+                  h ])
+            hornResult
+
 /// Constructs a HSF script for a model.
 let hsfModel
-  ({ SharedVars = sharedVars; ViewDefs = definer; Axioms = xs }
+  ({ SharedVars = svars; ViewDefs = definer; Axioms = xs; DeferredChecks = ds }
      : Model<CmdTerm<MBoolExpr, GView<MarkedVar>, MVFunc>,
              FuncDefiner<BoolExpr<Var> option>>)
   : Result<Horn list, Error> =
-    let uniquify = Set.ofList >> Set.toList
+    // This is complicated so as to preserve order.
+    let uniquify hs =
+        let f seenSoFar horn =
+            match horn with
+            | Clause (_) as c ->
+                if (Set.contains c seenSoFar)
+                then (seenSoFar, Comment "(duplicate clause)")
+                else (Set.add c seenSoFar, c)
+            | l -> (seenSoFar, l)
+        snd (mapAccumL f Set.empty hs)
+
     let collectMap f = Seq.map f >> collect
 
     trial {
-        let! varHorn = hsfModelVariables sharedVars
+        let! varHorn = hsfModelVariables svars
+
+        let! dcHorns =
+            lift
+                (List.concat >> uniquify)
+                (collectMap (hsfModelDeferredCheck svars) ds)
 
         let! defHorns =
             definer
@@ -478,5 +594,5 @@ let hsfModel
             |> collectMap (hsfTerm definer)
             |> lift (List.concat >> uniquify)
 
-        return varHorn :: List.append defHorns axHorns
+        return varHorn :: List.concat [ defHorns; axHorns; dcHorns ]
     }

--- a/Horn.fs
+++ b/Horn.fs
@@ -52,19 +52,33 @@ module Types =
         /// A query-naming call.
         | QueryNaming of Func<string>
 
-    /// An error caused when emitting a Horn clause.
+    /// <summary>
+    ///     An error caused when emitting a Horn clause.
+    /// </summary>
     type Error =
-        /// A Func is inconsistent with its definition.
+        /// <summary>
+        ///     A Func is inconsistent with its definition.
+        /// </summary>
         | InconsistentFunc of func : MVFunc * err : Starling.Core.Definer.Error
-        /// A viewdef has a non-arithmetic param.
+        /// <summary>
+        ///     A viewdef has a non-arithmetic param.
+        /// </summary>
         | NonArithParam of TypedVar
-        /// A model has a non-arithmetic variable.
+        /// <summary>
+        ///     A model has a non-arithmetic variable.
+        /// </summary>
         | NonArithVar of TypedVar
-        /// The expression given is not supported in the given position.
+        /// <summary>
+        ///     The expression given is not supported in the given position.
+        /// </summary>
         | UnsupportedExpr of VExpr
-        /// The expression given is compound, but empty.
+        /// <summary>
+        ///     The expression given is compound, but empty.
+        /// </summary>
         | EmptyCompoundExpr of exptype : string
-        /// HSF can't check the given deferred check.
+        /// <summary>
+        ///     HSF can't check the given deferred check.
+        /// </summary>
         | CannotCheckDeferred of check : DeferredCheck * why : string
 
 
@@ -177,8 +191,15 @@ module Pretty =
     /// Emits a Horn clause list.
     let printHorns (hs : Horn list) : Doc = hs |> List.map printHorn |> vsep
 
-    let printHornError : Error -> Doc =
-        function
+    /// <summary>
+    ///     Pretty-prints a MuZ3 backend error.
+    /// </summary>
+    /// <param name="err">The error to print.</param>
+    /// <returns>
+    ///     A <see cref="Doc"/> representing <paramref name="err"/>.
+    /// </returns>
+    let printError (err : Error) : Doc =
+        match err with
         | InconsistentFunc (func, err) ->
             wrapped "view func"
                     (printMVFunc func)
@@ -504,10 +525,9 @@ let hsfModelDeferredCheck (svars : VarMap) (check : DeferredCheck)
             | None -> fail (CannotCheckDeferred (check, "malformed iterator"))
         let funcPredZeroResult =
             lift2
-                (fun it pred ->
-                    subIteratorInPred it (fun _ -> AInt 0L) pred)
-                    iterVarResult
-                    funcPredResult
+                (fun it pred -> subIteratorInPred it (fun _ -> AInt 0L) pred)
+                iterVarResult
+                funcPredResult
 
         let empPredResult = predOfEmp svars
 
@@ -535,11 +555,9 @@ let hsfModelDeferredCheck (svars : VarMap) (check : DeferredCheck)
 
         let funcPredSuccResult =
             lift2
-                (fun it pred -> subIteratorInPred it (fun i -> mkAdd2 (AVar i) (AInt 1L)) pred)
+                (fun it pred -> subIteratorInPred it incVar pred)
                 iterVarResult
                 funcPredResult
-
-        let empPredResult = predOfEmp svars
 
         let hornResult =
             lift3

--- a/HornTests.fs
+++ b/HornTests.fs
@@ -18,7 +18,7 @@ open Starling.Backends.Horn
 module Tests =
     /// The globals environment used in the tests.
     let SharedVars : VarMap =
-        returnOrFail <| makeVarMap
+        returnOrFail <| VarMap.ofTypedVarSeq
             [ TypedVar.Int "serving"
               TypedVar.Int "ticket" ]
 

--- a/Instantiate.fs
+++ b/Instantiate.fs
@@ -311,17 +311,17 @@ module DefinerFilter =
 
     /// <summary>
     ///     Tries to convert a <c>ViewDef</C> based model into one over
-    ///     definite or indefinite constraints.
+    ///     non-symbolic constraints.
     /// </summary>
     /// <param name="model">
     ///     A model over <c>ViewDef</c>s.
     /// </param>
     /// <returns>
     ///     A <c>Result</c> over <c>Error</c> containing the
-    ///     new model if the original contained only definite view
+    ///     new model if the original contained only non-symbolic view
     ///     definitions.
     /// </returns>
-    let filterModelIndefinite
+    let filterModelNonSymbolicConstraints
       (model : Model<CmdTerm<SMBoolExpr, GView<Sym<MarkedVar>>, SMVFunc>,
                      FuncDefiner<SVBoolExpr option>> )
       : Result<Model<CmdTerm<MBoolExpr, GView<MarkedVar>, MVFunc>,

--- a/Instantiate.fs
+++ b/Instantiate.fs
@@ -24,7 +24,6 @@ open Starling.Collections
 open Starling.Utils
 open Starling.Core.Definer
 open Starling.Core.TypeSystem
-open Starling.Core.TypeSystem.Check
 open Starling.Core.Var
 open Starling.Core.Expr
 open Starling.Core.View

--- a/Instantiate.fs
+++ b/Instantiate.fs
@@ -127,7 +127,7 @@ module Pretty =
                     (printGView (printSym printMarkedVar))
                     (printVFunc (printSym printMarkedVar))
                     sterm.Original ]
-              headed "Symbolic conversion" <|
+              headed "After instantiation" <|
                 [ printTerm
                     (printBoolExpr (printSym printMarkedVar))
                     (printBoolExpr (printSym printMarkedVar))

--- a/Instantiate.fs
+++ b/Instantiate.fs
@@ -4,7 +4,7 @@
 ///     <para>
 ///         Starling has multiple stages during which we need to look up a
 ///         func in a list mapping funcs to Boolean expressions, and
-///         substitute func's arguments for the parameters in that Boolean
+///         substitute the func's arguments for the parameters in that Boolean
 ///         expression.
 ///     </para>
 ///     <para>
@@ -12,10 +12,6 @@
 ///         which contains the function <c>instantiate</c> for this
 ///         purpose.
 ///      </para>
-///     <para>
-///         In addition, it contains more generic functions for looking
-///         up funcs in tables, which are useful throughout Starling.
-///     </para>
 /// </summary>
 module Starling.Core.Instantiate
 

--- a/InstantiateTests.fs
+++ b/InstantiateTests.fs
@@ -6,7 +6,9 @@ module Starling.Tests.Instantiate
 open NUnit.Framework
 open Starling.Collections
 open Starling.Utils
+open Starling.Utils.Testing
 open Starling.Core.TypeSystem
+open Starling.Core.Definer
 open Starling.Core.Expr
 open Starling.Core.Model
 open Starling.Core.Var
@@ -64,23 +66,32 @@ module FuncInstantiate =
 
     [<Test>]
     let ``Instantiate func with too many arguments``() =
-        Assert.That
-            (testInstantiateFail (smvfunc "foo" [ AInt 101L |> Expr.Int ]),
-             Is.EqualTo
-                ([ CountMismatch(1, 0) ] |> Some))
-    [<Test>]
+        Some
+            [ BadFuncLookup
+                (smvfunc "foo" [ AInt 101L |> Expr.Int ],
+                 CountMismatch(1, 0)) ]
+        ?=? testInstantiateFail (smvfunc "foo" [ AInt 101L |> Expr.Int ])
     let ``Instantiate func with too few arguments``() =
-        Assert.That
-            (testInstantiateFail (smvfunc "bar" []),
-             Is.EqualTo
-                ([ CountMismatch(0, 1) ] |> Some))
+        Some
+            [ BadFuncLookup
+                (smvfunc "bar" [],
+                 CountMismatch(0, 1)) ]
+        ?=? testInstantiateFail (smvfunc "bar" [])
     [<Test>]
     let ``Instantiate func with two arguments of incorrect types``() =
-        Assert.That
-            (testInstantiateFail
+        Some
+            [ BadFuncLookup
                 (smvfunc "baz"
                     [ BTrue |> Expr.Bool
-                      siAfter "burble" |> Expr.Int ]),
-             Is.EqualTo
-                ([ TypeMismatch (Int "quux", Bool ())
-                   TypeMismatch (Bool "flop", Int ()) ] |> Some))
+                      siAfter "burble" |> Expr.Int ],
+                 TypeMismatch (Int "quux", Bool ()))
+              BadFuncLookup
+                (smvfunc "baz"
+                    [ BTrue |> Expr.Bool
+                      siAfter "burble" |> Expr.Int ],
+                 TypeMismatch (Bool "flop", Int ())) ]
+        ?=?
+            testInstantiateFail
+                (smvfunc "baz"
+                    [ BTrue |> Expr.Bool
+                      siAfter "burble" |> Expr.Int ])

--- a/Main.fs
+++ b/Main.fs
@@ -475,7 +475,7 @@ let runStarling (request : Request)
         bind (Core.Instantiate.Phase.run shouldApprox
               >> mapMessages Error.ModelFilterError)
     let eliminate : Result<Model<_, _>, Error> -> Result<Model<_, _>, Error>  =
-        lift (Backends.Z3.eliminate shouldUseRealsForInts)
+        lift (Backends.Z3.runZ3OnModel shouldUseRealsForInts)
 
     let backend m =
         let phase op response =

--- a/Main.fs
+++ b/Main.fs
@@ -461,10 +461,11 @@ let runStarling (request : Request)
                         (fun _ { Backends.Z3.Types.ZTerm.Original = a } -> a)
                         nonProvenZTerms
                 let nonProvenModel = withAxioms nonProvenAxioms model
-                let npmIndefinite =
-                    Core.Instantiate.DefinerFilter.filterModelIndefinite
+                // We can't have symbols in our view constraints, so strip them.
+                let npmNoSymbolicConstraintsR =
+                    Core.Instantiate.DefinerFilter.filterModelNonSymbolicConstraints
                         nonProvenModel
-                mapMessages ModelFilterError npmIndefinite)
+                mapMessages ModelFilterError npmNoSymbolicConstraintsR)
 
     let symproof : Result<Model<_, _>, Error> -> Result<Model<_, _>, Error> =
         bind (Core.Instantiate.Phase.run approx

--- a/Main.fs
+++ b/Main.fs
@@ -134,13 +134,13 @@ let requestList : (string * (string * Request)) list =
        ("Proves as much as possible using SMT, returning the remaining proof.",
         Request.SMTProof Backends.Z3.Types.Request.RemainingSymBools))
       ("mutranslate",
-       ("Generates a proof using MuZ3 and outputs the individual terms.",
+       ("(EXPERIMENTAL: KNOWN TO BE UNSOUND) Generates a proof using MuZ3 and outputs the individual terms.",
         Request.MuZ3 Backends.MuZ3.Types.Request.Translate))
       ("mufix",
-       ("Generates a proof using MuZ3 and outputs the fixed point.",
+       ("(EXPERIMENTAL: KNOWN TO BE UNSOUND) Generates a proof using MuZ3 and outputs the fixed point.",
         Request.MuZ3 Backends.MuZ3.Types.Request.Fix))
       ("musat",
-       ("Executes a proof using MuZ3 and reports the result.",
+       ("(EXPERIMENTAL: KNOWN TO BE UNSOUND) Executes a proof using MuZ3 and reports the result.",
         Request.MuZ3 Backends.MuZ3.Types.Request.Sat))
       ("hsf",
        ("Outputs a proof in HSF format.",

--- a/Main.fs
+++ b/Main.fs
@@ -208,14 +208,12 @@ let printResponse (mview : ModelView) : Response -> Doc =
         printModelView
             paxiom
             (printViewDefiner
-                (Option.map (printBoolExpr (printSym printVar))
-                 >> withDefault (String "?")))
+                (maybe (String "?") (printBoolExpr (printSym printVar))))
             mview m
     let printFModel paxiom m =
         printModelView paxiom
             (printFuncDefiner
-                (Option.map (printBoolExpr (printSym printVar))
-                 >> withDefault (String "?")))
+                (maybe (String "?") (printBoolExpr (printSym printVar))))
             mview m
     let printUModel paxiom m =
         printModelView paxiom (fun _ -> Seq.empty) mview m
@@ -385,16 +383,14 @@ let runStarling (request : Request)
 
     let opts =
         config.optimisers
-        |> Option.map Utils.parseOptionString
-        |> withDefault (Seq.empty)
+        |> maybe (Seq.empty) Utils.parseOptionString
         |> Seq.toList
         |> Optimiser.Utils.parseOptimisationString
 
     let bp = backendParams ()
     let { Approx = approx; Reals = reals } =
         config.backendOpts
-        |> Option.map Utils.parseOptionString
-        |> withDefault (Seq.empty)
+        |> maybe (Seq.empty) Utils.parseOptionString
         |> Seq.fold
                (fun opts str ->
                     match (bp.TryFind str) with

--- a/Main.fs
+++ b/Main.fs
@@ -10,6 +10,7 @@ open Starling.Utils.Config
 open Starling.Core.Pretty
 open Starling.Core.Graph
 open Starling.Core.Graph.Pretty
+open Starling.Core.Definer
 open Starling.Core.Expr
 open Starling.Core.Expr.Pretty
 open Starling.Core.Var

--- a/Model.fs
+++ b/Model.fs
@@ -8,6 +8,7 @@ open Chessie.ErrorHandling
 open Starling.Collections
 open Starling.Utils
 open Starling.Core.TypeSystem
+open Starling.Core.Definer
 open Starling.Core.Expr
 open Starling.Core.Var
 open Starling.Core.Symbolic
@@ -96,36 +97,6 @@ module Types =
 
     /// A term using only internal boolean expressions.
     type FTerm = CTerm<MBoolExpr>
-
-    (*
-     * Func lookup
-     *)
-
-    /// <summary>
-    ///     A definer function mapping views to their meanings.
-    /// </summary>
-    /// <typeparam name="defn">
-    ///     Type of definitions of <c>View</c>s stored in the table.
-    ///     May be <c>unit</c>.
-    /// </typeparam>
-    type ViewDefiner<'defn> =
-        // TODO(CaptainHayashi): this should probably be a map,
-        // but translating it to one seems non-trivial.
-        // Would need to define equality on funcs very loosely.
-        (DView * 'defn) list
-
-    /// <summary>
-    ///     A definer function mapping funcs to their meanings.
-    /// </summary>
-    /// <typeparam name="defn">
-    ///     Type of definitions of <c>Func</c>s stored in the table.
-    ///     May be <c>unit</c>.
-    /// </typeparam>
-    type FuncDefiner<'defn> =
-        // TODO(CaptainHayashi): this should probably be a map,
-        // but translating it to one seems non-trivial.
-        // Would need to define equality on funcs very loosely.
-        (DFunc * 'defn) list
 
     type PrimSemantics = { Name: string; Results: TypedVar list; Args: TypedVar list; Body: SVBoolExpr }
     type SemanticsMap<'a> = Map<string, 'a>
@@ -497,83 +468,3 @@ let mapViewDefs (f : 'x -> 'y) (model : Model<'axiom, 'x>) : Model<'axiom, 'y> =
 let tryMapViewDefs (f : 'x -> Result<'y, 'e>) (model : Model<'axiom, 'x>)
     : Result<Model<'axiom, 'y>, 'e> =
     lift (fun x -> withViewDefs x model) (model |> viewDefs |> f)
-
-module FuncDefiner =
-    /// <summary>
-    ///     Converts a <c>FuncDefiner</c> to a sequence of pairs of
-    ///     <c>Func</c> and definition.
-    /// </summary>
-    /// <param name="definer">
-    ///     A <see cref="FuncDefiner"/> to convert to a sequence.
-    /// </param>
-    /// <typeparam name="defn">
-    ///     The type of <c>Func</c> definitions.  May be <c>unit</c>.
-    /// </typeparam>
-    /// <returns>
-    ///     The sequence of (<c>Func</c>, <c>'defn</c>) pairs.
-    ///     A <c>FuncDefiner</c> allowing the <c>'defn</c>s of the given
-    ///     <c>Func</c> to be looked up.
-    /// </returns>
-    let toSeq (definer : FuncDefiner<'defn>) : (DFunc * 'defn) seq =
-        // This function exists to smooth over any changes in Definer
-        // representation we make later (eg. to maps).
-        List.toSeq definer
-
-    /// <summary>
-    ///     Builds a <c>FuncDefiner</c> from a sequence of pairs of
-    ///     <c>Func</c> and definition.
-    /// </summary>
-    /// <param name="fseq">
-    ///     The sequence of (<c>Func</c>, <c>'defn</c>) pairs.
-    /// </param>
-    /// <typeparam name="defn">
-    ///     The type of <c>Func</c> definitions.  May be <c>unit</c>.
-    /// </typeparam>
-    /// <returns>
-    ///     A <c>FuncDefiner</c> allowing the <c>'defn</c>s of the given
-    ///     <c>Func</c> to be looked up.
-    /// </returns>
-    let ofSeq (fseq : #((DFunc * 'defn) seq)) : FuncDefiner<'defn> =
-        // This function exists to smooth over any changes in Definer
-        // representation we make later (eg. to maps).
-        Seq.toList fseq
-
-module ViewDefiner =
-    /// <summary>
-    ///     Converts a <c>ViewDefiner</c> to a sequence of pairs of
-    ///     <c>View</c> and definition.
-    /// </summary>
-    /// <param name="definer">
-    ///     A <see cref="ViewDefiner"/> to convert to a sequence.
-    /// </param>
-    /// <typeparam name="defn">
-    ///     The type of <c>View</c> definitions.  May be <c>unit</c>.
-    /// </typeparam>
-    /// <returns>
-    ///     The sequence of (<c>View</c>, <c>'defn</c>) pairs.
-    ///     A <c>ViewDefiner</c> allowing the <c>'defn</c>s of the given
-    ///     <c>View</c> to be looked up.
-    /// </returns>
-    let toSeq (definer : ViewDefiner<'defn>) : (DView * 'defn) seq =
-        // This function exists to smooth over any changes in Definer
-        // representation we make later (eg. to maps).
-        List.toSeq definer
-
-    /// <summary>
-    ///     Builds a <c>ViewDefiner</c> from a sequence of pairs of
-    ///     <c>View</c> and definition.
-    /// </summary>
-    /// <param name="fseq">
-    ///     The sequence of (<c>Func</c>, <c>'defn</c>) pairs.
-    /// </param>
-    /// <typeparam name="defn">
-    ///     The type of <c>Func</c> definitions.  May be <c>unit</c>.
-    /// </typeparam>
-    /// <returns>
-    ///     A <c>ViewDefiner</c> allowing the <c>'defn</c>s of the given
-    ///     <c>View</c>s to be looked up.
-    /// </returns>
-    let ofSeq (fseq : #((DView * 'defn) seq)) : ViewDefiner<'defn> =
-        // This function exists to smooth over any changes in Definer
-        // representation we make later (eg. to maps).
-        Seq.toList fseq

--- a/Model.fs
+++ b/Model.fs
@@ -136,12 +136,12 @@ module Types =
         ///     The given iterated func needs its definition checking for base
         ///     downclosure.
         /// </summary>
-        | NeedsBaseDownclosure of func : DFunc
+        | NeedsBaseDownclosure of func : IteratedDFunc * why : string
         /// <summary>
         ///     The given iterated func needs its definition checking for
         ///     inductive downclosure.
         /// </summary>
-        | NeedsInductiveDownclosure of func : DFunc
+        | NeedsInductiveDownclosure of func : IteratedDFunc * why : string
 
     (*
      * Models

--- a/Model.fs
+++ b/Model.fs
@@ -237,17 +237,14 @@ module Pretty =
             match check with
             | NeedsBaseDownclosure (func, why) ->
                 colonSep
-                    [ hsep
-                        [ String "iterated func"
-                          printIteratedDFunc func
-                          String "needs base downclosure check" ]
+                    [ String "base downclosure check for iterated func"
+                        <+> printIteratedDFunc func
                       String why ]
             | NeedsInductiveDownclosure (func, why) ->
                 colonSep
                     [ hsep
-                        [ String "iterated func"
-                          printIteratedDFunc func
-                          String "needs inductive downclosure check" ]
+                        [ String "inductive downclosure check for iterated func"
+                            <+> printIteratedDFunc func ]
                       String why ]
 
     /// Pretty-prints a model given axiom and defining-view printers.

--- a/Model.fs
+++ b/Model.fs
@@ -185,6 +185,7 @@ module Types =
 module Pretty =
     open Starling.Core.Pretty
     open Starling.Core.Symbolic.Pretty
+    open Starling.Core.Var.Pretty
     open Starling.Core.View.Pretty
     open Starling.Core.TypeSystem.Pretty
     open Starling.Core.Command.Pretty
@@ -226,6 +227,29 @@ module Pretty =
       : Doc =
         printMap Indented String pAxiom model.Axioms
 
+    /// <summary>
+    ///     Pretty-prints a deferred check.
+    /// </summary>
+    /// <param name="check">The deferred check to print.</param>
+    /// <returns>A <see cref="Doc"/> capturing the deferred check.</returns>
+    let printDeferredCheck (check : DeferredCheck) : Doc =
+        warning <|
+            match check with
+            | NeedsBaseDownclosure (func, why) ->
+                colonSep
+                    [ hsep
+                        [ String "iterated func"
+                          printIteratedDFunc func
+                          String "needs base downclosure check" ]
+                      String why ]
+            | NeedsInductiveDownclosure (func, why) ->
+                colonSep
+                    [ hsep
+                        [ String "iterated func"
+                          printIteratedDFunc func
+                          String "needs inductive downclosure check" ]
+                      String why ]
+
     /// Pretty-prints a model given axiom and defining-view printers.
     let printModel
       (pAxiom : 'Axiom -> Doc)
@@ -242,7 +266,9 @@ module Pretty =
               headed "ViewDefs" <|
                   pDefiner model.ViewDefs
               headed "Axioms" <|
-                  Seq.singleton (printModelAxioms pAxiom model) ]
+                  Seq.singleton (printModelAxioms pAxiom model)
+              headed "Deferred checks" <|
+                  Seq.map printDeferredCheck model.DeferredChecks ]
 
     /// <summary>
     ///     Pretty-prints <see cref="FuncDefiner"/>s.

--- a/Model.fs
+++ b/Model.fs
@@ -369,9 +369,8 @@ module Pretty =
         | ModelView.Model -> printModel pAxiom pDefiner m
         | ModelView.Terms -> printModelAxioms pAxiom m
         | ModelView.Term termstr ->
-            Map.tryFind termstr m.Axioms
-            |> Option.map pAxiom
-            |> withDefault (termstr |> sprintf "no term '%s'" |> String)
+            maybe (termstr |> sprintf "no term '%s'" |> String) pAxiom
+                (Map.tryFind termstr m.Axioms)
 
 
     /// Prints a Term<CommandSemantics, 'WPre, 'Goal> using the WPre and Goal printers provided

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -197,9 +197,7 @@ module Pretty =
     /// Pretty-prints a CView.
     and printCView : CView -> Doc =
         printMultiset
-            (printIteratedContainer
-                printCFunc
-                (Option.map (printSym printVar) >> withDefault Nop))
+            (printIteratedContainer printCFunc (maybe Nop (printSym printVar)))
         >> ssurround "[|" "|]"
 
     /// Pretty-prints a part-cmd at the given indent level.
@@ -214,11 +212,10 @@ module Pretty =
             cmdHeaded (hsep [String "begin if"
                              (printSVBoolExpr expr) ])
                       [headed "True" [printBlock pView (printPartCmd pView) inTrue]
-                       withDefault Nop
-                            (Option.map
-                                (fun f ->
-                                    headed "False" [printBlock pView (printPartCmd pView) f])
-                                inFalse) ]
+                       maybe Nop
+                            (fun f ->
+                                headed "False" [printBlock pView (printPartCmd pView) f])
+                            inFalse ]
 
     /// Pretty-prints expression conversion errors.
     let printExprError : ExprError -> Doc =

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -10,7 +10,6 @@ open Starling.Collections
 open Starling.Core
 open Starling.Core.Definer
 open Starling.Core.TypeSystem
-open Starling.Core.TypeSystem.Check
 open Starling.Core.Expr
 open Starling.Core.Var
 open Starling.Core.Symbolic
@@ -1067,7 +1066,7 @@ let modelCAS : MethodContext -> LValue -> LValue -> Expression -> Result<PrimCom
              let v = wrapMessages BadTVar (lookupVar tvars) testLV
              lift (mkPair dest) v)
     >>= (function
-         | UnifyBool (d, t) ->
+         | (Bool d, Bool t) ->
              set
              |> wrapMessages BadExpr (modelBoolExpr tvars MarkedVar.Before)
              |> lift
@@ -1077,7 +1076,7 @@ let modelCAS : MethodContext -> LValue -> LValue -> Expression -> Result<PrimCom
                             [ d |> sbBefore |> Expr.Bool
                               t |> sbBefore |> Expr.Bool
                               s |> Expr.Bool ] )
-         | UnifyInt (d, t) ->
+         | (Int d, Int t) ->
             set
             |> wrapMessages BadExpr (modelIntExpr tvars MarkedVar.Before)
             |> lift
@@ -1087,7 +1086,7 @@ let modelCAS : MethodContext -> LValue -> LValue -> Expression -> Result<PrimCom
                             [ d |> siBefore |> Expr.Int
                               t |> siBefore |> Expr.Int
                               s |> Expr.Int ] )
-         | UnifyFail (d, t) ->
+         | (d, t) ->
              // Oops, we have a type error.
              // Arbitrarily single out test as the cause of it.
              fail (TypeMismatch (typeOf d, testLV, typeOf t)))

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -1354,5 +1354,6 @@ let model
               ViewDefs = constraints
               Semantics = coreSemantics
               Axioms = axioms
-              ViewProtos = vprotos }
+              ViewProtos = vprotos
+              DeferredChecks = [] }
     }

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -8,6 +8,7 @@ open Chessie.ErrorHandling
 open Starling
 open Starling.Collections
 open Starling.Core
+open Starling.Core.Definer
 open Starling.Core.TypeSystem
 open Starling.Core.TypeSystem.Check
 open Starling.Core.Expr
@@ -100,7 +101,7 @@ module Types =
         /// A view was requested that does not exist.
         | NoSuchView of name : string
         /// A view lookup failed.
-        | LookupError of name : string * err : Instantiate.Types.Error
+        | LookupError of name : string * err : Core.Definer.Error
         /// A view used variables in incorrect ways, eg by duplicating.
         | BadVar of err : VarMapError
         /// A viewdef conflicted with the shared variables.
@@ -243,7 +244,10 @@ module Pretty =
         | ViewError.BadExpr(expr, err) ->
             wrapped "expression" (printExpression expr) (printExprError err)
         | NoSuchView name -> fmt "no view prototype for '{0}'" [ String name ]
-        | LookupError(name, err) -> wrapped "lookup for view" (name |> String) (err |> Instantiate.Pretty.printError)
+        | LookupError(name, err) ->
+            wrapped "lookup for view"
+                (String name)
+                (Definer.Pretty.printError err)
         | ViewError.BadVar err ->
             colonSep [ "invalid variable usage" |> String
                        err |> printVarMapError ]
@@ -662,11 +666,11 @@ let funcViewParMerge (ppars : TypedVar list) (dpars : Var list)
   : TypedVar list =
     List.map2 (fun ppar dpar -> withType (typeOf ppar) dpar) ppars dpars
 
-/// Adapts Instantiate.lookup to the modeller's needs.
+/// Adapts Definer.lookup to the modeller's needs.
 let lookupFunc (protos : FuncDefiner<ProtoInfo>) (func : Func<_>)
   : Result<DFunc, ViewError> =
     protos
-    |> Instantiate.lookup func
+    |> FuncDefiner.lookup func
     |> mapMessages (curry LookupError func.Name)
     |> bind (function
              | Some (proto, _) -> proto |> ok
@@ -925,11 +929,11 @@ let modelCFunc
              |> collect
              // Then, put them into a VFunc.
              |> lift (vfunc afunc.Name)
-             // Now, we can use Instantiate's type checker to ensure
+             // Now, we can use Definer's type checker to ensure
              // the params in the VFunc are of the types mentioned
              // in proto.
              |> bind (fun vfunc ->
-                          Instantiate.checkParamTypes vfunc proto
+                          FuncDefiner.checkParamTypes vfunc proto
                           |> mapMessages (curry LookupError vfunc.Name)))
     // Finally, lift to CFunc.
     |> lift CFunc.Func

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -931,7 +931,6 @@ let modelCFunc
              |> bind (fun vfunc ->
                           FuncDefiner.checkParamTypes vfunc proto
                           |> mapMessages (curry LookupError vfunc.Name)))
-    // Finally, lift to CFunc.
     |> lift CFunc.Func
 
 /// Tries to flatten a view AST into a CView.

--- a/ModellerTests.fs
+++ b/ModellerTests.fs
@@ -9,6 +9,7 @@ open Starling.Utils.Testing
 open Starling.Collections
 open Starling.Core
 open Starling.Core.TypeSystem
+open Starling.Core.Definer
 open Starling.Core.Expr
 open Starling.Core.Var
 open Starling.Core.Symbolic

--- a/ModellerTests.fs
+++ b/ModellerTests.fs
@@ -127,11 +127,11 @@ module BooleanExprs =
 
 module VarLists =
     let checkFail (vars : TypedVar list) (expectedErrs : VarMapError list) =
-        let varmap = failOption <| makeVarMap vars
+        let varmap = failOption <| VarMap.ofTypedVarSeq vars
         AssertAreEqual(Some expectedErrs, varmap)
 
     let checkPass (vars : TypedVar list) (expectedMap : Map<string, CTyped<unit>>) =
-        let varmap = okOption <| makeVarMap vars
+        let varmap = okOption <| VarMap.ofTypedVarSeq vars
         AssertAreEqual(Some expectedMap, varmap)
 
     [<Test>]
@@ -154,14 +154,14 @@ module VarLists =
                           ("baz", Bool ()) ])
 
     [<Test>]
-    let ``duplicate vars of same type fail in makeVarMap`` () =
+    let ``duplicate vars of same type fail in VarMap.ofTypedVarSeq`` () =
         checkFail
             ([ Bool "foo"
                Bool "foo" ])
             ([ VarMapError.Duplicate "foo" ])
 
     [<Test>]
-    let ``duplicate var with different type fails in makeVarMap`` () =
+    let ``duplicate var with different type fails in VarMap.ofTypedVarSeq`` () =
         checkFail
             ([ Bool "foo"
                Int  "foo" ])

--- a/MuZ3Backend.fs
+++ b/MuZ3Backend.fs
@@ -592,7 +592,7 @@ module Translator =
     /// <param name="svars">Map of shared variables in the program.</param>
     /// <param name="check">The deferred check to translate.</param>
     /// <returns>
-    ///     If successful, an optional a pair of the constructed rule's name
+    ///     If successful, an optional pair of the constructed rule's name
     ///     and body.
     /// </returns>
     let translateDeferredCheck

--- a/MuZ3Backend.fs
+++ b/MuZ3Backend.fs
@@ -864,6 +864,11 @@ module Run =
       (view : VFunc<Var>)
       (def : BoolExpr<Var>)
       : unit =
+        (* To model a view definition, we introduce an if and only if.
+           This can't be modelled directly in MuZ3, so instead we split it
+           into two implications.
+
+           This is the 'def => view' part. *)
         let defImpliesView =
             Translator.mkRule
                 shouldUseRealsForInts id ctx funcDecls def Multiset.empty view
@@ -888,7 +893,12 @@ module Run =
                                 shouldUseRealsForInts ctx (typeOf var)))
                     vars)
 
-        // Introduce 'V ^ ¬D(V) -> unsafe'.
+        (* This is the 'view => def' part.
+           We can't model this directly in MuZ3 because the head of a MuZ3
+           constraint must be a single positive func.
+           Instead, we rearrange to 'view && !def => unsafe', where unsafe is
+           a stand-in for some notion of false. *)
+        // TODO(CaptainHayashi): in practice this appears to be unsound.
         let viewImpliesDef =
             Translator.mkQuantifiedEntailment
                 ctx

--- a/MuZ3Backend.fs
+++ b/MuZ3Backend.fs
@@ -30,6 +30,7 @@ open Starling
 open Starling.Collections
 open Starling.Semantics
 open Starling.Core.TypeSystem
+open Starling.Core.Definer
 open Starling.Core.Expr
 open Starling.Core.Var
 open Starling.Core.Model

--- a/MuZ3Backend.fs
+++ b/MuZ3Backend.fs
@@ -602,7 +602,7 @@ module Translator =
       (svars : VarMap)
       (check : DeferredCheck)
       : Result<(string * Z3.BoolExpr) option, Error> =
-        let svarSeq = toVarSeq svars
+        let svarSeq = VarMap.toTypedVarSeq svars
 
         // TODO(CaptainHayashi): clean this up?
         let varToExpr v =

--- a/Pretty.fs
+++ b/Pretty.fs
@@ -54,6 +54,8 @@ let error d = Styled([Red], d)
 let errorContext d = Styled([Cyan], d)
 let errorInfo d = Styled([Magenta], d)
 let warning d = Styled([Yellow], d)
+let success d = Styled([Green], d)
+let inconclusive d = Styled([Blue], d)
 
 /// <summary>
 ///     Styles a string with ANSI escape sequences.

--- a/Pretty.fs
+++ b/Pretty.fs
@@ -86,8 +86,6 @@ let stylise s l d =
 
     let codify = List.map code >> String.concat ";"
 
-    printfn "%A (previous %A)" s l
-
     let prefix = "\u001b[" + codify s + "m"
     let suffix = "\u001b[" + withDefault "0" (Option.map codify l) + "m"
     prefix + d + suffix
@@ -196,6 +194,17 @@ let hsepStr s c = HSep(c, String s)
 let hjoin c = HSep(c, Nop)
 /// Horizontally separates a list of commands with a space separator.
 let hsep c = hsepStr " " c
+/// Binary version of hsep.
+let hsep2 sep x y =
+    // Do a bit of optimisation in case we get long chains of hsep2s.
+    match (x, y) with
+    | HSep (xs, sx), HSep (ys, sy) when sx = sep && sy = sep ->
+        HSep (Seq.append xs ys, sep)
+    | HSep (xs, sx), y when sx = sep -> HSep (Seq.append xs (Seq.singleton y), sep)
+    | x, HSep (ys, sy) when sy = sep -> HSep (Seq.append (Seq.singleton x) ys, sep)
+    | x, y -> HSep (Seq.ofList [ x; y ], sep)
+/// Infix version of hsep.
+let (<+>) x y = hsep2 (String " ") x y
 /// Horizontally separates a list of commands with commas.
 let commaSep c = hsepStr ", " c
 /// Horizontally separates a list of commands with semicolons.

--- a/Pretty.fs
+++ b/Pretty.fs
@@ -205,6 +205,8 @@ let hsep2 sep x y =
     | HSep (xs, sx), y when sx = sep -> HSep (Seq.append xs (Seq.singleton y), sep)
     | x, HSep (ys, sy) when sy = sep -> HSep (Seq.append (Seq.singleton x) ys, sep)
     | x, y -> HSep (Seq.ofList [ x; y ], sep)
+/// Infix version of hjoin.
+let (<->) x y = hsep2 Nop x y
 /// Infix version of hsep.
 let (<+>) x y = hsep2 (String " ") x y
 /// Horizontally separates a list of commands with commas.

--- a/Reifier.fs
+++ b/Reifier.fs
@@ -255,8 +255,7 @@ module Downclosure =
       : Result<DeferredCheck list, Error> =
         (* To do the inductive downclosure, we need to replace all instances of
            the iterator in the definition with (iterator + 1) in one version. *)
-        let increment v = mkAdd2 (AVar (Reg v)) (AInt 1L)
-        let succDefn = mapOverIteratorUses increment iterator defn
+        let succDefn = mapOverIteratorUses (Reg >> incVar) iterator defn
 
         (* Inductive downclosure for a view V[n](x):
              (0 <= n) => (D(V[n+1](x)) => D(V[n](x)))

--- a/Reifier.fs
+++ b/Reifier.fs
@@ -307,10 +307,14 @@ module Downclosure =
         | Some d ->
             let checkedIterR = checkIterator func.Iterator
             bind
-                (fun i ->
-                    deferred
-                    |> checkBaseDownclosure empDefn i func d
-                    >>= checkInductiveDownclosure i func d)
+                (fun checkedIter ->
+                    let baseDeferredR =
+                        checkBaseDownclosure empDefn checkedIter func d deferred
+                    bind
+                        (fun baseDeferred ->
+                            checkInductiveDownclosure checkedIter func d
+                                baseDeferred)
+                        baseDeferredR)
                 checkedIterR
 
     /// <summary>

--- a/Reifier.fs
+++ b/Reifier.fs
@@ -134,7 +134,6 @@ module Downclosure =
     /// </returns>
     let lookupFunc (protos : FuncDefiner<ProtoInfo>) (func : DFunc)
       : Result<ProtoInfo option, Error> =
-        // TODO(CaptainHayashi): proper doc comment
         // TODO(CaptainHayashi): merge with Modeller.lookupFunc?
         let look func = Core.Definer.FuncDefiner.lookup func protos
         let record = wrapMessages LookupError look func
@@ -674,7 +673,7 @@ let reify
             model.ViewDefs
             model.DeferredChecks
     let checkedModelR =
-        lift (fun ds ->  { model with DeferredChecks = ds }) deferredCheckR
+        lift (fun ds -> { model with DeferredChecks = ds }) deferredCheckR
 
     lift
         (mapAxioms (mapTerm id (reifyView model.ViewProtos model.ViewDefs) id))

--- a/Reifier.fs
+++ b/Reifier.fs
@@ -736,7 +736,7 @@ module Pretty =
             fmt "view '{0}' is not iterated, but used in an iterated constraint"
                 [ printIteratedContainer
                     printDFunc
-                    (Option.map printTypedVar >> withDefault Nop)
+                    (maybe Nop printTypedVar)
                     func ]
         | BadIteratorType (view, ty) ->
             fmt "iterator on constraint '{0}' is of type {1}, should be int"

--- a/Reifier.fs
+++ b/Reifier.fs
@@ -7,6 +7,7 @@ module Starling.Reifier
 open Chessie.ErrorHandling
 open Starling.Collections
 open Starling.Utils
+open Starling.Core.Definer
 open Starling.Core.Expr
 open Starling.Core.View
 open Starling.Core.Var
@@ -88,7 +89,7 @@ module Types =
         ///         to make sure.
         ///     </para>
         /// </summary>
-        | LookupError of func : DFunc * err : Core.Instantiate.Types.Error
+        | LookupError of func : DFunc * err : Core.Definer.Error
         /// <summary>
         ///     An iterator had the wrong type.
         /// </summary>
@@ -135,7 +136,7 @@ module Downclosure =
       : Result<ProtoInfo option, Error> =
         // TODO(CaptainHayashi): proper doc comment
         // TODO(CaptainHayashi): merge with Modeller.lookupFunc?
-        let look func = Core.Instantiate.lookup func protos
+        let look func = Core.Definer.FuncDefiner.lookup func protos
         let record = wrapMessages LookupError look func
         lift (Option.map snd) record
 
@@ -703,7 +704,7 @@ module Pretty =
         | LookupError(func, err) ->
             wrapped "lookup for view"
                 (printDFunc func)
-                (err |> Core.Instantiate.Pretty.printError)
+                (err |> Core.Definer.Pretty.printError)
         | IteratorOnNonIterated func ->
             fmt "view '{0}' is not iterated, but used in an iterated constraint"
                 [ printIteratedContainer

--- a/ReifierTests.fs
+++ b/ReifierTests.fs
@@ -5,6 +5,7 @@ module Starling.Tests.Reifier
 
 open NUnit.Framework
 open Starling.Utils.Testing
+open Starling.Core.Definer
 open Starling.Core.Expr
 open Starling.Core.Symbolic
 open Starling.Core.TypeSystem

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -16,7 +16,6 @@ module Starling.Semantics
 open Chessie.ErrorHandling
 open Starling.Collections
 open Starling.Core.TypeSystem
-open Starling.Core.TypeSystem.Check
 open Starling.Core.Command
 open Starling.Core.Command.Compose
 open Starling.Core.GuardedView
@@ -146,10 +145,10 @@ let lookupPrim : PrimCommand -> PrimSemanticsMap -> Result<PrimSemantics option,
 let checkParamTypesPrim : PrimCommand -> PrimSemantics -> Result<PrimCommand, Error> =
     fun prim sem ->
     List.map2
-        (curry
-             (function
-              | UnifyInt _ | UnifyBool _ -> ok ()
-              | UnifyFail (fp, dp) -> fail (TypeMismatch (dp, typeOf fp))))
+        (fun fp dp ->
+            if typeOf fp = typeOf dp
+            then ok ()
+            else fail (TypeMismatch (dp, typeOf fp)))
         prim.Args
         sem.Args
     |> collect

--- a/TermGen.fs
+++ b/TermGen.fs
@@ -7,6 +7,7 @@ module Starling.TermGen
 open Chessie.ErrorHandling
 
 open Starling.Collections
+open Starling.Core.Definer
 open Starling.Core.TypeSystem
 open Starling.Core.Expr
 open Starling.Core.View
@@ -235,7 +236,7 @@ module Iter =
         ///     A func was lowered that doesn't have a valid prototype.
         /// </summary>
         | ProtoLookupError of FuncName : string
-                            * Error : Starling.Core.Instantiate.Types.Error
+                            * Error : Starling.Core.Definer.Error
         /// <summary>
         ///     A func was lowered that doesn't have a prototype at all.
         /// </summary>
@@ -261,7 +262,7 @@ module Iter =
             Core.Pretty.wrapped
                 "prototype lookup for func"
                 (Core.Pretty.String func)
-                (Core.Instantiate.Pretty.printError error)
+                (Core.Definer.Pretty.printError error)
         | ProtoMissing func ->
             Core.Pretty.fmt
                 "prototype missing for func '{0}'"
@@ -294,7 +295,7 @@ module Iter =
       (protos : FuncDefiner<ProtoInfo>)
       (func : Func<'Param>)
       : Result<bool, Error> =
-            lookup func protos
+            FuncDefiner.lookup func protos
             |> mapMessages (fun f -> ProtoLookupError (func.Name, f))
             |> bind
                 (function

--- a/TermGenTests.fs
+++ b/TermGenTests.fs
@@ -8,6 +8,7 @@ open Starling.TermGen
 open Starling.Utils
 open Starling.Utils.Testing
 open Starling.Core.TypeSystem
+open Starling.Core.Definer
 open Starling.Core.Expr
 open Starling.Core.Model
 open Starling.Core.View

--- a/TestStudies.fs
+++ b/TestStudies.fs
@@ -6,6 +6,7 @@ module Starling.Tests.Studies
 open Starling
 open Starling.Collections
 open Starling.Core.TypeSystem
+open Starling.Core.Definer
 open Starling.Core.Expr
 open Starling.Core.Symbolic
 open Starling.Core.Var

--- a/TestStudies.fs
+++ b/TestStudies.fs
@@ -583,4 +583,5 @@ let ticketLockModel : Model<ModellerMethod, ViewDefiner<SVBoolExpr option>> =
       Axioms = ticketLockMethods
       ViewDefs = ticketLockViewDefs
       ViewProtos = ticketLockViewProtos
-      Semantics = Starling.Lang.Modeller.coreSemantics }
+      Semantics = Starling.Lang.Modeller.coreSemantics
+      DeferredChecks = [] }

--- a/TypeSystem.fs
+++ b/TypeSystem.fs
@@ -112,20 +112,6 @@ type CMapper<'context, 'src, 'dst> = Mapper<'context, 'src, 'src, 'dst, 'dst>
 
 
 /// <summary>
-///     The Starling type checker.
-/// </summary>
-module Check =
-    /// <summary>
-    ///     Active pattern performing type unification.
-    /// </summary>
-    let (|UnifyInt|UnifyBool|UnifyFail|)
-        = function
-          | (Typed.Int x, Typed.Int y) -> UnifyInt (x, y)
-          | (Typed.Bool x, Typed.Bool y) -> UnifyBool (x, y)
-          | x, y -> UnifyFail (x, y)
-
-
-/// <summary>
 ///     Functions and types for mapping typed values.
 /// </summary>
 module Mapper =

--- a/Utils.fs
+++ b/Utils.fs
@@ -116,26 +116,12 @@ let onlyOne (s : 'A seq) : 'A option =
 /// Reverses a 2-argument function.
 let flip (f : 'A -> 'B -> 'C) (x : 'B) (y : 'A) : 'C = f y x
 
-/// Reverses a pair.
-let flipPair (x : 'A1, y : 'A2) : 'A2 * 'A1 = (y, x)
-
 /// A predicate that always returns true.
 let always (_ : _) : bool = true
 
-/// Applies f and g to x and returns (f x, g x).
-let splitThrough (f : 'A -> 'B) (g : 'A -> 'C) (x : 'A) : 'B * 'C =
-    (f x, g x)
-
-/// Given f and x, returns (x, f x).
-let inAndOut (f : 'A -> 'B) : 'A -> 'A * 'B = splitThrough id f
-
-/// Given f and (x, y), returns (x, f x y).
-let inAndOut2 (f : 'A -> 'B -> 'C) (x : 'A, y : 'B) : 'A * 'C =
-    (x, f x y)
-
 /// Passes fst through f, and snd through g.
-let pairMap (f : 'A1 -> 'B1) (g : 'A2 -> 'B2) : 'A1 * 'A2 -> 'B1 * 'B2 =
-    splitThrough (fst >> f) (snd >> g)
+let pairMap (f : 'A1 -> 'B1) (g : 'A2 -> 'B2) (a1 : 'A1, a2 : 'A2) : 'B1 * 'B2 =
+    (f a1, g a2)
 
 /// Converts a pairwise function to a function of two arguments.
 let curry (f : 'A * 'B -> 'C) (a : 'A) (b : 'B) : 'C = f (a, b)
@@ -156,11 +142,26 @@ let cons (x : 'X) (xs : 'X list) : 'X list = x :: xs
 /// Puts a onto the top of a sequence b.
 let scons (x : 'X) : 'X seq -> 'X seq = Seq.append (Seq.singleton x)
 
-/// Returns `a` if the input is `Some a`, or `d` otherwise.
-let withDefault (d : 'A) : 'A option -> 'A =
-    function
-    | Some a -> a
+/// <summary>
+///     Returns a default value if the input is <c>None</c>, and maps a function
+///     over it otherwise.
+/// </summary>
+/// <param name="d">The default value.</param>
+/// <param name="f">The transformer used if the input is <c>Some</c>.</param>
+/// <param name="input">The input value.</param>
+/// <typeparam name="In">The type of the input.</typeparam>
+/// <typeparam name="Out">The type of the input.</typeparam>
+/// <returns>
+///     <paramref name="d"/> if <paramref name="input"/> is <c>None</c>;
+///     <paramref name="f"/> <c>v</c> if it is <c>Some v</c>.
+/// </returns>
+let maybe (d : 'Out) (f : 'In -> 'Out) (input: 'In option) : 'Out =
+    match input with
+    | Some a -> f a
     | None -> d
+
+/// Returns `a` if the input is `Some a`, or `d` otherwise.
+let withDefault (d : 'A) : 'A option -> 'A = maybe d id
 
 /// Maps a function f through a sequence, and concatenates the resulting
 /// list of lists into one set.

--- a/Var.fs
+++ b/Var.fs
@@ -220,6 +220,16 @@ let lookupVar
     |> tryLookupVar env
     |> failIfNone (NotFound (flattenLV s))
 
+/// <summary>
+///     Converts a variable map to a sequence of typed variables.
+/// </summary>
+/// <param name="vmap">The map to convert.</param>
+/// <returns>
+///     <paramref name="vmap"/>, as a sequence of <see cref="TypedVar"/>s.
+/// </returns>
+let toVarSeq (vmap : VarMap) : TypedVar seq =
+    Seq.map (fun (name, ty) -> withType ty name) (Map.toSeq vmap)
+
 
 (*
  * Variable constructors
@@ -283,4 +293,3 @@ module Tests =
             // The fun x boilerplate seems to be necessary.
             // Otherwise, mutations to fg apparently don't propagate!
             List.map (fun x -> goalVar fg x) xs
-

--- a/Var.fs
+++ b/Var.fs
@@ -175,60 +175,55 @@ let rec flattenLV =
     function
     | LVIdent s -> s
 
-/// Makes a variable map from a list of type-name pairs.
-let makeVarMap lst =
-    lst
-    |> List.map valueOf // Extract all names from the list.
-    |> findDuplicates
-    |> Seq.toList
-    |> function
-       | [] -> lst
-               |> Seq.ofList
-               |> Seq.map (fun param -> (valueOf param, typeOf param))
-               |> Map.ofSeq |> ok
-       | ds -> List.map Duplicate ds |> Bad
+module VarMap =
+    /// Makes a variable map from a sequence of typed variables.
+    /// Can fail if there are duplicates.
+    let ofTypedVarSeq (vars : TypedVar seq) : Result<VarMap, VarMapError> =
+        // Before we make the map, make sure we have no duplicates.
+        let duplicates = findDuplicates (Seq.map valueOf vars)
+        match (Seq.toList duplicates) with 
+        | [] ->
+            let pairs = Seq.map (fun v -> (valueOf v, typeOf v)) vars
+            ok (Map.ofSeq pairs)
+        | ds -> Bad (List.map Duplicate ds)
 
-/// Tries to combine two variable maps.
-/// Fails if the environments are not disjoint.
-/// Failures are in terms of VarMapError.
-let combineMaps (a : VarMap) (b : VarMap) =
-    Map.fold (fun (sR : Result<VarMap, VarMapError>) name var ->
-        trial {
-            let! s = sR
-            if s.ContainsKey name then return! (fail (Duplicate name))
-            else return (s.Add(name, var))
-        }) (ok a) b
+    /// Tries to combine two variable maps.
+    /// Fails if the environments are not disjoint.
+    /// Failures are in terms of VarMapError.
+    let combine (a : VarMap) (b : VarMap) : Result<VarMap, VarMapError> =
+        Map.fold (fun (sR : Result<VarMap, VarMapError>) name var ->
+            trial {
+                let! s = sR
+                if s.ContainsKey name then return! (fail (Duplicate name))
+                else return (s.Add(name, var))
+            }) (ok a) b
 
-/// Tries to look up a variable record in a variable map.
-/// Failures are in terms of Some/None.
-let tryLookupVar
-  (env : VarMap)
-  : LValue -> CTyped<string> option =
-    function
-    | LVIdent s ->
-        s
-        |> env.TryFind
-        |> Option.map (fun ty -> withType ty s)
+    /// Tries to look up a variable record in a variable map.
+    /// Failures are in terms of Some/None.
+    let tryLookup
+      (env : VarMap)
+      : LValue -> CTyped<string> option =
+        function
+        | LVIdent s ->
+            Option.map (fun ty -> withType ty s) (env.TryFind s)
 
-/// Looks up a variable record in a variable map.
-/// Failures are in terms of VarMapError.
-let lookupVar
-  (env : VarMap)
-  (s : LValue)
-  : Result<CTyped<string>, VarMapError> =
-    s
-    |> tryLookupVar env
-    |> failIfNone (NotFound (flattenLV s))
+    /// Looks up a variable record in a variable map.
+    /// Failures are in terms of VarMapError.
+    let lookup
+      (env : VarMap)
+      (s : LValue)
+      : Result<CTyped<string>, VarMapError> =
+        failIfNone (NotFound (flattenLV s)) (tryLookup env s)
 
-/// <summary>
-///     Converts a variable map to a sequence of typed variables.
-/// </summary>
-/// <param name="vmap">The map to convert.</param>
-/// <returns>
-///     <paramref name="vmap"/>, as a sequence of <see cref="TypedVar"/>s.
-/// </returns>
-let toVarSeq (vmap : VarMap) : TypedVar seq =
-    Seq.map (fun (name, ty) -> withType ty name) (Map.toSeq vmap)
+    /// <summary>
+    ///     Converts a variable map to a sequence of typed variables.
+    /// </summary>
+    /// <param name="vmap">The map to convert.</param>
+    /// <returns>
+    ///     <paramref name="vmap"/>, as a sequence of <see cref="TypedVar"/>s.
+    /// </returns>
+    let toTypedVarSeq (vmap : VarMap) : TypedVar seq =
+        Seq.map (fun (name, ty) -> withType ty name) (Map.toSeq vmap)
 
 
 (*

--- a/View.fs
+++ b/View.fs
@@ -211,9 +211,7 @@ module Pretty =
 
     /// Pretty-prints an IteratedDFunc.
     let printIteratedDFunc : IteratedDFunc -> Doc =
-        printIteratedContainer
-            printDFunc
-            (function | None -> Nop | Some i -> printTypedVar i)
+        printIteratedContainer printDFunc (maybe Nop printTypedVar)
 
     /// Pretty-prints an IteratedOView.
     let printIteratedOView : IteratedOView -> Doc =

--- a/View.fs
+++ b/View.fs
@@ -231,10 +231,7 @@ module Pretty =
 
     /// Pretty-prints a DView.
     let printDView : DView -> Doc =
-        List.map
-            (printIteratedContainer
-                printDFunc
-                (Option.map printTypedVar >> withDefault Nop))
+        List.map (printIteratedContainer printDFunc (maybe Nop printTypedVar))
         >> semiSep >> squared
 
     /// Pretty-prints view expressions.

--- a/View.fs
+++ b/View.fs
@@ -209,7 +209,13 @@ module Pretty =
         | AInt 1L -> Nop
         | e -> printIntExpr pVar e
 
-    /// Pretty-prints an OView.
+    /// Pretty-prints an IteratedDFunc.
+    let printIteratedDFunc : IteratedDFunc -> Doc =
+        printIteratedContainer
+            printDFunc
+            (function | None -> Nop | Some i -> printTypedVar i)
+
+    /// Pretty-prints an IteratedOView.
     let printIteratedOView : IteratedOView -> Doc =
         List.map
             (printIteratedContainer

--- a/ViewDesugar.fs
+++ b/ViewDesugar.fs
@@ -30,7 +30,7 @@ let makeFreshView (tvars : VarMap) (fg : FreshGen) : View * ViewProto =
         fg |> getFresh |> sprintf "%A"
     let viewArgs =
         tvars |> Map.toSeq |> Seq.map (fst >> LVIdent >> LV >> fun l -> freshNode l)
-    let viewParams = toVarSeq tvars
+    let viewParams = VarMap.toTypedVarSeq tvars
 
     (Func (func viewName viewArgs), NoIterator (func viewName viewParams, false))
 

--- a/ViewDesugar.fs
+++ b/ViewDesugar.fs
@@ -30,8 +30,7 @@ let makeFreshView (tvars : VarMap) (fg : FreshGen) : View * ViewProto =
         fg |> getFresh |> sprintf "%A"
     let viewArgs =
         tvars |> Map.toSeq |> Seq.map (fst >> LVIdent >> LV >> fun l -> freshNode l)
-    let viewParams =
-        tvars |> Map.toSeq |> Seq.map (fun (name, ty) -> withType ty name)
+    let viewParams = toVarSeq tvars
 
     (Func (func viewName viewArgs), NoIterator (func viewName viewParams, false))
 

--- a/Z3.fs
+++ b/Z3.fs
@@ -17,11 +17,13 @@ module Pretty =
     let printZ3Exp (expr : #Z3.Expr) = String(expr.ToString())
 
     /// Pretty-prints a satisfiability result.
-    let printSat =
-        function
-        | Z3.Status.SATISFIABLE -> Styled ([Red], String "fail")
-        | Z3.Status.UNSATISFIABLE -> Styled ([Green], String "success")
-        | _ -> Styled ([Yellow], String "unknown")
+    let printSat (sat : Z3.Status) : Doc =
+        match sat with
+        (* Remember: we're trying to _refute_ the proof term with Z3.
+           Thus, sat is what we're trying to _avoid_ here. *)
+        | Z3.Status.SATISFIABLE -> error (String "fail")
+        | Z3.Status.UNSATISFIABLE -> success (String "success")
+        | _ -> inconclusive (String "unknown")
 
 
 /// <summary>

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -203,8 +203,9 @@ module Pretty =
 
     /// Pretty-prints a response.
     let printResponse (mview : ModelView) (response : Response) : Doc =
-        let attachChecks doc =
-            function
+        // Add deferred checks to a response if and only if there are some.
+        let attachChecks doc deferredChecks =
+            match deferredChecks with
             | [] -> doc
             | xs ->
                 vsep

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -165,7 +165,7 @@ module Pretty =
                     (printGView (printSym printMarkedVar))
                     (printVFunc (printSym printMarkedVar))
                     zterm.Original ]
-              headed "Symbolic conversion" <|
+              headed "After instantiation" <|
                 [ printTerm
                     (printBoolExpr (printSym printMarkedVar))
                     (printBoolExpr (printSym printMarkedVar))

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -256,7 +256,9 @@ let runZ3OnModel (shouldUseRealsForInts : bool)
     // Save us from having to supply all of these arguments every time.
     let toZ3 b = Expr.boolToZ3 shouldUseRealsForInts unmarkVar ctx b
 
-    // Try to remove symbols from boolean expressions: don't error if we can't
+    (* Try to remove symbols from boolean expressions.
+       Suppress the Chessie error that happens if we can't, because in that case
+       we just return a 'Z3 can't prove this' result. *)
     let removeSym bexp =
         let _, res = Mapper.mapBoolCtx (tsfRemoveSym id) NoCtx bexp
         okOption res

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -1,5 +1,5 @@
 /// <summary>
-///     The Z3 backend.
+///     The Z3 term eliminator.
 ///
 ///     <para>
 ///         This converts Starling proof terms into fully interpreted
@@ -19,11 +19,15 @@ open Microsoft
 open Chessie.ErrorHandling
 open Starling
 open Starling.Collections
+open Starling.Core.Definer
 open Starling.Core.Expr
 open Starling.Core.Var
 open Starling.Core.Model
 open Starling.Core.GuardedView
 open Starling.Core.Instantiate
+open Starling.Core.Sub
+open Starling.Core.Symbolic
+open Starling.Core.TypeSystem
 open Starling.Core.Z3
 
 
@@ -32,17 +36,65 @@ open Starling.Core.Z3
 /// </summary>
 [<AutoOpen>]
 module Types =
-    // A Z3-reified term.
-    type ZTerm = Term<Z3.BoolExpr, Z3.BoolExpr, Z3.BoolExpr>
+    /// <summary>
+    ///     A term combining a fully preprocessed Starling term and its Z3
+    ///     equivalent.
+    /// </summary>
+    type ZTerm =
+        { /// <summary>
+          ///     The original, fully preprocessed Starling term.
+          /// <summary>
+          Original: Core.Instantiate.Types.FinalTerm
 
-    /// Type of requests to the Z3 backend.
+          /// <summary>
+          ///     The above as a Boolean expression with all non-Z3-native parts
+          ///     converted to symbols.
+          /// </summary>
+          SymBool: CmdTerm<BoolExpr<Sym<MarkedVar>>,
+                           BoolExpr<Sym<MarkedVar>>,
+                           BoolExpr<Sym<MarkedVar>>>
+
+          /// <summary>
+          ///     The Z3-reified equivalent, which may be optional if the
+          ///     original term could not be converted into Z3.
+          /// </summary>
+          Z3: Term<Z3.BoolExpr, Z3.BoolExpr, Z3.BoolExpr> option
+
+          /// <summary>
+          ///     The proof status of this term.
+          /// </summary>
+          Status: Z3.Status option }
+
+    /// <summary>
+    ///     Type of models coming out of the Z3 prover.
+    /// </summary>
+    type ZModel = Model<ZTerm, FuncDefiner<BoolExpr<Sym<Var>> option>>
+
+    /// <summary>
+    ///     Type of requests to the Z3 backend.
+    /// </summary>
     type Request =
-        /// Only translate the term views; return `Response.Translate`.
-        | Translate
-        /// Translate and combine term Z3 expressions; return `Response.Combine`.
-        | Combine
-        /// Translate, combine, and run term Z3 expressions; return `Response.Sat`.
-        | Sat
+        /// <summary>
+        ///     Collect the results of SMT elimination in 'name: status' form.
+        ///     <para>
+        ///         This used to be the default output style, and is kept around
+        ///         for regression tests.
+        ///     </para>
+        /// </summary>
+        | SatMap
+        /// <summary>
+        ///     Collect the failures from SMT elimination in expanded form.
+        /// </summary>
+        | Failures
+        /// <summary>
+        ///     Show every proof term, its derivation, and its Z3 status.
+        /// </summary>
+        | AllTerms
+        /// <summary>
+        ///     Show the remaining proof obligations as symbolic Boolean
+        ///     expressions.
+        /// </summary>
+        | RemainingSymBools
 
     /// <summary>
     ///     Type of responses from the Z3 backend.
@@ -50,17 +102,26 @@ module Types =
     [<NoComparison>]
     type Response =
         /// <summary>
-        ///     Output of the term translation step only.
+        ///     Collect the results of SMT elimination in 'name: status' form.
+        ///     <para>
+        ///         This used to be the default output style, and is kept around
+        ///         for regression tests.
+        ///     </para>
         /// </summary>
-        | Translate of Model<ZTerm, unit>
+        | SatMap of Map<string, Z3.Status option>
         /// <summary>
-        ///     Output of the final Z3 terms only.
+        ///     Collect the failures from SMT elimination in expanded form.
         /// </summary>
-        | Combine of Model<Z3.BoolExpr, unit>
+        | Failures of Map<string, ZTerm>
         /// <summary>
-        ///     Output of satisfiability reports for the Z3 terms.
+        ///     Show every proof term, its derivation, and its Z3 status.
         /// </summary>
-        | Sat of Map<string, Z3.Status>
+        | AllTerms of Map<string, ZTerm>
+        /// <summary>
+        ///     Show the remaining proof obligations as symbolic Boolean
+        ///     expressions.
+        /// </summary>
+        | RemainingSymBools of Map<string, BoolExpr<Sym<MarkedVar>>>
 
 
 /// <summary>
@@ -68,91 +129,209 @@ module Types =
 /// </summary>
 module Pretty =
     open Starling.Core.Pretty
+    open Starling.Core.Command.Pretty
     open Starling.Core.Expr.Pretty
+    open Starling.Core.GuardedView.Pretty
     open Starling.Core.Model.Pretty
     open Starling.Core.Instantiate.Pretty
+    open Starling.Core.Symbolic.Pretty
+    open Starling.Core.Var.Pretty
+    open Starling.Core.View.Pretty
     open Starling.Core.Z3.Pretty
 
+    /// Pretty-prints a partial satisfiability result.
+    let printMaybeSat (sat : Z3.Status option) : Doc =
+        match sat with
+        | None -> warning (String "not SMT solvable")
+        | Some s -> printSat s
+
+    /// <summary>
+    ///     Pretty-prints a ZTerm.
+    /// </summary>
+    /// <param name="zterm">The <see cref="ZTerm"/> to pretty-print.</param>
+    /// <returns>
+    ///     A <see cref="Doc"/> capturing <paramref name="zterm"/>.
+    /// </returns>
+    let printZTerm (zterm : ZTerm) : Doc =
+        vsep
+            [ headed "Original term" <|
+                [ printCmdTerm
+                    (printBoolExpr (printSym printMarkedVar))
+                    (printGView (printSym printMarkedVar))
+                    (printVFunc (printSym printMarkedVar))
+                    zterm.Original ]
+              headed "Symbolic conversion" <|
+                [ printCmdTerm
+                    (printBoolExpr (printSym printMarkedVar))
+                    (printBoolExpr (printSym printMarkedVar))
+                    (printBoolExpr (printSym printMarkedVar))
+                    zterm.SymBool ]
+              headed "Z3 expansion" <|
+                [ withDefault (String "None available")
+                    (Option.map (printTerm printZ3Exp printZ3Exp printZ3Exp)
+                        zterm.Z3) ]
+              colonSep [ String "Status"; printMaybeSat zterm.Status ] ]
+
+    /// <summary>
+    ///     Pretty-prints a <see cref="ZTerm"/> as a failure report.
+    /// </summary>
+    /// <param ref="name">The name of the proof term to print.</param>
+    /// <param ref="term">The <see cref="ZTerm"/> to print.</param>
+    /// <returns>
+    ///     The <see cref="Doc"/> corresponding to <paramref name="term"/>.
+    /// </returns>
+    let printFailure (name : string) (term : ZTerm) : Doc =
+        let genpred p =
+            errorInfo (headed "which was translated into" [ p ])
+        cmdHeaded (errorContext (String name) <+> printMaybeSat term.Status)
+            [ cmdHeaded (error (String "Could not prove that this command"))
+                [ printCommand term.Original.Cmd.Cmd
+                  genpred <| printBoolExpr (printSym printMarkedVar) term.Original.Cmd.Semantics ]
+              cmdHeaded (error (String "under the weakest precondition"))
+                [ printGView (printSym printMarkedVar) term.Original.WPre
+                  genpred <| printBoolExpr (printSym printMarkedVar) term.SymBool.WPre ]
+              cmdHeaded (error (String "establishes"))
+                [ printVFunc (printSym printMarkedVar) term.Original.Goal
+                  genpred <| printBoolExpr (printSym printMarkedVar) term.SymBool.Goal ]
+            ]
+
     /// Pretty-prints a response.
-    let printResponse mview =
-        function
-        | Response.Translate m ->
-            printModelView
-                (printTerm printZ3Exp printZ3Exp printZ3Exp)
-                (fun _ -> Seq.empty)
-                mview
-                m
-        | Response.Combine m ->
-            printModelView
-                printZ3Exp
-                (fun _ -> Seq.empty)
-                mview
-                m
-        | Response.Sat s ->
-            printMap Inline String printSat s
+    let printResponse (mview : ModelView) (response : Response) : Doc =
+        match response with
+        | SatMap map -> printMap Inline String printMaybeSat map
+        | Failures map ->
+            if Map.isEmpty map
+            then success (String "No proof failures")
+            else
+                cmdHeaded (error (String "Proof failures"))
+                    (Seq.map (uncurry printFailure) (Map.toSeq map))
+        | AllTerms map -> printMap Indented String printZTerm map
+        | RemainingSymBools map ->
+            printMap Indented String (printBoolExpr (printSym printMarkedVar))
+                map
 
-
-/// <summary>
-///     Functions for translating Starling elements into Z3.
-/// </summary>
-module Translator =
-    open Starling.Core.Z3.Expr
-    ///
-    /// Combines the components of a reified term.
-    let combineTerm reals (ctx: Z3.Context) ({Cmd = c; WPre = w; Goal = g} : CmdTerm<MBoolExpr, MBoolExpr, MBoolExpr>) =
-        (* This is effectively asking Z3 to refute (c ^ w => g).
-         *
-         * This arranges to:
-         *   - ¬(c^w => g) premise
-         *   - ¬(¬(c^w) v g) def. =>
-         *   - ((c^w) ^ ¬g) deMorgan
-         *   - (c^w^¬g) associativity.
-         *)
-        boolToZ3 reals unmarkVar ctx (mkAnd [c.Semantics ; w; mkNot g] )
-
-    /// Combines reified terms into a list of Z3 terms.
-    let combineTerms reals ctx = mapAxioms (combineTerm reals ctx)
-
+/// Runs Z3 on a single term.
+let runTerm (ctx: Z3.Context) term =
+    let solver = ctx.MkSimpleSolver ()
+    solver.Assert [| term |]
+    solver.Check [||]
 
 /// <summary>
-///     Proof execution using Z3.
-/// </summary>
-module Run =
-    /// Runs Z3 on a single term, given the context in `model`.
-    let runTerm (ctx: Z3.Context) _ term =
-        let solver = ctx.MkSimpleSolver()
-        solver.Assert [| term |]
-        solver.Check [||]
-
-    /// Runs Z3 on a model.
-    let run ctx = axioms >> Map.map (runTerm ctx)
-
-
-/// Shorthand for the combination stage of the Z3 pipeline.
-let combine reals = Translator.combineTerms reals
-/// Shorthand for the satisfiability stage of the Z3 pipeline.
-let sat = Run.run
-
-/// <summary>
-///     The Starling Z3 backend driver.
+///     Uses Z3 to mark some proof terms as eliminated.
 /// </summary>
 /// <param name="reals">
 ///     Whether to use Real instead of Int.
 ///     This can be faster, but is slightly inaccurate.
 /// </param>
-/// <param name="req">
-///     The request to handle.
-/// </param>
+/// <param name="model">The model to translate and part-solve.</param>
 /// <returns>
-///     A function implementing the chosen Z3 backend process.
+///     A model with proof terms marked up with their SMT solver results.
 /// </returns>
-let run reals req : Model<ProofTerm, unit> -> Response =
-    use ctx = new Z3.Context()
-    match req with
-    | Request.Translate ->
-        (mapAxioms (mapTerm (fun c -> Expr.boolToZ3 reals unmarkVar ctx c.Semantics)
-                            (Expr.boolToZ3 reals unmarkVar ctx)
-                            (Expr.boolToZ3 reals unmarkVar ctx)))
-        >> Response.Translate
-    | Request.Combine -> combine reals ctx >> Response.Combine
-    | Request.Sat -> combine reals ctx >> sat ctx >> Response.Sat
+let eliminate
+  (reals: bool)
+  (model : Model<SymProofTerm, FuncDefiner<BoolExpr<Sym<Var>> option>>)
+  : ZModel =
+    use ctx = new Z3.Context ()
+
+    // Try to remove symbols from boolean expressions: don't error if we can't
+    let removeSym bexp =
+        let _, res = Mapper.mapBoolCtx (tsfRemoveSym id) NoCtx bexp
+        okOption res
+
+    let z3Term (term : SymProofTerm) : ZTerm =
+        // We can only run Z3 if the symbool has no symbols in it.
+        let cmdO = removeSym term.SymBool.Cmd.Semantics
+        let wpreO = removeSym term.SymBool.WPre
+        let goalO = removeSym term.SymBool.Goal
+
+        let z3, status =
+            match cmdO, wpreO, goalO with
+            | Some cmd, Some wpre, Some goal ->
+                (* This is mainly for auditing purposes: we don't use it in the
+                   proof.  Instead, we combine cmd, wpre, and goal _before_
+                   converting to Z3. *)
+                let z =
+                    { Cmd = Expr.boolToZ3 reals unmarkVar ctx cmd
+                      WPre = Expr.boolToZ3 reals unmarkVar ctx wpre
+                      Goal = Expr.boolToZ3 reals unmarkVar ctx goal }
+
+                (* This is effectively asking Z3 to refute (c ^ w => g).
+                 *
+                 * This arranges to:
+                 *   - ¬(c^w => g) premise
+                 *   - ¬(¬(c^w) v g) def. =>
+                 *   - ((c^w) ^ ¬g) deMorgan
+                 *   - (c^w^¬g) associativity.
+                 *)
+                let combined =
+                    Expr.boolToZ3 reals unmarkVar ctx
+                        (mkAnd [ cmd; wpre; mkNot goal ])
+
+                // This bit actually runs Z3 on the term.
+                let s = runTerm ctx combined
+                Some z, Some s
+            | _ -> None, None
+
+        { Original = term.Original
+          SymBool = term.SymBool
+          Z3 = z3
+          Status = status }
+
+    mapAxioms z3Term model
+
+/// <summary>
+///     Extracts the satisfiability results from a system of
+///     <see cref="ZTerm"/>s inside a model.
+/// </summary>
+/// <param name="model">The model to convert.</param>
+/// <returns>
+///     The satisfiability results, as a map from term names to Z3 statuses.
+/// </returns>
+let extractSats (model : ZModel) : Map<string, Z3.Status option> =
+    let zterms = model.Axioms
+    Map.map (fun _ v -> v.Status) zterms
+
+/// <summary>
+///     Extracts the proof failures from a system of
+///     <see cref="ZTerm"/>s inside a model.
+/// </summary>
+/// <param name="model">The model to convert.</param>
+/// <returns>
+///     The map of <see cref="ZTerm"/>s that failed SMT solving.
+/// </returns>
+let extractFailures (model : ZModel) : Map<string, ZTerm> =
+    let axseq = Map.toSeq model.Axioms
+    let failseq =
+        // Remember: we're trying to prove _unsat_ here.
+        Seq.filter (fun (_, v) -> v.Status <> Some Z3.Status.UNSATISFIABLE)
+            axseq
+    Map.ofSeq failseq
+
+/// <summary>
+///     Uses the SMT eliminator as a proof backend.
+/// </summary>
+/// <param name="reals">
+///     Whether to use Real instead of Int.
+///     This can be faster, but is slightly inaccurate.
+/// </param>
+/// <param name="request">The backend request to implement.</param>
+/// <param name="model">The model after SMT elimination.</param>
+/// <returns>
+///     A model with proof terms marked up with their SMT solver results.
+/// </returns>
+let backend (reals: bool) (request : Request) (model : ZModel)
+  : Response =
+    // TODO(CaptainHayashi): reject if any deferred checks.
+    match request with
+    | Request.SatMap -> SatMap (extractSats model)
+    | Request.AllTerms -> AllTerms (model.Axioms)
+    | Request.Failures -> Failures (extractFailures model)
+    | Request.RemainingSymBools ->
+        RemainingSymBools
+            (Map.map
+                (fun _ v ->
+                    mkAnd
+                        [ v.SymBool.Cmd.Semantics
+                          v.SymBool.WPre
+                          mkNot v.SymBool.Goal ])
+                model.Axioms)

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -212,12 +212,6 @@ module Pretty =
             printMap Indented String (printBoolExpr (printSym printMarkedVar))
                 map
 
-/// Runs Z3 on a single term.
-let runTerm (ctx: Z3.Context) term =
-    let solver = ctx.MkSimpleSolver ()
-    solver.Assert [| term |]
-    solver.Check [||]
-
 /// <summary>
 ///     Uses Z3 to mark some proof terms as eliminated.
 ///     If approximates were enabled, Z3 will prove them instead of the
@@ -277,7 +271,7 @@ let eliminate (reals : bool)
                         (mkAnd [ cmd; wpre; mkNot goal ])
 
                 // This bit actually runs Z3 on the term.
-                let s = runTerm ctx combined
+                let s = Starling.Core.Z3.Run.runTerm ctx combined
                 Some z, Some s
             | _ -> None, None
 

--- a/Z3Backend.fs
+++ b/Z3Backend.fs
@@ -281,7 +281,7 @@ let runZ3OnModel (shouldUseRealsForInts : bool)
               SymBool = term.SymBool
               Z3 = None
               Status = None }
-              
+
         // Now, see if we can fill them in.
         match cmdO, wpreO, goalO with
         | Some cmd, Some wpre, Some goal ->
@@ -361,5 +361,5 @@ let backend (request : Request) (model : ZModel) : Response =
                 (fun _ v ->
                     mkAnd
                         [ v.SymBool.Cmd; v.SymBool.WPre; mkNot v.SymBool.Goal ])
-                model.Axioms,
+                (extractFailures model),
              dcs)

--- a/starling-hsf.sh
+++ b/starling-hsf.sh
@@ -20,7 +20,8 @@ then
 fi
 
 echo "--- STARLING ---"
-./starling.sh -shsf $* | tee $tempfile
+# no-smt-reduce is needed to give HSF enough contraints to be practical.
+./starling.sh -shsf -Bno-smt-reduce $* | tee $tempfile
 echo "--- HSF ---"
 $QARMC -get-model $tempfile
 rm $tempfile

--- a/starling.fsproj
+++ b/starling.fsproj
@@ -59,6 +59,7 @@
     <Compile Include="Z3.fs" />
     <Compile Include="ExprEquiv.fs" />
     <Compile Include="Command.fs" />
+    <Compile Include="Definer.fs" />
     <Compile Include="Model.fs" />
     <Compile Include="GuardedView.fs" />
     <Compile Include="Axiom.fs" />


### PR DESCRIPTION
As above.

This also rearranges the Z3 backend to serve as a preprocessor for subsequent backends.  This works well if the Z3 output is going to grasshopper or a human, but poorly if it's going to HSF (and possibly even soundness-breaking if it's going to MuZ3?), so I might change the default option to suppress it if people think that'd be better.

Z3 also has a few new output stages to print failures in more detail (`smt-failures`), amongst others.  `sat` has been renamed `smt-sat` and now reports any proof terms Z3 can't solve but another solver can.

While doing this work I seem to have found some soundness and completeness bugs in MuZ3 (as in, I don't think the backend is working at all!), but I haven't addressed them here.
