### PR TITLE
Added `disjoint` and `exclusive` constraints

### DIFF
--- a/AST.fs
+++ b/AST.fs
@@ -214,6 +214,7 @@ module Types =
         | Search of int // search 0;
         | ViewProtos of ViewProto list // view name(int arg);
         | Constraint of ViewSignature * Expression option // constraint emp => true
+        | Exclusive of List<ViewSignature> // exclusive p(x), q(x), r(x) 
         override this.ToString() = sprintf "%A" this
     and ScriptItem = Node<ScriptItem'>
 
@@ -310,6 +311,12 @@ module Pretty =
                (match def with
                 | Some d -> printExpression d
                 | None _ -> String "?" |> syntax) ]
+        |> withSemi
+
+    /// Pretty-prints exclusivity constraints.
+    let printExclusive (xs : List<ViewSignature>) : Doc =
+        hsep ((String "exclusive") :: 
+              (List.map printViewSignature xs)) 
         |> withSemi
 
     /// Pretty-prints fetch modes.
@@ -473,6 +480,7 @@ module Pretty =
         | ViewProtos v -> printViewProtoList v
         | Search i -> printSearch i
         | Constraint (view, def) -> printConstraint view def
+        | Exclusive xs -> printExclusive xs 
     let printScriptItem (x : ScriptItem) : Doc = printScriptItem' x.Node
 
     /// Pretty-prints scripts.

--- a/AST.fs
+++ b/AST.fs
@@ -100,6 +100,9 @@ module Types =
     /// An AST func.
     type AFunc = Func<Expression>
 
+    /// A function view definition
+    type strFunc = Func<string> 
+
     /// <summary>
     ///     An AST type literal.
     ///     <para>
@@ -214,7 +217,8 @@ module Types =
         | Search of int // search 0;
         | ViewProtos of ViewProto list // view name(int arg);
         | Constraint of ViewSignature * Expression option // constraint emp => true
-        | Exclusive of List<ViewSignature> // exclusive p(x), q(x), r(x) 
+        | Exclusive of List<strFunc> // exclusive p(x), q(x), r(x) 
+        // | Disjoint of List<Func<string>> // disjoint p(x), q(x), r(x) 
         override this.ToString() = sprintf "%A" this
     and ScriptItem = Node<ScriptItem'>
 
@@ -314,10 +318,16 @@ module Pretty =
         |> withSemi
 
     /// Pretty-prints exclusivity constraints.
-    let printExclusive (xs : List<ViewSignature>) : Doc =
+    let printExclusive (xs : List<strFunc>) : Doc =
         hsep ((String "exclusive") :: 
-              (List.map printViewSignature xs)) 
+              (List.map (printFunc String) xs)) 
         |> withSemi
+
+    /// Pretty-prints exclusivity constraints.
+    // let printDisjoint (xs : List<ViewSignature>) : Doc =
+    //     hsep ((String "disjoint") :: 
+    //           (List.map (printFunc String) xs)) 
+    //     |> withSemi
 
     /// Pretty-prints fetch modes.
     let printFetchMode : FetchMode -> Doc =
@@ -481,6 +491,7 @@ module Pretty =
         | Search i -> printSearch i
         | Constraint (view, def) -> printConstraint view def
         | Exclusive xs -> printExclusive xs 
+        // | Disjoint xs -> printDisjoint xs 
     let printScriptItem (x : ScriptItem) : Doc = printScriptItem' x.Node
 
     /// Pretty-prints scripts.

--- a/AST.fs
+++ b/AST.fs
@@ -146,8 +146,8 @@ module Types =
     type ViewSignature =
         | Unit
         | Join of ViewSignature * ViewSignature
-        | Func of Func<string>
-        | Iterated of Func<string> * string
+        | Func of strFunc 
+        | Iterated of strFunc * string
 
     /// <summary>
     ///     An AST variable declaration.
@@ -218,7 +218,7 @@ module Types =
         | ViewProtos of ViewProto list // view name(int arg);
         | Constraint of ViewSignature * Expression option // constraint emp => true
         | Exclusive of List<strFunc> // exclusive p(x), q(x), r(x) 
