### PR TITLE
Minor quality of life changes (split off from #66)

### DIFF
--- a/AST.fs
+++ b/AST.fs
@@ -164,7 +164,7 @@ module Types =
         | ThreadVars of Type * Var list // thread int name1, name2, name3;
         | Method of CMethod<Marked<View>> // method main(argv, argc) { ... }
         | Search of int // search 0;
-        | ViewProto of ViewProto // view name(int arg);
+        | ViewProtos of ViewProto list // view name(int arg);
         | Constraint of ViewSignature * Expression option // constraint emp => true
         override this.ToString() = sprintf "%A" this
     and ScriptItem = Node<ScriptItem'>
@@ -367,6 +367,11 @@ module Pretty =
                    squared (String i)]
             |> withSemi
 
+    /// Pretty-prints a view prototype.
+    let printViewProtoList (vps : ViewProto list) : Doc =
+        hsep [ syntax (String "view")
+               commaSep (List.map printViewProto vps) ]
+
     /// Pretty-prints a search directive.
     let printSearch (i : int) : Doc =
         hsep [ String "search" |> syntax
@@ -385,7 +390,7 @@ module Pretty =
         | Method m ->
             fun mdoc -> vsep [Nop; mdoc; Nop]
             <| printMethod (printMarkedView printView) (printCommand (printMarkedView printView)) m
-        | ViewProto v -> printViewProto v
+        | ViewProtos v -> printViewProtoList v
         | Search i -> printSearch i
         | Constraint (view, def) -> printConstraint view def
     let printScriptItem (x : ScriptItem) : Doc = printScriptItem' x.Node

--- a/AST.fs
+++ b/AST.fs
@@ -125,10 +125,10 @@ module Types =
     type Command'<'view> =
         /// A set of sequentially composed primitives.
         | Prim of PrimSet
-        /// An if-then-else statement.
-        | If of Expression
-              * Block<'view, Command<'view>>
-              * Block<'view, Command<'view>>
+        /// An if-then-else statement, with optional else.
+        | If of ifCond : Expression
+              * thenBlock : Block<'view, Command<'view>>
+              * elseBlock : Block<'view, Command<'view>> option
         /// A while loop.
         | While of Expression
                  * Block<'view, Command<'view>>
@@ -324,26 +324,26 @@ module Pretty =
                          |> semiSep |> withSemi |> braced |> angled)
                   yield! Seq.map (uncurry printAssign) qs }
             |> semiSep |> withSemi
-        | Command'.If(c, t, f) ->
+        | Command'.If(c, t, fo) ->
             hsep [ "if" |> String |> syntax
-                   c
-                   |> printExpression
-                   |> parened
+                   c |> printExpression |> parened
                    t |> printBlock pView (printCommand pView)
-                   f |> printBlock pView (printCommand pView) ]
+                   (withDefault Nop
+                        (Option.map
+                            (fun f ->
+                                hsep
+                                    [ "else" |> String |> syntax
+                                      printBlock pView (printCommand pView) f ])
+                            fo)) ]
         | Command'.While(c, b) ->
             hsep [ "while" |> String |> syntax
-                   c
-                   |> printExpression
-                   |> parened
+                   c |> printExpression |> parened
                    b |> printBlock pView (printCommand pView) ]
         | Command'.DoWhile(b, c) ->
             hsep [ "do" |> String |> syntax
                    b |> printBlock pView (printCommand pView)
                    "while" |> String |> syntax
-                   c
-                   |> printExpression
-                   |> parened ]
+                   c |> printExpression |> parened ]
             |> withSemi
         | Command'.Blocks bs ->
             bs

--- a/Collator.fs
+++ b/Collator.fs
@@ -61,7 +61,7 @@ module Pretty =
             withSemi (hsep [ String cls |> syntax; printTypedVar v ])
 
         let definites =