-        // | Disjoint of List<Func<string>> // disjoint p(x), q(x), r(x) 
+        | Disjoint of List<strFunc> // disjoint p(x), q(x), r(x) 
         override this.ToString() = sprintf "%A" this
     and ScriptItem = Node<ScriptItem'>
 
@@ -324,10 +324,10 @@ module Pretty =
         |> withSemi
 
     /// Pretty-prints exclusivity constraints.
-    // let printDisjoint (xs : List<ViewSignature>) : Doc =
-    //     hsep ((String "disjoint") :: 
-    //           (List.map (printFunc String) xs)) 
-    //     |> withSemi
+    let printDisjoint (xs : List<strFunc>) : Doc =
+        hsep ((String "disjoint") :: 
+              (List.map (printFunc String) xs)) 
+        |> withSemi
 
     /// Pretty-prints fetch modes.
     let printFetchMode : FetchMode -> Doc =
@@ -491,7 +491,7 @@ module Pretty =
         | Search i -> printSearch i
         | Constraint (view, def) -> printConstraint view def
         | Exclusive xs -> printExclusive xs 
-        // | Disjoint xs -> printDisjoint xs 
+        | Disjoint xs -> printDisjoint xs 
     let printScriptItem (x : ScriptItem) : Doc = printScriptItem' x.Node
 
     /// Pretty-prints scripts.

--- a/AST.fs
+++ b/AST.fs
@@ -101,7 +101,7 @@ module Types =
     type AFunc = Func<Expression>
 
     /// A function view definition
-    type strFunc = Func<string> 
+    type StrFunc = Func<string> 
 
     /// <summary>
     ///     An AST type literal.
@@ -146,8 +146,8 @@ module Types =
     type ViewSignature =
         | Unit
         | Join of ViewSignature * ViewSignature
-        | Func of strFunc 
-        | Iterated of strFunc * string
+        | Func of StrFunc 
+        | Iterated of StrFunc * string
 
     /// <summary>
     ///     An AST variable declaration.
@@ -217,8 +217,8 @@ module Types =
         | Search of int // search 0;
         | ViewProtos of ViewProto list // view name(int arg);
         | Constraint of ViewSignature * Expression option // constraint emp => true
-        | Exclusive of List<strFunc> // exclusive p(x), q(x), r(x) 
-        | Disjoint of List<strFunc> // disjoint p(x), q(x), r(x) 
+        | Exclusive of List<StrFunc> // exclusive p(x), q(x), r(x) 
+        | Disjoint of List<StrFunc> // disjoint p(x), q(x), r(x) 
         override this.ToString() = sprintf "%A" this
     and ScriptItem = Node<ScriptItem'>
 
@@ -318,13 +318,13 @@ module Pretty =
         |> withSemi
 
     /// Pretty-prints exclusivity constraints.
-    let printExclusive (xs : List<strFunc>) : Doc =
+    let printExclusive (xs : List<StrFunc>) : Doc =
         hsep ((String "exclusive") :: 
               (List.map (printFunc String) xs)) 
         |> withSemi
 
     /// Pretty-prints exclusivity constraints.
-    let printDisjoint (xs : List<strFunc>) : Doc =
+    let printDisjoint (xs : List<StrFunc>) : Doc =
         hsep ((String "disjoint") :: 
               (List.map (printFunc String) xs)) 
         |> withSemi

--- a/Collator.fs
+++ b/Collator.fs
@@ -109,14 +109,14 @@ let rec makeExclusive views =
     | [] -> [] 
 
 
-let rec makeDisjoint (xs : List<strFunc>) = 
+let rec makeDisjoint (xs : List<StrFunc>) = 
 
     let str2Expr (s : string) : Expression = 
       freshNode (Identifier s) 
 
     let makeNeqArgs 
-         ({Name = fx; Params = px}: strFunc) 
-         ({Name = fy; Params = py}: strFunc) : Expression = 
+         ({Name = fx; Params = px}: StrFunc) 
+         ({Name = fy; Params = py}: StrFunc) : Expression = 
       List.zip (List.map str2Expr px) (List.map str2Expr py) 
       |> 
       List.map (fun (a,b) -> freshNode (BopExpr(Neq,a,b))) 
@@ -125,7 +125,7 @@ let rec makeDisjoint (xs : List<strFunc>) =
         (fun acc e -> freshNode (BopExpr(Or,acc,e))) 
         (freshNode False) 
 
-    let makeJoin (x: strFunc) (y: strFunc)  = 
+    let makeJoin (x: StrFunc) (y: StrFunc)  = 
       ViewSignature.Join (ViewSignature.Func x, ViewSignature.Func y)
  
     let makeDisjointSingle x xs = 

--- a/Examples/WIP/constraintSugar.cvf
+++ b/Examples/WIP/constraintSugar.cvf
@@ -1,0 +1,3 @@
+view foo(), bar(), baz(int x); 
+
+exclusive foo(), bar(), baz(x); 

--- a/Examples/WIP/constraintSugar.cvf
+++ b/Examples/WIP/constraintSugar.cvf
@@ -1,7 +1,7 @@
 view foo(int x), bar(int y), baz(int x); 
 view foo2(), bar2(), baz2(); 
 
-exclusive foo(x), bar(y), baz(z); 
+exclusive foo(x), bar(y), baz(z) ; 
 
 disjoint foo(x), bar(y), baz(z); 
 disjoint foo2(), bar2(), baz2(); 

--- a/Examples/WIP/constraintSugar.cvf
+++ b/Examples/WIP/constraintSugar.cvf
@@ -1,5 +1,7 @@
 view foo(int x), bar(int y), baz(int x); 
+view foo2(), bar2(), baz2(); 
 
-exclusive foo(x), bar(y), baz(x); 
+exclusive foo(x), bar(y), baz(z); 
 
-// disjoint foo(x), bar(y), baz(z); 
+disjoint foo(x), bar(y), baz(z); 
+disjoint foo2(), bar2(), baz2(); 

--- a/Examples/WIP/constraintSugar.cvf
+++ b/Examples/WIP/constraintSugar.cvf
@@ -1,3 +1,5 @@
-view foo(), bar(), baz(int x); 
+view foo(int x), bar(int y), baz(int x); 
 
-exclusive foo(), bar(), baz(x); 
+exclusive foo(x), bar(y), baz(x); 
+
+// disjoint foo(x), bar(y), baz(z); 

--- a/Parser.fs
+++ b/Parser.fs
@@ -409,7 +409,7 @@ let parseViewExpr =
  *)
 
 /// Parses a functional view definition.
-let parseDFuncView = parseFunc parseIdentifier |>> ViewSignature.Func
+let parsestrFuncView = parseFunc parseIdentifier |>> ViewSignature.Func
 
 /// Parses the unit view definition.
 let parseDUnit = stringReturn "emp" ViewSignature.Unit
@@ -437,7 +437,7 @@ let parseDIterated =
 let parseBasicViewSignature =
     choice [ parseDUnit
              // ^- `emp'
-             parseDFuncView
+             parsestrFuncView
              // ^- <identifier>
              //  | <identifier> <arg-list>
              inParens parseViewSignature ]
@@ -587,10 +587,17 @@ let parseConstraint : Parser<ViewSignature * Expression option, unit> =
 
 
 /// parse an exclusivity constraint
-let parseExclusive : Parser<List<ViewSignature>, unit> = 
+let parseExclusive : Parser<List<strFunc>, unit> = 
     pstring "exclusive" >>. ws
     // ^- exclusive ..  
-    >>. parseDefs parseViewSignature
+    >>. parseDefs (parseFunc parseIdentifier)
+    .>> pstring ";" 
+       
+/// parse a disjointness constraint
+let parseDisjoint : Parser<List<strFunc>, unit> = 
+    pstring "disjoint" >>. ws
+    // ^- exclusive ..  
+    >>. parseDefs (parseFunc parseIdentifier) 
     .>> pstring ";" 
        
 