-            [ vsep <| Seq.map printViewProto cs.VProtos
+            [ vsep <| Seq.map (fun p -> printViewProtoList [p]) cs.VProtos
               vsep <| Seq.map (printScriptVar "shared") cs.SharedVars
               vsep <| Seq.map (printScriptVar "thread") cs.ThreadVars
               vsep <| Seq.map (uncurry printConstraint) cs.Constraints
@@ -114,7 +114,7 @@ let collate (script : ScriptItem list) : CollatedScript =
             // Flatten eg. 'int x, y, z' into 'int x; int y; int z'.
             let s = List.map (withType t) vs
             { cs with ThreadVars = s @ cs.ThreadVars }
-        | ViewProto v -> { cs with VProtos = v::cs.VProtos }
+        | ViewProtos v -> { cs with VProtos = v @ cs.VProtos }
         | Search i -> { cs with Search = Some i }
         | Method m -> { cs with Methods = m::cs.Methods }
         | Constraint (v, d) -> { cs with Constraints = (v, d)::cs.Constraints }

--- a/Examples/Pass/arc.cvf
+++ b/Examples/Pass/arc.cvf
@@ -53,7 +53,7 @@ method drop() {
 }
 
 view error();
-view arc()[n];
+view iter[n] arc();
 view noCnt();
 
 // These views just add free=f and count=c to the final proof predicates

--- a/Examples/Pass/arc.cvf
+++ b/Examples/Pass/arc.cvf
@@ -22,8 +22,6 @@ method print() {
     // Test for disposal
     if (f == true) {
       {| error() |} ; {| error() |}
-    } else {
-      {| arc() |} ; {| arc() |}
     }
   {| arc() |}
 }
@@ -36,8 +34,6 @@ method drop() {
       {| noCnt() |}
         <free = (true)>;
       {| emp |}
-    } else {
-      {| emp |} ; {| emp |}
     }
   {| emp |}
 }

--- a/Examples/Pass/arc.cvf
+++ b/Examples/Pass/arc.cvf
@@ -8,13 +8,9 @@ shared int count;
 thread bool f;
 thread int c;
 
-thread bool dummy; // used in dummy skips
-
 // Assumption: clone() cannot be called when there are no references
 method clone() {
-  {| arc() |}
-    < count++ >;
-  {| arc() * arc() |}
+  {| arc() |} < count++ >; {| arc() * arc() |}
 }
 
 // Try to prove that print() when holding a reference is always valid
@@ -25,13 +21,9 @@ method print() {
   {| arc() * specialViewForFree(f) |}
     // Test for disposal
     if (f == true) {
-      {| error() |}
-        dummy = dummy; // skip;
-      {| error() |}
+      {| error() |} ; {| error() |}
     } else {
-      {| arc() |}
-        dummy = dummy; // skip;
-      {| arc() |}
+      {| arc() |} ; {| arc() |}
     }
   {| arc() |}
 }
@@ -45,9 +37,7 @@ method drop() {
         <free = (true)>;
       {| emp |}
     } else {
-      {| emp |}
-        dummy = dummy; // skip;
-      {| emp |}
+      {| emp |} ; {| emp |}
     }
   {| emp |}
 }

--- a/Examples/Pass/singleWriterMultiReaderLock.cvf
+++ b/Examples/Pass/singleWriterMultiReaderLock.cvf
@@ -32,7 +32,7 @@ method readAcquire() {
       {| if r > (m - 1) then holdInnerLock() else canHoldReadLock() |}
     } while (r > (m - 1));
   {| canHoldReadLock() |}
-  
+
   <readCount++>;
   {| holdInnerLock() * holdReadLock() |}
     <serving++>;
@@ -77,16 +77,11 @@ method writeRelease() {
 }
 
 
-//Utility predicate
-view Lift(bool b);
-constraint Lift(b)                              -> b;
-
-
 view holdTick(int t);
 view holdInnerLock();
 view holdWriteLock();
 view canHoldReadLock();