@@ -629,6 +636,8 @@ let parseScript =
                              // ^- constraint <view> -> <expression> ;
                              parseExclusive |>> Exclusive
                              // ^- exclusive <view>, <view>, ... ;
+                             // parseDisjoint |>> Disjoint
+                             // ^- disjoint <view>, <view>, ... ;
                              parseViewProtoSet |>> ViewProtos
                              // ^- view <identifier> ;
                              //  | view <identifier> <view-proto-param-list> ;

--- a/Parser.fs
+++ b/Parser.fs
@@ -585,6 +585,15 @@ let parseConstraint : Parser<ViewSignature * Expression option, unit> =
             (fun d _ v -> (d, v))
     .>> pstring ";"
 
+
+/// parse an exclusivity constraint
+let parseExclusive : Parser<List<ViewSignature>, unit> = 
+    pstring "exclusive" >>. ws
+    // ^- exclusive ..  
+    >>. parseDefs parseViewSignature
+    .>> pstring ";" 
+       
+
 /// Parses a single method, excluding leading or trailing whitespace.
 let parseMethod =
     pstring "method" >>. ws >>.
@@ -618,6 +627,8 @@ let parseScript =
                              // ^- method <identifier> <arg-list> <block>
                              parseConstraint |>> Constraint
                              // ^- constraint <view> -> <expression> ;
+                             parseExclusive |>> Exclusive
+                             // ^- exclusive <view>, <view>, ... ;
                              parseViewProtoSet |>> ViewProtos
                              // ^- view <identifier> ;
                              //  | view <identifier> <view-proto-param-list> ;

--- a/Parser.fs
+++ b/Parser.fs
@@ -409,7 +409,7 @@ let parseViewExpr =
  *)
 
 /// Parses a functional view definition.
-let parsestrFuncView = parseFunc parseIdentifier |>> ViewSignature.Func
+let parseStrFuncView = parseFunc parseIdentifier |>> ViewSignature.Func
 
 /// Parses the unit view definition.
 let parseDUnit = stringReturn "emp" ViewSignature.Unit
@@ -437,7 +437,7 @@ let parseDIterated =
 let parseBasicViewSignature =
     choice [ parseDUnit
              // ^- `emp'
-             parsestrFuncView
+             parseStrFuncView
              // ^- <identifier>
              //  | <identifier> <arg-list>
              inParens parseViewSignature ]
@@ -587,18 +587,18 @@ let parseConstraint : Parser<ViewSignature * Expression option, unit> =
 
 
 /// parse an exclusivity constraint
-let parseExclusive : Parser<List<strFunc>, unit> = 
+let parseExclusive : Parser<List<StrFunc>, unit> = 
     pstring "exclusive" >>. ws
     // ^- exclusive ..  
     >>. parseDefs (parseFunc parseIdentifier)
-    .>> pstring ";" 
+    .>> wsSemi 
        
 /// parse a disjointness constraint
-let parseDisjoint : Parser<List<strFunc>, unit> = 
+let parseDisjoint : Parser<List<StrFunc>, unit> = 
     pstring "disjoint" >>. ws
     // ^- exclusive ..  
     >>. parseDefs (parseFunc parseIdentifier) 
-    .>> pstring ";" 
+    .>> wsSemi 
        
 
 /// Parses a single method, excluding leading or trailing whitespace.

--- a/Parser.fs
+++ b/Parser.fs
@@ -636,7 +636,7 @@ let parseScript =
                              // ^- constraint <view> -> <expression> ;
                              parseExclusive |>> Exclusive
                              // ^- exclusive <view>, <view>, ... ;
-                             // parseDisjoint |>> Disjoint
+                             parseDisjoint |>> Disjoint
                              // ^- disjoint <view>, <view>, ... ;
                              parseViewProtoSet |>> ViewProtos
                              // ^- view <identifier> ;


### PR DESCRIPTION
Currently doesn't check well-formedness of the views, so you'll get weird results or crashes if: 
 1. argument vars are reused in the same disjoint / exclusive clause
 2. atomic views have different arities. 