-view holdReadLock()[n];
+view iter[n] holdReadLock();
 
 // Invariant
 constraint emp                                  -> ticket >= serving && readCount >= 0 && maxCount > 0;

--- a/Flattener.fs
+++ b/Flattener.fs
@@ -109,17 +109,17 @@ let flatten
   : Model<Term<_, GView<Sym<MarkedVar>>, SMVFunc>,
           FuncDefiner<SVBoolExpr option>> =
     /// Build a function making a list of global arguments, for view assertions.
-    let globalsF marker = varMapToExprs (marker >> Reg) model.Globals
+    let globalsF marker = varMapToExprs (marker >> Reg) model.SharedVars
 
     /// Build a list of global parameters, for view definitions.
     let globalsP =
-        model.Globals
+        model.SharedVars
         |> Map.toSeq
         |> Seq.map (fun (name, ty) -> withType ty name)
         |> List.ofSeq
 
-    { Globals = model.Globals
-      Locals = model.Locals
+    { SharedVars = model.SharedVars
+      ThreadVars = model.ThreadVars
       Axioms = Map.map (fun _ x -> flattenTerm globalsF x) model.Axioms
       ViewDefs =
           model.ViewDefs

--- a/Graph.fs
+++ b/Graph.fs
@@ -387,7 +387,14 @@ let unify (src : NodeID) (dest : NodeID) (graph : Graph) : Graph option =
                     |> Set.map swapIn
                     |> if name = dest then Set.union srcIn else id
 
-                Some (name, (view, newOut, newIn, unifyNodeKind nodeKind nodeKind2))
+                (* If we are the destination, then we need to merge in the
+                   source's node kind. *)
+                let newNodeKind =
+                    if name = dest
+                    then unifyNodeKind nodeKind nodeKind2
+                    else nodeKind2
+
+                Some (name, (view, newOut, newIn, newNodeKind))
 
         let contents =
             graph.Contents

--- a/Grapher.fs
+++ b/Grapher.fs
@@ -135,7 +135,8 @@ let rec graphWhile
 ///     The block of actions inside the true leg of the if statement.
 /// </param>
 /// <param name="inFalse">
-///     The block of actions inside the false leg of the if statement.
+///     The block of actions inside the false leg of the if statement,
+///     which is optional (there may be no false leg).
 /// </param>
 /// <returns>
 ///     A Chessie result containing the graph of this if statement.
@@ -147,7 +148,7 @@ and graphITE
   (oQ : NodeID)
   (expr : SVBoolExpr)
   (inTrue : GuarderBlock)
-  (inFalse : GuarderBlock)
+  (inFalse : GuarderBlock option)
   : Result<Subgraph, Error> =
     (* First, we need to convert the expression into an assert.
        This means we cast it into the pre-state, as it is diverging the
@@ -155,29 +156,44 @@ and graphITE
        false. *)
     let _, exprB = Mapper.mapBoolCtx before NoCtx expr
 
-    // Translating [|oP|] if (C) { [|tP|] [|tQ|] } else { [|fP|] [|fQ|] } [|oQ|].
     trial {
-        (* We presume oP and oQ are added into the nodes list by the caller,
-         * and that tP and tQ are returned in tGraph (and fP/fQ in fGraph).
-         * This means the nodes we return are tGraph and fGraph.
-         *)
+        (* We definitely have an inner graph for the true leg, so get that
+           out of the way first. *)
         let! tP, tQ, tGraph = graphBlock false vg cg inTrue
-        let! fP, fQ, fGraph = graphBlock false vg cg inFalse
-        let! tfGraph = combine tGraph fGraph
 
-        let cEdges =
+        // We also definitely have these edges.
+        let tEdges =
             [ // {|oP|} assume C {|tP|}: enter true block
               (cg (), edge oP (cAssume exprB) tP)
               // {|tQ|} id {|oQ|}: exit true block
-              (cg (), edge tQ cId oQ)
-              // {|oP|} assume ¬C {|fP|}: enter false block
-              (cg (), edge oP (cAssumeNot exprB) fP)
-              // {|fQ|} id {|oQ|}: exit false block
-              (cg (), edge fQ cId oQ) ]
+              (cg (), edge tQ cId oQ) ]
+
+        // Model the remainder, which depends on whether we have a false leg.
+        let! tfGraph, fEdges =
+            match inFalse with
+            | None ->
+                // [|oP|] if (C) { [|tP|] [|tQ|] } [|oQ|].
+                ok
+                    (// No additional graph for the false leg
+                     tGraph,
+                     // {|oP|} assume ¬C {|fP|}: bypass true block
+                     [ cg (), edge oP (cAssumeNot exprB) oQ ])
+            | Some f ->
+                // [|oP|] if (C) { [|tP|] [|tQ|] } else { [|fP|] [|fQ|] } [|oQ|].
+                trial {
+                    let! fP, fQ, fGraph = graphBlock false vg cg f
+                    let! tfGraph = combine tGraph fGraph
+
+                    return
+                        (tfGraph,
+                         [ // {|oP|} assume ¬C {|fP|}: enter false block
+                           (cg (), edge oP (cAssumeNot exprB) fP)
+                           // {|fQ|} id {|oQ|}: exit false block
+                           (cg (), edge fQ cId oQ) ]) }
 
         // We don't add anything into the graph here.
         let cGraph = { Nodes = Map.empty
-                       Edges = Map.ofSeq cEdges }
+                       Edges = Map.ofSeq (Seq.append tEdges fEdges) }
 
         return! combine cGraph tfGraph }
 

--- a/GuardedView.fs
+++ b/GuardedView.fs
@@ -638,7 +638,7 @@ module Sub =
             Position.changePos
                 id
                 (subExprInVFunc sub)
-                context
+                contextC
                 item
 
         (context', { Cond = cond'; Item = item' } )

--- a/Guarder.fs
+++ b/Guarder.fs
@@ -72,7 +72,7 @@ and guardPartCmd : ModellerPartCmd -> GuarderPartCmd =
     | While (isDo, expr, inner) ->
         While (isDo, expr, guardBlock inner)
     | ITE (expr, inTrue, inFalse) ->
-        ITE (expr, guardBlock inTrue, guardBlock inFalse)
+        ITE (expr, guardBlock inTrue, Option.map guardBlock inFalse)
 
 /// Converts a method to guarded views.
 let guardMethod

--- a/Horn.fs
+++ b/Horn.fs
@@ -447,7 +447,7 @@ let hsfTerm
 
 /// Constructs a HSF script for a model.
 let hsfModel
-  ({ Globals = sharedVars; ViewDefs = definer; Axioms = xs }
+  ({ SharedVars = sharedVars; ViewDefs = definer; Axioms = xs }
      : Model<CmdTerm<MBoolExpr, GView<MarkedVar>, MVFunc>,
              FuncDefiner<BoolExpr<Var> option>>)
   : Result<Horn list, Error> =

--- a/HornTests.fs
+++ b/HornTests.fs
@@ -18,7 +18,7 @@ open Starling.Tests.Studies
 /// Tests for Starling.Horn and Starling.HSF.
 module Tests =
     /// The globals environment used in the tests.
-    let Globals : VarMap =
+    let SharedVars : VarMap =
         returnOrFail <| makeVarMap
             [ TypedVar.Int "serving"
               TypedVar.Int "ticket" ]
@@ -112,7 +112,7 @@ module Tests =
     [<Test>]
     let ``the HSF variable initialiser works correctly using various variable maps``() =
         Assert.That(
-            Globals |> hsfModelVariables |> okOption,
+            SharedVars |> hsfModelVariables |> okOption,
             Is.EqualTo(
                 Clause (Pred { Name = "emp"
                                Params = [ AVar "Vserving"; AVar "Vticket" ] },

--- a/Model.fs
+++ b/Model.fs
@@ -153,8 +153,8 @@ module Types =
 
     /// A parameterised model of a Starling program.
     type Model<'axiom, 'viewdefs> =
-        { Globals : VarMap
-          Locals : VarMap
+        { SharedVars : VarMap
+          ThreadVars : VarMap
           Axioms : Map<string, 'axiom>
           /// <summary>
           ///     The semantic function for this model.
@@ -224,10 +224,10 @@ module Pretty =
         headed "Model"
             [ headed "Shared variables" <|
                   Seq.singleton
-                      (printMap Inline String printType model.Globals)
+                      (printMap Inline String printType model.SharedVars)
               headed "Thread variables" <|
                   Seq.singleton
-                      (printMap Inline String printType model.Locals)
+                      (printMap Inline String printType model.ThreadVars)
               headed "ViewDefs" <|
                   pDefiner model.ViewDefs
               headed "Axioms" <|
@@ -452,8 +452,8 @@ let axioms ({Axioms = xs} : Model<'Axiom, _>) : Map<string, 'Axiom> = xs
 /// The axiom set may be of a different type.
 let withAxioms (xs : Map<string, 'y>) (model : Model<'x, 'dview>)
     : Model<'y, 'dview> =
-    { Globals = model.Globals
-      Locals = model.Locals
+    { SharedVars = model.SharedVars
+      ThreadVars = model.ThreadVars
       ViewDefs = model.ViewDefs
       Semantics = model.Semantics
       Axioms = xs
@@ -482,8 +482,8 @@ let viewDefs ({ViewDefs = ds} : Model<_, 'Definer>) : 'Definer = ds
 let withViewDefs (ds : 'Definer2)
                  (model : Model<'Axiom, 'Definer1>)
                  : Model<'Axiom, 'Definer2> =
-    { Globals = model.Globals
-      Locals = model.Locals
+    { SharedVars = model.SharedVars
+      ThreadVars = model.ThreadVars
       ViewDefs = ds
       Semantics = model.Semantics
       Axioms = model.Axioms

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -225,11 +225,11 @@ module Pretty =
         | ExprNotBoolean ->
             "expression is not suitable for use in a Boolean position" |> String
         | VarNotBoolean lv ->
-            fmt "lvalue '{0}' is not a suitable type for use in a Boolean expressio    n" [ printLValue lv ]
+            fmt "lvalue '{0}' is not a suitable type for use in a Boolean expression" [ printLValue lv ]
         | ExprNotInt ->
             "expression is not suitable for use in an integral position" |> String
         | VarNotInt lv ->
-            fmt "lvalue '{0}' is not a suitable type for use in an integral expre    ssion" [ printLValue lv ]
+            fmt "lvalue '{0}' is not a suitable type for use in an integral expression" [ printLValue lv ]
         | Var(var, err) -> wrapped "variable" (var |> printLValue) (err |> printVarMapError)
         | AmbiguousSym sym ->
             fmt

--- a/MuZ3Backend.fs
+++ b/MuZ3Backend.fs
@@ -658,7 +658,7 @@ module Translator =
     let translate
       (reals : bool)
       (ctx : Z3.Context)
-      ({ Globals = svars ; ViewDefs = ds ; Axioms = xs }
+      ({ SharedVars = svars ; ViewDefs = ds ; Axioms = xs }
          : Model<CmdTerm<MBoolExpr, GView<MarkedVar>, MVFunc>,
                  FuncDefiner<BoolExpr<Var> option>> ) =
         let funcDecls, definites = translateViewDefs reals ctx ds

--- a/Optimiser.fs
+++ b/Optimiser.fs
@@ -904,7 +904,7 @@ module Graph =
     /// </returns>
     let optimise (opts : (string * bool) list) (mdl : Model<Graph, _>)
       : Model<Graph, _> =
-        mapAxioms (optimiseGraph mdl.Locals opts) mdl
+        mapAxioms (optimiseGraph mdl.ThreadVars opts) mdl
 
 
 /// <summary>

--- a/Parser.fs
+++ b/Parser.fs
@@ -65,7 +65,7 @@ let inSquareBrackets p = inBrackets "[" "]" p
 /// Parser for items in {braces}.
 let inBraces p = inBrackets "{" "}" p
 /// Parser for items in {|view braces|}.
-let inViewBraces p = inBrackets "{" "|}" p
+let inViewBraces p = inBrackets "{|" "|}" p
 /// Parser for items in <angle brackets>.
 let inAngles p = inBrackets "<" ">" p
 
@@ -360,19 +360,19 @@ let parseBasicView =
 do parseViewRef := parseViewLike parseBasicView Join
 
 /// Parser for view expressions.
-let parseViewExpr = between
-                        (pstring "{|" .>> ws)
-                        (pstring "|}")
-                        ((stringReturn "?" Unknown .>> ws)
-                         <|> pipe2ws parseView
-                                     (opt (stringReturn "?" ()))
-                                     (fun v qm ->
-                                          match qm with
-                                          | Some () -> Questioned v
-                                          | None -> Unmarked v))
-                    // ^- {| <view> |}
-                    //  | {| <view> ? |}
-                    //  | {| ? |}
+let parseViewExpr =
+    inViewBraces
+        ((stringReturn "?" Unknown .>> ws)
+        <|> pipe2ws
+                parseView
+                (opt (stringReturn "?" ()))
+                (fun v qm ->
+                     match qm with
+                     | Some () -> Questioned v
+                     | None -> Unmarked v))
+        // ^- {| <view> |}
+        //  | {| <view> ? |}
+        //  | {| ? |}
 
 
 (*

--- a/Parser.fs
+++ b/Parser.fs
@@ -462,8 +462,8 @@ let parseDoWhile =
 /// Parser for if (expr) block else block.
 let parseIf =
     pipe3ws (pstring "if" >>. ws >>. inParens parseExpression)
-            (parseBlock .>> ws .>> pstring "else")
             parseBlock
+            (opt (pstring "else" >>. ws >>. parseBlock))
             (curry3 If)
 
 /// Parser for prim compositions.

--- a/ParserTests.fs
+++ b/ParserTests.fs
@@ -5,10 +5,10 @@ module Starling.Tests.Lang.Parser
 
 open NUnit.Framework
 
-open Starling
+open Starling.Collections
+open Starling.Utils.Testing
 open Starling.Core.Var
-open Starling.Core.Model
-open Starling.Core.View
+open Starling.Core.TypeSystem
 open Starling.Lang.AST
 open Starling.Lang.Parser
 
@@ -21,12 +21,40 @@ let get =
 
 let check p str ast =
     let actual = run p str
-    Assert.AreEqual (ast, get actual)
+    assertEqual ast (get actual)
 
 
 // Perform the same trick matt uses in Main.fs to overwrite a right-associative
 // operator with the correct behaviour
 let ( ** ) = ( <| )
+
+
+module ViewProtoTests =
+    [<Test>]
+    let ``Test single view prototype is parsed correctly`` () =
+        check parseViewProtoSet "view foo(int a, int b);"
+            (Some <|
+             [ NoIterator
+                (Func =
+                    func "foo"
+                        [ Int "a"
+                          Int "b" ],
+                 IsAnonymous = false) ])
+
+    [<Test>]
+    let ``Test multiple view prototype is parsed correctly`` () =
+        check parseViewProtoSet "view foo(int a, int b), bar(int c, bool d);"
+            (Some <|
+             [ NoIterator
+                (Func = func "foo"[ Int "a"; Int "b" ],
+                 IsAnonymous = false)
+               NoIterator
+                (Func = func "bar"[ Int "c"; Bool "d" ],
+                 IsAnonymous = false) ])
+
+    [<Test>]
+    let ``Test nullary view prototype is not allowed`` () =
+        check parseViewProtoSet "view ;" None
 
 
 // Conversion of mattw's test cases into new system

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -196,7 +196,7 @@ let instantiateSemanticsOfPrim
 ///     converting *all* After variables to (Intermediate i) variables
 ///     converts any Before variables where an Intermediate exists, to that Intermediate
 ///
-/// the frame can then be constructed by taking the BoolExpr and looking for the aforementioned Intermediate 
+/// the frame can then be constructed by taking the BoolExpr and looking for the aforementioned Intermediate
 /// variables and adding a (= (After v) (Intermediate maxInterValue v)) if it finds one
 let seqComposition xs =
     // since we are trying to keep track of explicit state (where we are in terms of the intermediate variables)
@@ -278,7 +278,7 @@ open Starling.Core.Axiom.Types
 let translate
   (model : Model<GoalAxiom<Command>, 'viewdef>)
   : Result<Model<GoalAxiom<CommandSemantics<SMBoolExpr>>, 'viewdef>, Error> =
-    let modelSemantics = semanticsOfCommand model.Semantics model.Globals model.Locals
+    let modelSemantics = semanticsOfCommand model.Semantics model.SharedVars model.ThreadVars
     let replaceCmd ga c = { Goal = ga.Goal; Axiom = {Pre = ga.Axiom.Pre; Post = ga.Axiom.Post; Cmd = c }}
     let transSem ga = bind (replaceCmd ga >> ok) (modelSemantics ga.Axiom.Cmd)
     tryMapAxioms transSem model

--- a/SemanticsTests.fs
+++ b/SemanticsTests.fs
@@ -99,8 +99,8 @@ module Frames =
     let checkExpr expr framedExpr =
         let actualExpr =
             frame
-                (ticketLockModel.Globals)
-                (ticketLockModel.Locals)
+                (ticketLockModel.SharedVars)
+                (ticketLockModel.ThreadVars)
                 expr
 
         Assert.AreEqual(actualExpr, framedExpr)
@@ -139,8 +139,8 @@ module CommandTests =
             command
             |> semanticsOfCommand
                    (Starling.Lang.Modeller.coreSemantics)
-                   (ticketLockModel.Globals)
-                   (ticketLockModel.Locals)
+                   (ticketLockModel.SharedVars)
+                   (ticketLockModel.ThreadVars)
             |> okOption
             |> Option.bind (function
                             | { Semantics = BAnd xs } -> xs |> Set.ofList |> Some

--- a/TestStudies.fs
+++ b/TestStudies.fs
@@ -360,19 +360,19 @@ let ticketLockParsed =
       {Position = {StreamName = "Examples/Pass/ticketLock.cvf";
                    Line = 5L;
                    Column = 1L;};
-       Node = Global (Int "ticket");};
+       Node = SharedVars (Int (), ["ticket"]);};
       {Position = {StreamName = "Examples/Pass/ticketLock.cvf";
                    Line = 6L;
                    Column = 1L;};
-       Node = Global (Int "serving");};
+       Node = SharedVars (Int (), ["serving"]);};
       {Position = {StreamName = "Examples/Pass/ticketLock.cvf";
                    Line = 7L;
                    Column = 1L;};
-       Node = Local (Int "t");};
+       Node = ThreadVars (Int (), ["t"]);};
       {Position = {StreamName = "Examples/Pass/ticketLock.cvf";
                    Line = 8L;
                    Column = 1L;};
-       Node = Local (Int "s");};
+       Node = ThreadVars (Int (), ["s"]);};
 
       {Position = {StreamName = "Examples/Pass/ticketLock.cvf";
                    Line = 13L;
@@ -387,10 +387,10 @@ let ticketLockParsed =
 
 /// The collated form of the ticket lock.
 let ticketLockCollated =
-    { CollatedScript.Globals =
+    { CollatedScript.SharedVars =
           [ (TypedVar.Int "ticket")
             (TypedVar.Int "serving") ]
-      Locals =
+      ThreadVars =
           [ (TypedVar.Int "t")
             (TypedVar.Int "s") ]
       Search = None
@@ -570,10 +570,10 @@ let ticketLockViewProtos : FuncDefiner<ProtoInfo> =
 
 /// The model of the ticket lock.
 let ticketLockModel : Model<ModellerMethod, ViewDefiner<SVBoolExpr option>> =
-    { Globals =
+    { SharedVars =
           Map.ofList [ ("serving", Type.Int ())
                        ("ticket", Type.Int ()) ]
-      Locals =
+      ThreadVars =
           Map.ofList [ ("s", Type.Int ())
                        ("t", Type.Int ()) ]
       Axioms = ticketLockMethods

--- a/TestStudies.fs
+++ b/TestStudies.fs
@@ -313,14 +313,17 @@ let ticketLockParsed =
             { StreamName = "Examples/Pass/ticketLock.cvf"
               Line = 34L; Column = 1L }
         Node =
-            ViewProto <|
-                NoIterator ({ Name = "holdTick"; Params = [Int "t"] }, false) }
+            ViewProtos
+                [ NoIterator
+                    ({ Name = "holdTick"
+                       Params = [ Int "t" ] },
+                     false) ] }
       { Position =
             { StreamName = "Examples/Pass/ticketLock.cvf"
               Line = 35L; Column = 1L }
         Node =
-            ViewProto <|
-                NoIterator ({ Name = "holdLock"; Params = [] }, false) }
+            ViewProtos
+                [ NoIterator ({ Name = "holdLock"; Params = [] }, false) ] }
       { Position = {StreamName = "Examples/Pass/ticketLock.cvf";
                    Line = 38L;
                    Column = 1L;};

--- a/ViewDesugar.fs
+++ b/ViewDesugar.fs
@@ -81,9 +81,12 @@ let rec desugarCommand (tvars : VarMap) (fg : FreshGen)
     : Command<ViewExpr<View>> * ViewProto seq =
     let f = fun (a, b) -> (cmd |=> a, b)
     f <| match cmd.Node with
-            | If (e, t, f) ->
+            | If (e, t, fo) ->
                 let t', tv = desugarBlock tvars fg t
-                let f', fv = desugarBlock tvars fg f
+                let f', fv =
+                    match fo with
+                    | None -> None, Seq.empty
+                    | Some f -> f |> desugarBlock tvars fg |> pairMap Some id
                 let ast = If (e, t', f')
                 (ast, Seq.append tv fv)
             | While (e, b) ->

--- a/starling.fsproj
+++ b/starling.fsproj
@@ -20,6 +20,7 @@
     <PlatformTarget>x86</PlatformTarget>
     <Optimize>false</Optimize>
     <DocumentationFile>bin\Debug\starling.XML</DocumentationFile>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <OutputPath>bin\Release</OutputPath>
@@ -27,6 +28,7 @@
     <Externalconsole>true</Externalconsole>
     <WarningLevel>5</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
+    <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '11.0'">

--- a/starling.sh
+++ b/starling.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ "$(uname)" = "Darwin" ]; then
+if [ "$(uname)" = "Darwin" ] || [ "$(uname)" = "FreeBSD" ]; then
   mono ./bin/Debug/starling.exe $*
 elif [ "$(expr substr $(uname -s) 1 5)" = "Linux" ]; then
   mono ./bin/Debug/starling.exe $*


### PR DESCRIPTION
#66 is a massive PRQ that somehow pulled in unrelated stuff from `mw-pldi-quality-of-life`, so to make that PRQ easier to digest here is one that just has the quality of life stuff in.

This PRQ, which has been merged into PLDI experimental for a while but not into master:

* Allows if-then without else.
* Fixes some weird unification behaviour.
* Allows `int x, y, z;` as shorthand for `int x; int y; int z;`.
* Replaces `view foo()[n]` with `view iter[n] foo()`;
* Fixes some things in the examples.