### PR TITLE
Arrays, AST–model type split, and general type system churn

### DIFF
--- a/AST.fs
+++ b/AST.fs
@@ -487,18 +487,27 @@ let (|ArithIn|BoolIn|AnyIn|) : BinOp -> Choice<unit, unit, unit> =
     | Eq | Neq -> AnyIn
     | And | Or | Imp -> BoolIn
 
+/// Active pattern classifying inner expressions as to whether they are
+/// arithmetic, Boolean, or indeterminate.
+let (|BoolExp'|ArithExp'|AnyExp'|) (e : Expression')
+  : Choice<Expression', Expression', Expression'> =
+    match e with
+    | Identifier _ -> AnyExp' e
+    | Symbolic _ -> AnyExp' e
+    | ArraySubscript _ -> AnyExp' e
+    | Num _ -> ArithExp' e
+    | True | False -> BoolExp' e
+    | BopExpr(BoolOp, _, _) -> BoolExp' e
+    | BopExpr(ArithOp, _, _) -> ArithExp' e
+
 /// Active pattern classifying expressions as to whether they are
 /// arithmetic, Boolean, or indeterminate.
 let (|BoolExp|ArithExp|AnyExp|) (e : Expression)
   : Choice<Expression, Expression, Expression> =
     match e.Node with
-    | Identifier _ -> AnyExp e
-    | Symbolic _ -> AnyExp e
-    | ArraySubscript _ -> AnyExp e
-    | Num _ -> ArithExp e
-    | True | False -> BoolExp e
-    | BopExpr(BoolOp, _, _) -> BoolExp e
-    | BopExpr(ArithOp, _, _) -> ArithExp e
+    | BoolExp' _ -> BoolExp e
+    | ArithExp' _ -> ArithExp e
+    | AnyExp' _ -> AnyExp e
 
 /// <summary>
 ///     Active pattern classifying expressions as lvalues or rvalues.

--- a/AST.fs
+++ b/AST.fs
@@ -103,6 +103,8 @@ module Types =
         | TInt
         /// <summary>A Boolean type.</summary>
         | TBool
+        /// <summary>An array type.</summary>
+        | TArray of length : int * contentT : TypeLiteral
 
     /// <summary>
     ///     An AST formal parameter declaration.
@@ -352,6 +354,9 @@ module Pretty =
             match lit with
             | TInt -> hsep2 Nop (syntaxIdent (String ("int"))) suffix
             | TBool -> hsep2 Nop (syntaxIdent (String ("bool"))) suffix
+            | TArray (len, contents) ->
+                let lenSuffix = squared (String (sprintf "%d" len))
+                pl contents (hsep2 Nop suffix lenSuffix)
         pl lit Nop
 
     /// Pretty-prints parameters.

--- a/AST.fs
+++ b/AST.fs
@@ -514,7 +514,10 @@ let (|BoolExp|ArithExp|AnyExp|) (e : Expression)
 /// </summary>
 let (|LValue|RValue|) (e : Expression) : Choice<Expression, Expression> =
     match e.Node with
-    | Identifier _ | Symbolic _ | ArraySubscript _ -> LValue e
+    (* TODO(CaptainHayashi): symbolic lvalues?
+       These, however, need a lot of thought as to what the framing semantics
+       are. *)
+    | Identifier _ | ArraySubscript _ -> LValue e
     | _ -> RValue e
 
 (*

--- a/AST.fs
+++ b/AST.fs
@@ -353,11 +353,11 @@ module Pretty =
     let printTypeLiteral (lit : TypeLiteral) : Doc =
         let rec pl lit suffix =
             match lit with
-            | TInt -> hsep2 Nop (syntaxIdent (String ("int"))) suffix
-            | TBool -> hsep2 Nop (syntaxIdent (String ("bool"))) suffix
+            | TInt -> syntaxIdent (String ("int")) <-> suffix
+            | TBool -> syntaxIdent (String ("bool")) <-> suffix
             | TArray (len, contents) ->
                 let lenSuffix = squared (String (sprintf "%d" len))
-                pl contents (hsep2 Nop suffix lenSuffix)
+                pl contents (suffix <-> lenSuffix)
         pl lit Nop
 
     /// Pretty-prints parameters.

--- a/Command.fs
+++ b/Command.fs
@@ -181,12 +181,22 @@ module Compose =
             maxOpt (getIntermediate v x) (getIntermediate v y)
         | _ -> None
 
+    /// Gets the highest intermediate number for some variable in a given
+    /// array expression
+    and getArrayIntermediate v =
+        function
+        | AVar (Reg (Intermediate (n, name))) when name = v -> Some n
+        | AVar (Sym { Params = xs } ) ->
+            Seq.fold maxOpt None <| (Seq.map (getIntermediate v) <| xs)
+        | AVar _ -> None
+
     /// Gets the highest intermediate stage number for a given variable name
     /// in some expression.
     and getIntermediate v =
         function
         | Int x -> getIntIntermediate v x
         | Bool x -> getBoolIntermediate v x
+        | Array (_, _, x) -> getArrayIntermediate v x
 
 /// <summary>
 ///     Functions for removing symbols from commands.

--- a/Command.fs
+++ b/Command.fs
@@ -161,6 +161,9 @@ module Compose =
             Seq.fold maxOpt None <| (Seq.map (getIntIntermediate v) <| xs)
         | IDiv (x, y) | IMod (x, y) ->
             maxOpt (getIntIntermediate v x) (getIntIntermediate v y)
+        // Is this correct?
+        | IIdx (_, _, arr, idx) ->
+            maxOpt (getArrayIntermediate v arr) (getIntIntermediate v idx)
         | _ -> None
 
     /// Gets the highest intermediate number for some variable in a given
@@ -188,6 +191,9 @@ module Compose =
         | AVar (Reg (Intermediate (n, name))) when name = v -> Some n
         | AVar (Sym { Params = xs } ) ->
             Seq.fold maxOpt None <| (Seq.map (getIntermediate v) <| xs)
+        // Is this correct?
+        | AIdx (_, _, arr, idx) ->
+            maxOpt (getArrayIntermediate v arr) (getIntIntermediate v idx)
         | AVar _ -> None
 
     /// Gets the highest intermediate stage number for a given variable name

--- a/Command.fs
+++ b/Command.fs
@@ -195,6 +195,10 @@ module Compose =
         | AIdx (_, _, arr, idx) ->
             maxOpt (getArrayIntermediate v arr) (getIntIntermediate v idx)
         | AVar _ -> None
+        | AUpd (_, _, arr, idx, upd) ->
+            maxOpt
+                (getArrayIntermediate v arr)
+                (maxOpt (getIntIntermediate v idx) (getIntermediate v upd))
 
     /// Gets the highest intermediate stage number for a given variable name
     /// in some expression.

--- a/Command.fs
+++ b/Command.fs
@@ -39,7 +39,7 @@ module Types =
     type PrimCommand =
         { Name : string
           Results : SVExpr list
-          Args : SMExpr list
+          Args : SVExpr list
           Node : AST.Types.Atomic option }
         override this.ToString() = sprintf "%A" this
 
@@ -104,9 +104,9 @@ module Queries =
     /// <summary>
     ///     Active pattern matching assume commands.
     /// </summary>
-    let (|Assume|_|) : Command -> SMBoolExpr option =
+    let (|Assume|_|) : Command -> SVBoolExpr option =
         function
-        | [ { Name = n ; Args = [ SMExpr.Bool b ] } ]
+        | [ { Name = n ; Args = [ SVExpr.Bool b ] } ]
           when n = "Assume" -> Some b
         | _ -> None
 
@@ -134,7 +134,7 @@ module Queries =
     /// Retrieves the type annotated vars from the arguments to a
     /// command as a list
     let commandArgs cmd =
-        let f c = List.map SMExprVars c.Args
+        let f c = List.map SVExprVars c.Args
         let vars = collect (concatMap f cmd)
         lift Set.unionMany vars
 
@@ -255,11 +255,11 @@ module SymRemove =
 
 
 module Create =
-    let command : string -> SVExpr list -> SMExpr list -> PrimCommand =
-        fun name results args -> { Name = name; Results = results; Args = args; Node = None }
+    let command (name : string) (results : SVExpr list) (args : SVExpr list) : PrimCommand =
+        { Name = name; Results = results; Args = args; Node = None }
 
-    let command' : string -> AST.Types.Atomic -> SVExpr list -> SMExpr list -> PrimCommand =
-        fun name ast results args -> { Name = name; Results = results; Args = args; Node = Some ast }
+    let command' (name : string) (ast : AST.Types.Atomic) (results : SVExpr list) (args : SVExpr list) : PrimCommand =
+        { Name = name; Results = results; Args = args; Node = Some ast }
 
 /// <summary>
 ///     Pretty printers for commands.
@@ -274,7 +274,7 @@ module Pretty =
     /// Pretty-prints a Command.
     let printPrimCommand { Name = name; Args = xs; Results = ys } =
         hjoin [ commaSep <| Seq.map (printExpr (printSym printVar)) ys
-                " <- " |> String; name |> String; String " "; commaSep <| Seq.map printSMExpr xs ]
+                " <- " |> String; name |> String; String " "; commaSep <| Seq.map printSVExpr xs ]
 
     let printCommand : Command -> Doc = List.map printPrimCommand >> semiSep
 

--- a/Command.fs
+++ b/Command.fs
@@ -161,7 +161,7 @@ module Compose =
             Seq.fold maxOpt None <| (Seq.map (getIntIntermediate v) <| xs)
         | IDiv (x, y) | IMod (x, y) ->
             maxOpt (getIntIntermediate v x) (getIntIntermediate v y)
-        // Is this correct?
+        // TODO(CaptainHayashi): need to convince myself this is correct.
         | IIdx (_, _, arr, idx) ->
             maxOpt (getArrayIntermediate v arr) (getIntIntermediate v idx)
         | _ -> None
@@ -182,6 +182,9 @@ module Compose =
             maxOpt (getIntIntermediate v x) (getIntIntermediate v y)
         | BEq (x, y) ->
             maxOpt (getIntermediate v x) (getIntermediate v y)
+        // TODO(CaptainHayashi): need to convince myself this is correct.
+        | BIdx (_, _, arr, idx) ->
+            maxOpt (getArrayIntermediate v arr) (getIntIntermediate v idx)
         | _ -> None
 
     /// Gets the highest intermediate number for some variable in a given
@@ -191,7 +194,7 @@ module Compose =
         | AVar (Reg (Intermediate (n, name))) when name = v -> Some n
         | AVar (Sym { Params = xs } ) ->
             Seq.fold maxOpt None <| (Seq.map (getIntermediate v) <| xs)
-        // Is this correct?
+        // TODO(CaptainHayashi): need to convince myself this is correct.
         | AIdx (_, _, arr, idx) ->
             maxOpt (getArrayIntermediate v arr) (getIntIntermediate v idx)
         | AVar _ -> None

--- a/Command.fs
+++ b/Command.fs
@@ -12,6 +12,7 @@ open Starling.Core.TypeSystem
 open Starling.Core.Expr
 open Starling.Core.Var
 open Starling.Core.Symbolic
+open Starling.Core.Traversal
 
 
 /// <summary>
@@ -37,7 +38,7 @@ module Types =
     /// </remarks>
     type PrimCommand =
         { Name : string
-          Results : TypedVar list
+          Results : SVExpr list
           Args : SMExpr list
           Node : AST.Types.Atomic option }
         override this.ToString() = sprintf "%A" this
@@ -113,6 +114,22 @@ module Queries =
     /// Combines the results of each command into a list of all results
     let commandResults cs =
         List.fold (fun a c -> a @ c.Results) [] cs
+
+    /// <summary>
+    ///     Gets all variables mentioned in the results of a command.
+    /// </summary>
+    /// <param name="cmd">The <see cref="Command"/> to query.</param>
+    /// <typeparam name="'Error">The traversal-internal error type.</typeparam>
+    /// <returns>
+    ///     All variables mentioned in <paramref name="cmd"/>'s results, as
+    ///     <see cref="TypedVar"/>s.  This is wrapped in a result, because the
+    ///     internal traversal can fail.
+    /// </returns>
+    let commandResultVars (cmd : Command)
+      : Result<Set<TypedVar>, TraversalError<'Error>> =
+        let results = commandResults cmd
+        let trav = tchainL (tliftOverExpr collectSymVars) id
+        findVars trav results
 
     /// Retrieves the type annotated vars from the arguments to a
     /// command as a list
@@ -218,10 +235,10 @@ module SymRemove =
 
 
 module Create =
-    let command : string -> TypedVar list -> SMExpr list -> PrimCommand =
+    let command : string -> SVExpr list -> SMExpr list -> PrimCommand =
         fun name results args -> { Name = name; Results = results; Args = args; Node = None }
 
-    let command' : string -> AST.Types.Atomic -> TypedVar list -> SMExpr list -> PrimCommand =
+    let command' : string -> AST.Types.Atomic -> SVExpr list -> SMExpr list -> PrimCommand =
         fun name ast results args -> { Name = name; Results = results; Args = args; Node = Some ast }
 
 /// <summary>
@@ -229,13 +246,15 @@ module Create =
 /// </summary>
 module Pretty =
     open Starling.Core.Pretty
+    open Starling.Core.Expr.Pretty
     open Starling.Core.Var.Pretty
     open Starling.Core.TypeSystem.Pretty
     open Starling.Core.Symbolic.Pretty
 
     /// Pretty-prints a Command.
     let printPrimCommand { Name = name; Args = xs; Results = ys } =
-        hjoin [ commaSep <| Seq.map (printCTyped String) ys; " <- " |> String; name |> String; String " "; commaSep <| Seq.map printSMExpr xs ]
+        hjoin [ commaSep <| Seq.map (printExpr (printSym printVar)) ys
+                " <- " |> String; name |> String; String " "; commaSep <| Seq.map printSMExpr xs ]
 
     let printCommand : Command -> Doc = List.map printPrimCommand >> semiSep
 

--- a/CommandTests.fs
+++ b/CommandTests.fs
@@ -29,13 +29,13 @@ module Nops =
 
     [<Test>]
     let ``Reject baz <- Foo(bar) as a no-op``() =
-        checkNot [ command "Foo" [ Int "baz" ] [ SMExpr.Int <| siBefore "bar" ] ]
+        checkNot [ command "Foo" [ Int (siVar "baz") ] [ SMExpr.Int <| siBefore "bar" ] ]
 
     [<Test>]
     let ``Reject Assume (x!before); baz <- Foo(bar) as a no-op``() =
         checkNot
-            [ command "Assume" [] [ SMExpr.Bool <| sbBefore "x" ] 
-              command "Foo" [ Int "baz" ] [ SMExpr.Int <| siBefore "bar" ] ]
+            [ command "Assume" [] [ SMExpr.Bool <| sbBefore "x" ]
+              command "Foo" [ Int (siVar "baz") ] [ SMExpr.Int <| siBefore "bar" ] ]
 
 module Assumes =
     let isAssume c =
@@ -56,7 +56,7 @@ module Assumes =
 
     [<Test>]
     let ``Reject baz <- Foo(bar); Assume(x!before) as an Assume`` ()=
-        checkNot [ command "Foo" [ Int "baz" ] [ SMExpr.Int <| siBefore "bar" ]
+        checkNot [ command "Foo" [ Int (siVar "baz") ] [ SMExpr.Int <| siBefore "bar" ]
                    command "Assume" [] [ SMExpr.Bool <| sbBefore "x" ] ]
 
 

--- a/CommandTests.fs
+++ b/CommandTests.fs
@@ -25,17 +25,17 @@ module Nops =
 
     [<Test>]
     let ``Classify Assume(x!before) as a no-op``() =
-        check [ command "Assume" [] [ SMExpr.Bool <| sbBefore "x" ] ]
+        check [ command "Assume" [] [ Bool (sbVar "x") ] ]
 
     [<Test>]
     let ``Reject baz <- Foo(bar) as a no-op``() =
-        checkNot [ command "Foo" [ Int (siVar "baz") ] [ SMExpr.Int <| siBefore "bar" ] ]
+        checkNot [ command "Foo" [ Int (siVar "baz") ] [ Int (siVar "bar") ] ]
 
     [<Test>]
     let ``Reject Assume (x!before); baz <- Foo(bar) as a no-op``() =
         checkNot
-            [ command "Assume" [] [ SMExpr.Bool <| sbBefore "x" ]
-              command "Foo" [ Int (siVar "baz") ] [ SMExpr.Int <| siBefore "bar" ] ]
+            [ command "Assume" [] [ Bool (sbVar "x") ]
+              command "Foo" [ Int (siVar "baz") ] [ Int (siVar "bar") ] ]
 
 module Assumes =
     let isAssume c =
@@ -52,12 +52,12 @@ module Assumes =
 
     [<Test>]
     let ``Classify Assume(x!before) as an assume``() =
-        check [ command "Assume" [] [ SMExpr.Bool <| sbBefore "x" ] ]
+        check [ command "Assume" [] [ Bool (sbVar "x") ] ]
 
     [<Test>]
     let ``Reject baz <- Foo(bar); Assume(x!before) as an Assume`` ()=
-        checkNot [ command "Foo" [ Int (siVar "baz") ] [ SMExpr.Int <| siBefore "bar" ]
-                   command "Assume" [] [ SMExpr.Bool <| sbBefore "x" ] ]
+        checkNot [ command "Foo" [ Int (siVar "baz") ] [ Int (siVar "bar") ]
+                   command "Assume" [] [ Bool (sbVar "x") ] ]
 
 
     let checkIntermediate v i e = assertEqual i (getIntermediate v e)

--- a/Definer.fs
+++ b/Definer.fs
@@ -171,7 +171,7 @@ module FuncDefiner =
        : Result<Func<Expr<'Var>>, Error> =
         List.map2
             (fun fp dp ->
-                if typeOf fp = typeOf dp
+                if typesCompatible (typeOf fp) (typeOf dp)
                 then ok ()
                 else fail (TypeMismatch (dp, typeOf fp)))
             func.Params

--- a/Examples/Fail/petersonArrayBadTurns.cvf
+++ b/Examples/Fail/petersonArrayBadTurns.cvf
@@ -1,0 +1,95 @@
+/*
+ * Peterson's algorithm for mutual exclusion:
+ * http://dx.doi.org/10.1016/0020-0190(81)90106-X
+ *
+ * This version uses a flag array, and is purposely broken.
+ *
+ * This proof was manually written: future exercises could involve
+ * making it easier to synthesise parts of it.
+ */
+
+
+shared bool[2] flag;    // Status of the two threads' claims to the lock.
+shared int turn;        // Whichever thread locked most recently has this.
+
+thread bool oFlag;      // The thread's view of its opponent's flag state.
+thread int oTurn;       // The thread's view of the current turn.
+thread int i;           // The thread's turn identifier.
+
+view flagDown(int me);  // 'me' does not hold the lock and is not seeking it.
+view flagUp(int me);    // 'me' has put its flag up, but isn't waiting yet.
+view waiting(int me);   // 'me' is now waiting for the lock.
+view holdLock(int me);  // 'me' holds the lock.
+
+
+/*
+ * Locks the Peterson lock.
+ */
+method lock() {
+  {| flagDown(i) |}
+    <flag[i] = true>;
+  {| flagUp(i) |}
+    <turn = (i + 1) % 2>; // oops!
+  {| waiting(i) |}
+    do {
+      {| waiting(i) |}
+        <oFlag = flag[(i + 1) % 2]>;
+      {| if (oFlag) then waiting(i) else holdLock(i) |}
+        <oTurn = turn>;
+      {| if (oFlag && oTurn == i) then waiting(i) else holdLock(i) |}
+    } while (oFlag && (oTurn == i));
+  {| holdLock(i) |}
+}
+
+/*
+ * Unlocks the Peterson lock.
+ */
+method unlock() {
+  {| holdLock(i) |}
+    <flag[i] = false>;
+  {| flagDown(i) |}
+}
+
+// Invariant: turn is always something well-formed.
+constraint emp -> (turn == 0 || turn == 1);
+
+/*
+ * Predicate definitions.
+ *
+ * Most of the interesting work happens in the interactions between
+ * constraints: these just keep track of the flag and ensure 'me' is valid.
+ */
+constraint flagDown(me)      -> flag[me] == false && (me == 0 || me == 1);
+constraint flagUp(me)        -> flag[me] == true  && (me == 0 || me == 1);
+constraint waiting(me)       -> flag[me] == true  && (me == 0 || me == 1);
+constraint holdLock(me)      -> flag[me] == true  && (me == 0 || me == 1);
+
+/*
+ * If we have the lock, and the other thread is waiting, we have the turn.
+ * Also, we cannot be holding and waiting at the same time.
+ *
+ * We note that to get the lock we must have either seen
+ * the other thread's flag down (see above), or we must have already
+ * been given the turn.
+ *
+ * More directly (and closer to how Starling will be proving this),
+ * any transition where the other thread starts waiting sets the turn
+ * to our turn, and nothing destabilises this except us starting to
+ * wait too.
+ */
+constraint holdLock(me) * waiting(you) -> me != you && turn == you;
+
+/*
+ * We can't be in multiple states at the same time, unless exactly one of those
+ * states is flag-down.
+ */
+constraint flagDown(me) * flagDown(you) -> me != you;
+constraint flagUp(me)   * flagUp(you)   -> me != you;
+constraint flagUp(me)   * waiting(you)  -> me != you;
+constraint flagUp(me)   * holdLock(you) -> me != you;
+constraint waiting(me)  * waiting(you)  -> me != you;
+
+/*
+ * Goal: mutual exclusion.
+ */
+constraint holdLock(me) * holdLock(you) -> false;

--- a/Examples/Fail/petersonBadTurns.cvf
+++ b/Examples/Fail/petersonBadTurns.cvf
@@ -32,7 +32,7 @@ method lockA() {
   {| aFlagDown() |}
     <aFlag = (true)>;
   {| aFlagUp() |}
-    <turn = (2)>;  // oops!
+    <turn = 2>;  // oops!
   {| aWaiting() |}
     do {
       {| aWaiting() |}
@@ -58,9 +58,9 @@ method unlockA() {
  */
 method lockB() {
   {| bFlagDown() |}
-    <bFlag = (true)>;
+    <bFlag = true>;
   {| bFlagUp() |}
-    <turn = (1)>;  // oops!
+    <turn = 1>;  // oops!
   {| bWaiting() |}
     do {
       {| bWaiting() |}
@@ -77,7 +77,7 @@ method lockB() {
  */
 method unlockB() {
   {| bHoldLock() |}
-    <bFlag = (false)>;
+    <bFlag = false>;
   {| bFlagDown() |}
 }
 

--- a/Examples/Pass/peterson.cvf
+++ b/Examples/Pass/peterson.cvf
@@ -36,9 +36,9 @@ view bHoldLock();       // B holds the lock.
  */
 method lockA() {
   {| aFlagDown() |}
-    <aFlag = (true)>;
+    <aFlag = true>;
   {| aFlagUp() |}
-    <turn = (1)>;
+    <turn = 1>;
   {| aWaiting() |}
     do {
       {| aWaiting() |}
@@ -55,7 +55,7 @@ method lockA() {
  */
 method unlockA() {
   {| aHoldLock() |}
-    <aFlag = (false)>;
+    <aFlag = false>;
   {| aFlagDown() |}
 }
 
@@ -64,9 +64,9 @@ method unlockA() {
  */
 method lockB() {
   {| bFlagDown() |}
-    <bFlag = (true)>;
+    <bFlag = true>;
   {| bFlagUp() |}
-    <turn = (2)>;
+    <turn = 2>;
   {| bWaiting() |}
     do {
       {| bWaiting() |}
@@ -83,7 +83,7 @@ method lockB() {
  */
 method unlockB() {
   {| bHoldLock() |}
-    <bFlag = (false)>;
+    <bFlag = false>;
   {| bFlagDown() |}
 }
 

--- a/Examples/Pass/petersonArray.cvf
+++ b/Examples/Pass/petersonArray.cvf
@@ -1,0 +1,95 @@
+/*
+ * Peterson's algorithm for mutual exclusion:
+ * http://dx.doi.org/10.1016/0020-0190(81)90106-X
+ *
+ * This version uses a flag array.
+ *
+ * This proof was manually written: future exercises could involve
+ * making it easier to synthesise parts of it.
+ */
+
+
+shared bool[2] flag;    // Status of the two threads' claims to the lock.
+shared int turn;        // Whichever thread locked most recently has this.
+
+thread bool oFlag;      // The thread's view of its opponent's flag state.
+thread int oTurn;       // The thread's view of the current turn.
+thread int i;           // The thread's turn identifier.
+
+view flagDown(int me);  // 'me' does not hold the lock and is not seeking it.
+view flagUp(int me);    // 'me' has put its flag up, but isn't waiting yet.
+view waiting(int me);   // 'me' is now waiting for the lock.
+view holdLock(int me);  // 'me' holds the lock.
+
+
+/*
+ * Locks the Peterson lock.
+ */
+method lock() {
+  {| flagDown(i) |}
+    <flag[i] = true>;
+  {| flagUp(i) |}
+    <turn = i>;
+  {| waiting(i) |}
+    do {
+      {| waiting(i) |}
+        <oFlag = flag[(i + 1) % 2]>;
+      {| if (oFlag) then waiting(i) else holdLock(i) |}
+        <oTurn = turn>;
+      {| if (oFlag && oTurn == i) then waiting(i) else holdLock(i) |}
+    } while (oFlag && (oTurn == i));
+  {| holdLock(i) |}
+}
+
+/*
+ * Unlocks the Peterson lock.
+ */
+method unlock() {
+  {| holdLock(i) |}
+    <flag[i] = false>;
+  {| flagDown(i) |}
+}
+
+// Invariant: turn is always something well-formed.
+constraint emp -> (turn == 0 || turn == 1);
+
+/*
+ * Predicate definitions.
+ *
+ * Most of the interesting work happens in the interactions between
+ * constraints: these just keep track of the flag and ensure 'me' is valid.
+ */
+constraint flagDown(me)      -> flag[me] == false && (me == 0 || me == 1);
+constraint flagUp(me)        -> flag[me] == true  && (me == 0 || me == 1);
+constraint waiting(me)       -> flag[me] == true  && (me == 0 || me == 1);
+constraint holdLock(me)      -> flag[me] == true  && (me == 0 || me == 1);
+
+/*
+ * If we have the lock, and the other thread is waiting, we have the turn.
+ * Also, we cannot be holding and waiting at the same time.
+ *
+ * We note that to get the lock we must have either seen
+ * the other thread's flag down (see above), or we must have already
+ * been given the turn.
+ *
+ * More directly (and closer to how Starling will be proving this),
+ * any transition where the other thread starts waiting sets the turn
+ * to our turn, and nothing destabilises this except us starting to
+ * wait too.
+ */
+constraint holdLock(me) * waiting(you) -> me != you && turn == you;
+
+/*
+ * We can't be in multiple states at the same time, unless exactly one of those
+ * states is flag-down.
+ */
+constraint flagDown(me) * flagDown(you) -> me != you;
+constraint flagUp(me)   * flagUp(you)   -> me != you;
+constraint flagUp(me)   * waiting(you)  -> me != you;
+constraint flagUp(me)   * holdLock(you) -> me != you;
+constraint waiting(me)  * waiting(you)  -> me != you;
+
+/*
+ * Goal: mutual exclusion.
+ */
+constraint holdLock(me) * holdLock(you) -> false;

--- a/Examples/Pass/petersonInt.cvf
+++ b/Examples/Pass/petersonInt.cvf
@@ -40,9 +40,9 @@ view bHoldLock();       // B holds the lock.
  */
 method lockA() {
   {| aFlagDown() |}
-    <aFlag = (1)>;
+    <aFlag = 1>;
   {| aFlagUp() |}
-    <turn = (0)>;
+    <turn = 0>;
   {| aWaiting() |}
     do {
       {| aWaiting() |}
@@ -59,7 +59,7 @@ method lockA() {
  */
 method unlockA() {
   {| aHoldLock() |}
-    <aFlag = (0)>;
+    <aFlag = 0>;
   {| aFlagDown() |}
 }
 
@@ -68,9 +68,9 @@ method unlockA() {
  */
 method lockB() {
   {| bFlagDown() |}
-    <bFlag = (1)>;
+    <bFlag = 1>;
   {| bFlagUp() |}
-    <turn = (1)>;
+    <turn = 1>;
   {| bWaiting() |}
     do {
       {| bWaiting() |}
@@ -87,7 +87,7 @@ method lockB() {
  */
 method unlockB() {
   {| bHoldLock() |}
-    <bFlag = (0)>;
+    <bFlag = 0>;
   {| bFlagDown() |}
 }
 

--- a/Examples/Pass/petersonIntMissingSynthesised.cvf
+++ b/Examples/Pass/petersonIntMissingSynthesised.cvf
@@ -49,9 +49,9 @@ view v8(int f, int t);
  */
 method lockA() {
   {| aFlagDown() |}
-    <aFlag = (1)>;
+    <aFlag = 1>;
   {| v0(oFlag, oTurn) |}
-    <turn = (0)>;
+    <turn = 0>;
   {| v2(oFlag, oTurn) |}
     do {
       {| v2(oFlag, oTurn) |}
@@ -68,7 +68,7 @@ method lockA() {
  */
 method unlockA() {
   {| aHoldLock() |}
-    <aFlag = (0)>;
+    <aFlag = 0>;
   {| aFlagDown() |}
 }
 
@@ -77,9 +77,9 @@ method unlockA() {
  */
 method lockB() {
   {| bFlagDown() |}
-    <bFlag = (1)>;
+    <bFlag = 1>;
   {| v5(oFlag, oTurn) |}
-    <turn = (1)>;
+    <turn = 1>;
   {| v7(oFlag, oTurn) |}
     do {
       {| v7(oFlag, oTurn) |}
@@ -96,7 +96,7 @@ method lockB() {
  */
 method unlockB() {
   {| bHoldLock() |}
-    <bFlag = (0)>;
+    <bFlag = 0>;
   {| bFlagDown() |}
 }
 

--- a/Examples/Pass/petersonMultiCmd.cvf
+++ b/Examples/Pass/petersonMultiCmd.cvf
@@ -39,9 +39,9 @@ view bHoldLock();       // B holds the lock.
  */
 method lockA() {
   {| aFlagDown() |}
-    <aFlag = (true)>;
+    <aFlag = true>;
   {| aFlagUp() |}
-    <turn = (1)>;
+    <turn = 1>;
   {| aWaiting() |}
     do {
       {| aWaiting() |}
@@ -57,7 +57,7 @@ method lockA() {
  */
 method unlockA() {
   {| aHoldLock() |}
-    <aFlag = (false)>;
+    <aFlag = false>;
   {| aFlagDown() |}
 }
 
@@ -66,9 +66,9 @@ method unlockA() {
  */
 method lockB() {
   {| bFlagDown() |}
-    <bFlag = (true)>;
+    <bFlag = true>;
   {| bFlagUp() |}
-    <turn = (2)>;
+    <turn = 2>;
   {| bWaiting() |}
     do {
       {| bWaiting() |}
@@ -83,7 +83,7 @@ method lockB() {
  */
 method unlockB() {
   {| bHoldLock() |}
-    <bFlag = (false)>;
+    <bFlag = false>;
   {| bFlagDown() |}
 }
 

--- a/Examples/Pass/spinLock.cvf
+++ b/Examples/Pass/spinLock.cvf
@@ -25,7 +25,7 @@ method lock() {
  */
 method unlock() {
   {| holdLock() |}
-  <lock = (false)>;
+  <lock = false>;
   {| emp |}
 }
 

--- a/Examples/Pass/spinLockAdvisory.cvf
+++ b/Examples/Pass/spinLockAdvisory.cvf
@@ -25,7 +25,7 @@ method lock() {
  */
 method unlock() {
   {| holdLock() |}
-  <lock = (false)>;
+  <lock = false>;
   {| emp |}
 }
 

--- a/Examples/Pass/spinLockInt.cvf
+++ b/Examples/Pass/spinLockInt.cvf
@@ -28,7 +28,7 @@ method lock() {
  */
 method unlock() {
   {| holdLock() |}
-  <lock = (0)>;
+  <lock = 0>;
   {| emp |}
 }
 

--- a/Examples/Pass/spinLockMultiCmd.cvf
+++ b/Examples/Pass/spinLockMultiCmd.cvf
@@ -25,7 +25,7 @@ method lock() {
  */
 method unlock() {
   {| holdLock() |}
-  <lock = (false)>;
+  <lock = false>;
   {| emp |}
 }
 

--- a/Examples/Pass/ticketLockNonAtomicRelease.cvf
+++ b/Examples/Pass/ticketLockNonAtomicRelease.cvf
@@ -29,7 +29,7 @@ method unlock() {
   {| holdLock() |}
     <s = serving>;
   {| relLock(s) |}
-    <serving = (s + 1)>;
+    <serving = s + 1>;
   {| emp |}
 }
 

--- a/Examples/Pass/ticketLockNonAtomicRelease2.cvf
+++ b/Examples/Pass/ticketLockNonAtomicRelease2.cvf
@@ -29,7 +29,7 @@ method unlock() {
   {| holdLock() |}
     <s = serving>;
   {| /*relLock(s)*/ holdLock() |}
-    <serving = (s + 1)>;
+    <serving = s + 1>;
   {| emp |}
 }
 

--- a/Examples/PassHSF/petersonIntIndefinite.cvf
+++ b/Examples/PassHSF/petersonIntIndefinite.cvf
@@ -51,9 +51,9 @@ method init() {
  */
 method lockA() {
   {| aFlagDown() |}
-    <aFlag = (1)>;
+    <aFlag = 1>;
   {| aFlagUp() |}
-    <turn = (0)>;
+    <turn = 0>;
   {| aWaiting() |}
     do {
       {| aWaiting() |}
@@ -70,7 +70,7 @@ method lockA() {
  */
 method unlockA() {
   {| aHoldLock() |}
-    <aFlag = (0)>;
+    <aFlag = 0>;
   {| aFlagDown() |}
 }
 
@@ -79,9 +79,9 @@ method unlockA() {
  */
 method lockB() {
   {| bFlagDown() |}
-    <bFlag = (1)>;
+    <bFlag = 1>;
   {| bFlagUp() |}
-    <turn = (1)>;
+    <turn = 1>;
   {| bWaiting() |}
     do {
       {| bWaiting() |}
@@ -98,7 +98,7 @@ method lockB() {
  */
 method unlockB() {
   {| bHoldLock() |}
-    <bFlag = (0)>;
+    <bFlag = 0>;
   {| bFlagDown() |}
 }
 

--- a/Examples/PassHSF/petersonIntIndefiniteUnknownViews.cvf
+++ b/Examples/PassHSF/petersonIntIndefiniteUnknownViews.cvf
@@ -47,9 +47,9 @@ method init() {
  */
 method lockA() {
   {| aFlagDown() |}
-    <aFlag = (1)>;
+    <aFlag = 1>;
   {| ? |}
-    <turn = (0)>;
+    <turn = 0>;
   {| ? |}
     do {
       {| ? |}
@@ -66,7 +66,7 @@ method lockA() {
  */
 method unlockA() {
   {| aHoldLock() |}
-    <aFlag = (0)>;
+    <aFlag = 0>;
   {| aFlagDown() |}
 }
 
@@ -75,9 +75,9 @@ method unlockA() {
  */
 method lockB() {
   {| bFlagDown() |}
-    <bFlag = (1)>;
+    <bFlag = 1>;
   {| ? |}
-    <turn = (1)>;
+    <turn = 1>;
   {| ? |}
     do {
       {| ? |}
@@ -94,7 +94,7 @@ method lockB() {
  */
 method unlockB() {
   {| bHoldLock() |}
-    <bFlag = (0)>;
+    <bFlag = 0>;
   {| bFlagDown() |}
 }
 

--- a/Examples/PassHSF/ticketLockIndefiniteNonAtomicRelease.cvf
+++ b/Examples/PassHSF/ticketLockIndefiniteNonAtomicRelease.cvf
@@ -29,7 +29,7 @@ method unlock() {
   {| holdLock() |}
     <s = serving>;
   {| relLock(s) |}
-    <serving = (s + 1)>;
+    <serving = s + 1>;
   {| emp |}
 }
 

--- a/Examples/WIP/dimitrios-barrier-starling.cvf
+++ b/Examples/WIP/dimitrios-barrier-starling.cvf
@@ -1,0 +1,121 @@
+// Barrier proposed by Dimitrios Vytiniotis -- original source at the bottom 
+
+shared int no_threads; 
+shared int thr_cnt; 
+shared bool[10] ok; 
+
+thread int tid; 
+thread int ph; 
+thread int i; 
+thread int c; 
+thread bool b; 
+
+view isBarrier(int ph); 
+view isMaster(int tid); 
+view isInterior(int tid); 
+view isSlave(int tid); 
+view isThr(int tid); 
+view isSet(int tid); 
+
+
+method barrier (/* tid, ph */) { 
+ {| isBarrier(ph) * isThr(tid) |} 
+  if (tid == 0) { 
+   {| isBarrier(ph) * isMaster(0, ph) |} 
+    do { 
+     {| isBarrier(ph) * isMaster(0, ph) |} 
+      <c = thr_cnt>; 
+     {| if (c == (no_tideads -1)) 
+          then isInterior(ph) * isMaster(0, ph) 
+          else isBarrier(ph) * isMaster(0, ph) |} 
+    } while (c < (no_tideads - 1)); 
+   {| isMaster(0, ph) |} 
+    i = 0; 
+    <thr_cnt = i>; 
+   {| isMaster(1, ph) |} 
+    i = 1; 
+   {| isMaster(i, ph) |} 
+    while (i < no_tideads) { 
+     {| isMaster(i, ph) |} 
+      <ok[i] = true>; 
+     {| isMaster(i+1, ph) |} 
+      i = i + 1; 
+     {| isMaster(i, ph) |} 
+    } 
+   {| isBarrier(ph+1) * isThr(0) |} 
+  } else {
+   {| isBarrier(ph) * isSlave(tid) |} 
+    ok[tid] = false;  
+   {| isBarrier(ph) * isSet(tid) |} 
+    <i = thr_cnt++>; 
+   {| isInterior(ph) * isSet(tid) |} 
+    do { 
+     {| isInterior(ph) * isSet(tid) |} 
+      b = ok[tid];  
+     {| if b != true 
+          then isBarrier(ph+1) * isThr(tid) 
+          else isInterior(ph) * isSet(tid) |} 
+    } while (b != true); 
+   {| isBarrier(ph+1) * isThr(tid) |} 
+  } 
+ {| isBarrier(ph+1) * isThr(tid) |} 
+} 
+
+constraint emp -> no_threads <= 10;
+
+// Specification of barrier
+constraint isBarrier(p1) * isBarrier(p2)    ->  p1 == p2; 
+
+// Can't be in different interior phases 
+constraint isInterior(p1) * isInterior(p2)  ->  p1 == p2; 
+
+// Can't be master and outside the barrier sync
+constraint isMaster(i, p1) * isBarrier(p2)  ->  false; 
+
+constraint isSet(t)                         ->  ok[t] == false; 
+
+// Needed because we don't allow inline assertions 
+constraint isSlave(t)                       ->  t != 0;  
+
+// Iterated views
+constraint iter[i] isBarrier(p)             ->  (i + thr_cnt) < no_threads; 
+
+// One thread per tid
+constraint isThr(t)                         ->  0 <= t * t < no_threads; 
+constraint isThr(t) * isThr(t)              ->  false; 
+
+
+
+// // Original source from MattP & Dimitrios's email (13-10-2015) 
+// #define MAXPOSSIBLETHREADS 4
+// static volatile long thr_cnt = 0;
+// static volatile bool ok[MAXPOSSIBLETHREADS] = {true, true, true, true};
+// static volatile bool flag = false;
+//  
+// // When we come to a goto, we wait at the <state> barrier related to the current state
+// inline void barrier(LONG volatile *state, int no_threads, int thr)
+// {
+//  
+//        if (thr == 0)
+//        {
+//         // InterlockedIncrement(&thr_cnt); // atomically increment thr_cnt
+//               // if we are the master controller, wait for every thread to increment their counter
+//               while (thr_cnt < no_threads-1);
+//               // at this point thr_cnt = no_threads-1, so all other thread must be spinning
+//               // safe to zero-out thr_cnt as no-one is looking at this
+//               thr_cnt = 0;
+//               // one by one, unleash the other threads
+//               for (int i = 1; i < no_threads; i++) { ok[i] = true; }
+//        }
+//        else
+//        {
+//               //// all other threads reach here, set their flag to false and just busy-wait
+//               //if (!ok[thr]) {
+//               //     __debugbreak();
+//               //}
+//               ok[thr] = false;
+//               InterlockedIncrement(&thr_cnt); // atomically increment thr_cnt (NB: generates a barrier, YAY)
+//  
+//               while (!&ok[thr]);
+//        }
+// } 

--- a/Examples/WIP/senseBarrier.cvf
+++ b/Examples/WIP/senseBarrier.cvf
@@ -15,7 +15,7 @@ view hasPos(int p, bool s);
 view currSense(bool s); 
 view oldSense(bool s); 
 
-method await(i) { 
+method await() { 
  {| isBarrier(i) * currSense(mysense) |} 
   < pos = count-- >; 
  {| hasPos(pos, mysense) |} 
@@ -43,8 +43,8 @@ method await(i) {
  {| isBarrier(i+1) * currSense(mysense) |} 
 } 
 
-// // Iterated views
-// constraint isBarrier(a)[x]  ->  count + x <= size; 
+// Iterated views
+constraint iter[x] isBarrier(a) -> count + x <= size; 
 
 // Global invariant 
 constraint emp  ->  size >= count;  

--- a/Expr.fs
+++ b/Expr.fs
@@ -128,7 +128,7 @@ module Pretty =
       (pVar : 'Var -> Doc)
       (arr : ArrayExpr<'Var>)
       (idx : IntExpr<'Var>) : Doc =
-        cmdSexpr "[]" [ printIntExpr pVar idx; printArrayExpr pVar arr ]
+        cmdSexpr "select" [ printIntExpr pVar idx; printArrayExpr pVar arr ]
 
     /// Pretty-prints an arithmetic expression.
     and printIntExpr (pVar : 'Var -> Doc) : IntExpr<'Var> -> Doc =
@@ -165,7 +165,7 @@ module Pretty =
         | AVar c -> pVar c
         | AIdx (_, _, arr, idx) -> printIdx pVar arr idx
         | AUpd (_, _, arr, idx, value) ->
-            cmdSexpr "[]<-"
+            cmdSexpr "store"
                 [ printIntExpr pVar idx
                   printExpr pVar value
                   printArrayExpr pVar arr ]

--- a/Expr.fs
+++ b/Expr.fs
@@ -308,9 +308,9 @@ let isTrue (expr : BoolExpr<_>) : bool =
 /// Converts a typed variable to an expression.
 let mkVarExp (var : CTyped<'Var>) : Expr<'Var> =
     match var with
-    | Int s -> s |> IVar |> Int
-    | Bool s -> s |> BVar |> Bool
-    | Array (eltype, length, s) -> Array (eltype, length, AVar s)
+    | CTyped.Int i -> Expr.Int (IVar i)
+    | CTyped.Bool b -> Expr.Bool (BVar b)
+    | CTyped.Array (eltype, length, a) -> Expr.Array (eltype, length, AVar a)
 
 /// Converts a VarMap to a sequence of expressions.
 let varMapToExprs

--- a/Expr.fs
+++ b/Expr.fs
@@ -73,11 +73,25 @@ module Types =
     ///     The type of variables in the expression.
     /// </typeparam>
     and ArrayExpr<'Var> when 'Var : equality =
+        /// <summary>An array variable reference.</summary>
         | AVar of 'Var
+        /// <summary>
+        ///     An index into an array <c>arr</c> of type <c>eltype[length]</c>.
+        /// </summary>
         | AIdx of eltype : Type
                 * length : int option
                 * arr : ArrayExpr<'Var>
                 * idx : IntExpr<'Var>
+        /// <summary>
+        ///     A functional update of an array <c>arr</c> of type
+        ///     <c>eltype[length]</c>, overriding index <c>idx</c> with value
+        ///     <c>var</c>.
+        /// </summary>
+        | AUpd of eltype : Type
+                * length : int option
+                * arr : ArrayExpr<'Var>
+                * idx : IntExpr<'Var>
+                * nval : Expr<'Var>
 
     /// Type for fresh variable generators.
     type FreshGen = bigint ref
@@ -150,6 +164,11 @@ module Pretty =
         function
         | AVar c -> pVar c
         | AIdx (_, _, arr, idx) -> printIdx pVar arr idx
+        | AUpd (_, _, arr, idx, value) ->
+            cmdSexpr "[]<-"
+                [ printIntExpr pVar idx
+                  printExpr pVar value
+                  printArrayExpr pVar arr ]
 
     /// Pretty-prints an expression.
     and printExpr (pVar : 'Var -> Doc) : Expr<'Var> -> Doc =

--- a/FlattenerTests.fs
+++ b/FlattenerTests.fs
@@ -40,7 +40,9 @@ module Tests =
         Seq.map
             (function
              | TypedVar.Int x -> x |> siBefore |> Expr.Int
-             | TypedVar.Bool x -> x |> sbBefore |> Expr.Bool)
+             | TypedVar.Bool x -> x |> sbBefore |> Expr.Bool
+             | TypedVar.Array (eltype, length, x) ->
+                Expr.Array (eltype, length, AVar (Reg (Before x))))
             svarSeq
 
 

--- a/GraphTests.fs
+++ b/GraphTests.fs
@@ -44,7 +44,7 @@ module Tests =
 
         /// The guarded holdTick view.
         let gHoldTick cnd : IteratedGFunc<Sym<Var>> =
-            oneGFunc cnd "holdTick" [SVExpr.Int (siVar "t")]
+            oneGFunc cnd "holdTick" [Expr.Int (siVar "t")]
 
         let ticketLockLockGraph : Graph =
             { Name = "lock"
@@ -57,9 +57,10 @@ module Tests =
                                 OutEdge.Dest = "lock_V001"
                                 OutEdge.Command =
                                     [ command "!ILoad++"
-                                           [ Int (siVar "t"); Int (siVar "ticket") ]
-                                           [ Typed.Int (siVar "t")
-                                             Typed.Int (siVar "ticket")]] },
+                                           [ Expr.Int (siVar "t")
+                                             Expr.Int (siVar "ticket") ]
+                                           [ Expr.Int (siVar "t")
+                                             Expr.Int (siVar "ticket")]] },
                            Set.empty,
                            Entry)))
                         ("lock_V001",
@@ -73,9 +74,10 @@ module Tests =
                                 Src = "lock_V000"
                                 Command =
                                     [ command "!ILoad++"
-                                           [ Int (siVar "t"); Int (siVar "ticket"); ]
-                                           [ Typed.Int (siVar "t")
-                                             Typed.Int (siVar "ticket") ]] },
+                                           [ Expr.Int (siVar "t")
+                                             Expr.Int (siVar "ticket"); ]
+                                           [ Expr.Int (siVar "t")
+                                             Expr.Int (siVar "ticket") ]] },
                           Normal ))
                         ("lock_V002",
                          (Mandatory <| Multiset.singleton (gHoldLock BTrue),
@@ -85,7 +87,7 @@ module Tests =
                                 Src = "lock_V004"
                                 Command =
                                     [ command "Assume" []
-                                           [ Typed.Bool
+                                           [ Expr.Bool
                                                  (iEq (siVar "s")
                                                       (siVar "t")) ]] },
                            Exit))
@@ -96,14 +98,14 @@ module Tests =
                                 Dest = "lock_V004"
                                 Command =
                                     [ command "!ILoad"
-                                           [ Int (siVar "s") ]
-                                           [ Typed.Int (siVar "serving") ]] },
+                                           [ Expr.Int (siVar "s") ]
+                                           [ Expr.Int (siVar "serving") ]] },
                           Set.ofList
                               [ { Name = "lock_C002"
                                   Src = "lock_V004"
                                   Command =
                                       [ command "Assume" []
-                                             [ Typed.Bool
+                                             [ Expr.Bool
                                                    (BNot (iEq (siVar "s")
                                                               (siVar "t"))) ]] }
                                 { Name = "lock_C004"
@@ -120,14 +122,14 @@ module Tests =
                                   Dest = "lock_V003"
                                   Command =
                                       [ command "Assume" []
-                                             [ Typed.Bool
+                                             [ Expr.Bool
                                                    (BNot (iEq (siVar "s")
                                                               (siVar "t"))) ]] }
                                 { Name = "lock_C003"
                                   Dest = "lock_V002"
                                   Command =
                                       [ command "Assume" []
-                                             [ Typed.Bool
+                                             [ Expr.Bool
                                                    (iEq (siVar "s")
                                                         (siVar "t")) ]] } ],
                           Set.singleton
@@ -135,8 +137,8 @@ module Tests =
                                 Src = "lock_V003"
                                 Command =
                                     [ command "!ILoad"
-                                           [ Int (siVar "s") ]
-                                           [ Typed.Int (siVar "serving") ]] },
+                                           [ Expr.Int (siVar "s") ]
+                                           [ Expr.Int (siVar "serving") ]] },
 
                           Normal)) ] }
 
@@ -154,8 +156,8 @@ module Tests =
                                 Dest = "unlock_V001"
                                 Command =
                                     [ command "!I++"
-                                           [ Int (siVar "serving") ]
-                                           [ Typed.Int (siVar "serving") ]] },
+                                           [ Expr.Int (siVar "serving") ]
+                                           [ Expr.Int (siVar "serving") ]] },
                           Set.empty,
                           Entry))
                         ("unlock_V001",
@@ -166,8 +168,8 @@ module Tests =
                                 Src = "unlock_V000"
                                 Command =
                                     [ command "!I++"
-                                           [ Int (siVar "serving") ]
-                                           [ Typed.Int (siVar "serving") ]] },
+                                           [ Expr.Int (siVar "serving") ]
+                                           [ Expr.Int (siVar "serving") ]] },
                            Exit)) ] }
 
         /// The partial CFG for the ticket lock lock method.
@@ -189,21 +191,22 @@ module Tests =
                       [ ("lock_C000",
                              edge "lock_V000"
                                   [ command "!ILoad++"
-                                         [ Int (siVar "t"); Int (siVar "ticket") ]
-                                         [ Typed.Int (siVar "t")
-                                           Typed.Int (siVar "ticket") ]]
+                                         [ Expr.Int (siVar "t")
+                                           Expr.Int (siVar "ticket") ]
+                                         [ Expr.Int (siVar "t")
+                                           Expr.Int (siVar "ticket") ]]
                                   "lock_V001")
                         ("lock_C001",
                              edge "lock_V003"
                                   [ command "!ILoad"
-                                         [ Int (siVar "s") ]
-                                         [ Typed.Int (siVar "serving") ]]
+                                         [ Expr.Int (siVar "s") ]
+                                         [ Expr.Int (siVar "serving") ]]
                                   "lock_V004")
                         ("lock_C002",
                              edge "lock_V004"
                                   [ command "Assume"
                                          []
-                                         [ Typed.Bool
+                                         [ Expr.Bool
                                                (BNot (iEq (siVar "s")
                                                           (siVar "t"))) ]]
                                   "lock_V003")
@@ -211,7 +214,7 @@ module Tests =
                              edge "lock_V004"
                                   [ command "Assume"
                                          []
-                                         [ Typed.Bool
+                                         [ Expr.Bool
                                                (iEq (siVar "s")
                                                     (siVar "t")) ]]
                                   "lock_V002")
@@ -234,8 +237,8 @@ module Tests =
                       [ ("unlock_C000",
                              edge "unlock_V000"
                                   [ command "!I++"
-                                         [ Int (siVar "serving") ]
-                                         [ Typed.Int (siVar "serving") ]]
+                                         [ Expr.Int (siVar "serving") ]
+                                         [ Expr.Int (siVar "serving") ]]
                                   "unlock_V001" ) ] }
 
 
@@ -260,8 +263,8 @@ module Tests =
                                 Dest = "unlock_V001"
                                 Command =
                                     [ command "!I++"
-                                           [ Int (siVar "serving") ]
-                                           [ Int (siVar "serving") ]] },
+                                           [ Expr.Int (siVar "serving") ]
+                                           [ Expr.Int (siVar "serving") ]] },
                           Set.singleton
                               { Name = "unlock_N0"
                                 Src = "unlock_V001"
@@ -278,8 +281,8 @@ module Tests =
                                 Src = "unlock_V000"
                                 Command =
                                     [ command "!I++"
-                                           [ Int (siVar "serving") ]
-                                           [ Int (siVar "serving") ]] },
+                                           [ Expr.Int (siVar "serving") ]
+                                           [ Expr.Int (siVar "serving") ]] },
                           Exit)) ] )
                 .SetName("Adding a valid, unique edge to unlock works")]
 
@@ -313,8 +316,8 @@ module Tests =
                               [ ("unlock_C000",
                                  edge "unlock_V000"
                                       [ command "!I++"
-                                              [ Int (siVar "serving") ]
-                                              [ Int (siVar "serving") ]]
+                                              [ Expr.Int (siVar "serving") ]
+                                              [ Expr.Int (siVar "serving") ]]
                                       "unlock_V000" ) ] } )
                 .SetName("unify C1 into C0 on the ticket lock 'unlock'")
               TestCaseData(("unlock_V000", "unlock_V001"))
@@ -329,8 +332,8 @@ module Tests =
                               [ ("unlock_C000",
                                  edge "unlock_V001"
                                       [ command "!I++"
-                                              [ Int (siVar "serving") ]
-                                              [ Int (siVar "serving") ]]
+                                              [ Expr.Int (siVar "serving") ]
+                                              [ Expr.Int (siVar "serving") ]]
                                       "unlock_V001" ) ] } )
                 .SetName("unify C0 into C1 on the ticket lock 'unlock'")
               TestCaseData(("unlock_V000", "unlock_V002"))
@@ -387,10 +390,10 @@ module Tests =
               TestCaseData(Advisory
                                (Multiset.singleton
                                     (smgfunc BTrue "holdTick"
-                                         [ Int (siBefore "t") ] )))
+                                         [ Expr.Int (siBefore "t") ] )))
                   .Returns(Multiset.singleton
                                (smgfunc BTrue "holdTick"
-                                    [ Int (siBefore "t") ] ))
+                                    [ Expr.Int (siBefore "t") ] ))
                   .SetName("Flattening an advisory viewexpr returns its view") ]
 
         /// <summary>

--- a/GraphTests.fs
+++ b/GraphTests.fs
@@ -57,7 +57,7 @@ module Tests =
                                 OutEdge.Dest = "lock_V001"
                                 OutEdge.Command =
                                     [ command "!ILoad++"
-                                           [ Int "t"; Int "ticket" ]
+                                           [ Int (siVar "t"); Int (siVar "ticket") ]
                                            [ Typed.Int (siBefore "t")
                                              Typed.Int (siBefore "ticket")]] },
                            Set.empty,
@@ -73,7 +73,7 @@ module Tests =
                                 Src = "lock_V000"
                                 Command =
                                     [ command "!ILoad++"
-                                           [ Int "t"; Int "ticket"; ]
+                                           [ Int (siVar "t"); Int (siVar "ticket"); ]
                                            [ Typed.Int (siBefore "t")
                                              Typed.Int (siBefore "ticket") ]] },
                           Normal ))
@@ -96,7 +96,7 @@ module Tests =
                                 Dest = "lock_V004"
                                 Command =
                                     [ command "!ILoad"
-                                           [ Int "s" ]
+                                           [ Int (siVar "s") ]
                                            [ Typed.Int (siBefore "serving") ]] },
                           Set.ofList
                               [ { Name = "lock_C002"
@@ -135,7 +135,7 @@ module Tests =
                                 Src = "lock_V003"
                                 Command =
                                     [ command "!ILoad"
-                                           [ Int "s" ]
+                                           [ Int (siVar "s") ]
                                            [ Typed.Int (siBefore "serving") ]] },
 
                           Normal)) ] }
@@ -154,7 +154,7 @@ module Tests =
                                 Dest = "unlock_V001"
                                 Command =
                                     [ command "!I++"
-                                           [ Int "serving" ]
+                                           [ Int (siVar "serving") ]
                                            [ Typed.Int (siBefore "serving") ]] },
                           Set.empty,
                           Entry))
@@ -166,7 +166,7 @@ module Tests =
                                 Src = "unlock_V000"
                                 Command =
                                     [ command "!I++"
-                                           [ Int "serving" ]
+                                           [ Int (siVar "serving") ]
                                            [ Typed.Int (siBefore "serving") ]] },
                            Exit)) ] }
 
@@ -189,14 +189,14 @@ module Tests =
                       [ ("lock_C000",
                              edge "lock_V000"
                                   [ command "!ILoad++"
-                                         [ Int "t"; Int "ticket" ]
+                                         [ Int (siVar "t"); Int (siVar "ticket") ]
                                          [ Typed.Int (siBefore "t")
                                            Typed.Int (siBefore "ticket") ]]
                                   "lock_V001")
                         ("lock_C001",
                              edge "lock_V003"
                                   [ command "!ILoad"
-                                         [ Int "s" ]
+                                         [ Int (siVar "s") ]
                                          [ Typed.Int (siBefore "serving") ]]
                                   "lock_V004")
                         ("lock_C002",
@@ -234,7 +234,7 @@ module Tests =
                       [ ("unlock_C000",
                              edge "unlock_V000"
                                   [ command "!I++"
-                                         [ Int "serving" ]
+                                         [ Int (siVar "serving") ]
                                          [ Typed.Int (siBefore "serving") ]]
                                   "unlock_V001" ) ] }
 
@@ -260,7 +260,7 @@ module Tests =
                                 Dest = "unlock_V001"
                                 Command =
                                     [ command "!I++"
-                                           [ Int "serving" ]
+                                           [ Int (siVar "serving") ]
                                            [ SMExpr.Int (siBefore "serving") ]] },
                           Set.singleton
                               { Name = "unlock_N0"
@@ -278,7 +278,7 @@ module Tests =
                                 Src = "unlock_V000"
                                 Command =
                                     [ command "!I++"
-                                           [ Int "serving" ]
+                                           [ Int (siVar "serving") ]
                                            [ SMExpr.Int (siBefore "serving") ]] },
                           Exit)) ] )
                 .SetName("Adding a valid, unique edge to unlock works")]
@@ -313,7 +313,7 @@ module Tests =
                               [ ("unlock_C000",
                                  edge "unlock_V000"
                                       [ command "!I++"
-                                              [ Int "serving" ]
+                                              [ Int (siVar "serving") ]
                                               [ SMExpr.Int (siBefore "serving") ]]
                                       "unlock_V000" ) ] } )
                 .SetName("unify C1 into C0 on the ticket lock 'unlock'")
@@ -329,7 +329,7 @@ module Tests =
                               [ ("unlock_C000",
                                  edge "unlock_V001"
                                       [ command "!I++"
-                                              [ Int "serving" ]
+                                              [ Int (siVar "serving") ]
                                               [ SMExpr.Int (siBefore "serving") ]]
                                       "unlock_V001" ) ] } )
                 .SetName("unify C0 into C1 on the ticket lock 'unlock'")

--- a/GraphTests.fs
+++ b/GraphTests.fs
@@ -58,8 +58,8 @@ module Tests =
                                 OutEdge.Command =
                                     [ command "!ILoad++"
                                            [ Int (siVar "t"); Int (siVar "ticket") ]
-                                           [ Typed.Int (siBefore "t")
-                                             Typed.Int (siBefore "ticket")]] },
+                                           [ Typed.Int (siVar "t")
+                                             Typed.Int (siVar "ticket")]] },
                            Set.empty,
                            Entry)))
                         ("lock_V001",
@@ -74,8 +74,8 @@ module Tests =
                                 Command =
                                     [ command "!ILoad++"
                                            [ Int (siVar "t"); Int (siVar "ticket"); ]
-                                           [ Typed.Int (siBefore "t")
-                                             Typed.Int (siBefore "ticket") ]] },
+                                           [ Typed.Int (siVar "t")
+                                             Typed.Int (siVar "ticket") ]] },
                           Normal ))
                         ("lock_V002",
                          (Mandatory <| Multiset.singleton (gHoldLock BTrue),
@@ -86,8 +86,8 @@ module Tests =
                                 Command =
                                     [ command "Assume" []
                                            [ Typed.Bool
-                                                 (iEq (siBefore "s")
-                                                      (siBefore "t")) ]] },
+                                                 (iEq (siVar "s")
+                                                      (siVar "t")) ]] },
                            Exit))
                         ("lock_V003",
                          (Mandatory <| Multiset.singleton (gHoldTick BTrue),
@@ -97,15 +97,15 @@ module Tests =
                                 Command =
                                     [ command "!ILoad"
                                            [ Int (siVar "s") ]
-                                           [ Typed.Int (siBefore "serving") ]] },
+                                           [ Typed.Int (siVar "serving") ]] },
                           Set.ofList
                               [ { Name = "lock_C002"
                                   Src = "lock_V004"
                                   Command =
                                       [ command "Assume" []
                                              [ Typed.Bool
-                                                   (BNot (iEq (siBefore "s")
-                                                              (siBefore "t"))) ]] }
+                                                   (BNot (iEq (siVar "s")
+                                                              (siVar "t"))) ]] }
                                 { Name = "lock_C004"
                                   Src = "lock_V001"
                                   Command = [] } ],
@@ -121,22 +121,22 @@ module Tests =
                                   Command =
                                       [ command "Assume" []
                                              [ Typed.Bool
-                                                   (BNot (iEq (siBefore "s")
-                                                              (siBefore "t"))) ]] }
+                                                   (BNot (iEq (siVar "s")
+                                                              (siVar "t"))) ]] }
                                 { Name = "lock_C003"
                                   Dest = "lock_V002"
                                   Command =
                                       [ command "Assume" []
                                              [ Typed.Bool
-                                                   (iEq (siBefore "s")
-                                                        (siBefore "t")) ]] } ],
+                                                   (iEq (siVar "s")
+                                                        (siVar "t")) ]] } ],
                           Set.singleton
                               { Name = "lock_C001"
                                 Src = "lock_V003"
                                 Command =
                                     [ command "!ILoad"
                                            [ Int (siVar "s") ]
-                                           [ Typed.Int (siBefore "serving") ]] },
+                                           [ Typed.Int (siVar "serving") ]] },
 
                           Normal)) ] }
 
@@ -155,7 +155,7 @@ module Tests =
                                 Command =
                                     [ command "!I++"
                                            [ Int (siVar "serving") ]
-                                           [ Typed.Int (siBefore "serving") ]] },
+                                           [ Typed.Int (siVar "serving") ]] },
                           Set.empty,
                           Entry))
                         ("unlock_V001",
@@ -167,7 +167,7 @@ module Tests =
                                 Command =
                                     [ command "!I++"
                                            [ Int (siVar "serving") ]
-                                           [ Typed.Int (siBefore "serving") ]] },
+                                           [ Typed.Int (siVar "serving") ]] },
                            Exit)) ] }
 
         /// The partial CFG for the ticket lock lock method.
@@ -190,30 +190,30 @@ module Tests =
                              edge "lock_V000"
                                   [ command "!ILoad++"
                                          [ Int (siVar "t"); Int (siVar "ticket") ]
-                                         [ Typed.Int (siBefore "t")
-                                           Typed.Int (siBefore "ticket") ]]
+                                         [ Typed.Int (siVar "t")
+                                           Typed.Int (siVar "ticket") ]]
                                   "lock_V001")
                         ("lock_C001",
                              edge "lock_V003"
                                   [ command "!ILoad"
                                          [ Int (siVar "s") ]
-                                         [ Typed.Int (siBefore "serving") ]]
+                                         [ Typed.Int (siVar "serving") ]]
                                   "lock_V004")
                         ("lock_C002",
                              edge "lock_V004"
                                   [ command "Assume"
                                          []
                                          [ Typed.Bool
-                                               (BNot (iEq (siBefore "s")
-                                                          (siBefore "t"))) ]]
+                                               (BNot (iEq (siVar "s")
+                                                          (siVar "t"))) ]]
                                   "lock_V003")
                         ("lock_C003",
                              edge "lock_V004"
                                   [ command "Assume"
                                          []
                                          [ Typed.Bool
-                                               (iEq (siBefore "s")
-                                                    (siBefore "t")) ]]
+                                               (iEq (siVar "s")
+                                                    (siVar "t")) ]]
                                   "lock_V002")
                         ("lock_C004",
                              edge "lock_V001"
@@ -235,7 +235,7 @@ module Tests =
                              edge "unlock_V000"
                                   [ command "!I++"
                                          [ Int (siVar "serving") ]
-                                         [ Typed.Int (siBefore "serving") ]]
+                                         [ Typed.Int (siVar "serving") ]]
                                   "unlock_V001" ) ] }
 
 
@@ -261,7 +261,7 @@ module Tests =
                                 Command =
                                     [ command "!I++"
                                            [ Int (siVar "serving") ]
-                                           [ SMExpr.Int (siBefore "serving") ]] },
+                                           [ Int (siVar "serving") ]] },
                           Set.singleton
                               { Name = "unlock_N0"
                                 Src = "unlock_V001"
@@ -279,7 +279,7 @@ module Tests =
                                 Command =
                                     [ command "!I++"
                                            [ Int (siVar "serving") ]
-                                           [ SMExpr.Int (siBefore "serving") ]] },
+                                           [ Int (siVar "serving") ]] },
                           Exit)) ] )
                 .SetName("Adding a valid, unique edge to unlock works")]
 
@@ -314,7 +314,7 @@ module Tests =
                                  edge "unlock_V000"
                                       [ command "!I++"
                                               [ Int (siVar "serving") ]
-                                              [ SMExpr.Int (siBefore "serving") ]]
+                                              [ Int (siVar "serving") ]]
                                       "unlock_V000" ) ] } )
                 .SetName("unify C1 into C0 on the ticket lock 'unlock'")
               TestCaseData(("unlock_V000", "unlock_V001"))
@@ -330,7 +330,7 @@ module Tests =
                                  edge "unlock_V001"
                                       [ command "!I++"
                                               [ Int (siVar "serving") ]
-                                              [ SMExpr.Int (siBefore "serving") ]]
+                                              [ Int (siVar "serving") ]]
                                       "unlock_V001" ) ] } )
                 .SetName("unify C0 into C1 on the ticket lock 'unlock'")
               TestCaseData(("unlock_V000", "unlock_V002"))
@@ -387,10 +387,10 @@ module Tests =
               TestCaseData(Advisory
                                (Multiset.singleton
                                     (smgfunc BTrue "holdTick"
-                                         [ SMExpr.Int (siBefore "t") ] )))
+                                         [ Int (siBefore "t") ] )))
                   .Returns(Multiset.singleton
                                (smgfunc BTrue "holdTick"
-                                    [ SMExpr.Int (siBefore "t") ] ))
+                                    [ Int (siBefore "t") ] ))
                   .SetName("Flattening an advisory viewexpr returns its view") ]
 
         /// <summary>

--- a/Grapher.fs
+++ b/Grapher.fs
@@ -76,7 +76,7 @@ let rec graphWhile
         let! exprB =
             mapMessages Traversal
                 (mapTraversal
-                    (tLiftToBoolSrc
+                    (tliftToBoolSrc
                         (tliftToExprDest
                             (traverseTypedSymWithMarker Before)))
                     expr)
@@ -165,7 +165,7 @@ and graphITE
         let! exprB =
             mapMessages Traversal
                 (mapTraversal
-                    (tLiftToBoolSrc
+                    (tliftToBoolSrc
                         (tliftToExprDest
                             (traverseTypedSymWithMarker Before)))
                     expr)

--- a/GuardedViewTests.fs
+++ b/GuardedViewTests.fs
@@ -39,6 +39,14 @@ module Tests =
                     | Positions (Negative::xs) -> IInt 0L
                     | _ -> IInt -1L
                     |> Int
+                | Array (eltype, length, ()) ->
+                    Array
+                        (eltype,
+                         length,
+                         match ctx with
+                         | Positions (Positive::xs) -> AVar "pos"
+                         | Positions (Negative::xs) -> AVar "neg"
+                         | _ -> AVar "?")
                 | Bool () ->
                     match ctx with
                     | Positions (x::xs) -> Context.overapprox x

--- a/Horn.fs
+++ b/Horn.fs
@@ -123,6 +123,7 @@ module Pretty =
         function
         | IVar c -> String c
         | IInt i -> sprintf "%d" i |> String
+        | IIdx _ -> failwith "unexpected array index"
         // Do some reshuffling of n-ary expressions into binary ones.
         // These expressions are left-associative, so this should be sound.
         | IAdd [] -> failwith "unexpected empty addition"

--- a/Instantiate.fs
+++ b/Instantiate.fs
@@ -228,7 +228,7 @@ let instantiate
 
     let subInTypedSym dfunc =
         tliftToTypedSymVarSrc (paramSubFun vfunc dfunc)
-    let subInBool dfunc = tLiftToBoolSrc (subInTypedSym dfunc)
+    let subInBool dfunc = tliftToBoolSrc (subInTypedSym dfunc)
 
     let result =
         bind
@@ -409,7 +409,7 @@ module Phase =
                This returns a pair of (useless) context and neq expression.
                Throw away the context with snd. *)
             let approxBoolExprR =
-                lift snd (toError (tLiftToBoolSrc approx position boolExpr))
+                lift snd (toError (tliftToBoolSrc approx position boolExpr))
 
             (* The above might have left some symbols, eg in integer position.
                Try to remove them, and fail if we can't. *)

--- a/Model.fs
+++ b/Model.fs
@@ -52,6 +52,22 @@ open Starling.Core.Command
 /// </summary>
 [<AutoOpen>]
 module Types =
+    /// <summary>
+    ///     Mid-level register transfer logic used to encode Starling
+    ///     commands.
+    /// </summary>
+    /// <typeparam name="L">The type of lvalues.</typeparam>
+    /// <typeparam name="L">The type of rvalue variables.</typeparam>
+    type Microcode<'L, 'RV> when 'RV : equality =
+        /// <summary>An assignment.</summary>
+        | Assign of lvalue : 'L * rvalue : Expr<'RV>
+        /// <summary>A diverging assertion.</summary>
+        | Assume of assumption : BoolExpr<'RV>
+        /// <summary>A conditional.</summary>
+        | Branch of conditional : BoolExpr<'RV>
+                  * ifTrue : Microcode<'L, 'RV> list
+                  * ifFalse : Microcode<'L, 'RV> list
+
     (*
      * Terms
      *)
@@ -98,7 +114,11 @@ module Types =
     /// A term using only internal boolean expressions.
     type FTerm = CTerm<MBoolExpr>
 
-    type PrimSemantics = { Name: string; Results: TypedVar list; Args: TypedVar list; Body: SVBoolExpr }
+    type PrimSemantics =
+        { Name: string
+          Results: TypedVar list
+          Args: TypedVar list
+          Body: Microcode<TypedVar, Var> list }
     type SemanticsMap<'a> = Map<string, 'a>
     type PrimSemanticsMap = SemanticsMap<PrimSemantics>
 

--- a/Model.fs
+++ b/Model.fs
@@ -67,6 +67,7 @@ module Types =
         | Branch of conditional : BoolExpr<'RV>
                   * ifTrue : Microcode<'L, 'RV> list
                   * ifFalse : Microcode<'L, 'RV> list
+        override this.ToString() = sprintf "%A" this
 
     (*
      * Terms

--- a/Model.fs
+++ b/Model.fs
@@ -57,7 +57,7 @@ module Types =
     ///     commands.
     /// </summary>
     /// <typeparam name="L">The type of lvalues.</typeparam>
-    /// <typeparam name="L">The type of rvalue variables.</typeparam>
+    /// <typeparam name="RV">The type of rvalue variables.</typeparam>
     type Microcode<'L, 'RV> when 'RV : equality =
         /// <summary>An assignment.</summary>
         | Assign of lvalue : 'L * rvalue : Expr<'RV>

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -845,7 +845,7 @@ and modelArrayExpr
              * array type.
              *)
             v
-            |> wrapMessages Var (lookupVar env)
+            |> wrapMessages Var (VarMap.lookup env)
             |> bind (function
                      | Typed.Array (eltype, length, vn) ->
                         ok (eltype, length, AVar (Reg (varF vn)))

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -597,10 +597,9 @@ let rec modelExpr
         (* We can use the active patterns above to figure out whether we
          * need to treat this expression as arithmetic or Boolean.
          *)
-        | _ -> match e with
-                | ArithExp expr -> expr |> modelIntExpr env idxEnv varF |> lift Expr.Int
-                | BoolExp expr -> expr |> modelBoolExpr env idxEnv varF |> lift Expr.Bool
-                | _ -> failwith "unreachable[modelExpr]"
+        | ArithExp' _ -> lift Expr.Int (modelIntExpr env idxEnv varF e)
+        | BoolExp' _ -> lift Expr.Bool (modelBoolExpr env idxEnv varF e)
+        | _ -> failwith "unreachable[modelExpr]"
 
 /// <summary>
 ///     Models a Starling Boolean expression as a <c>BoolExpr</c>.

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -1420,6 +1420,7 @@ let convertTypedVar (lit : AST.Types.TypeLiteral) (name : string)
     match lit with
     | TInt -> ok (Int name)
     | TBool -> ok (Bool name)
+    | TArray _ -> fail (ImpossibleType (lit, "arrays not yet implemented"))
 
 /// <summary>
 ///     Converts a type-variable list to a variable map.

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -1138,7 +1138,7 @@ let modelViewDefs
 
 /// Models an AFunc as a CFunc.
 let modelCFunc
-  ({ ViewProtos = protos; ThreadVars = env } : MethodContext)
+  ({ ViewProtos = protos; ThreadVars = tvars } : MethodContext)
   (afunc : Func<Expression>) =
     // First, make sure this AFunc actually has a prototype
     // and the correct number of parameters.
@@ -1149,7 +1149,7 @@ let modelCFunc
              afunc.Params
              |> Seq.map (fun e ->
                              e
-                             |> modelExpr env env id
+                             |> modelExpr tvars tvars id
                              |> mapMessages (curry ViewError.BadExpr e))
              |> collect
              // Then, put them into a VFunc.

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -81,7 +81,7 @@ module Types =
         /// <summary>
         ///     Two items that should have been the same type were not.
         /// </summary>
-        | TypeMismatch of expected : Type * got : Type
+        | TypeMismatch of expected : string * got : Type
         /// <summary>
         ///     A language type literal is inexpressible in Starling.
         /// </summary>
@@ -255,7 +255,7 @@ module Pretty =
         match err with
         | TypeMismatch (expected, got) ->
             errorStr "expected"
-            <+> quoted (printType expected)
+            <+> errorStr expected
             <&> errorStr "got"
             <+> quoted (printType got)
         | ImpossibleType (lit, why) ->
@@ -559,9 +559,9 @@ let rec modelExpr
   (e : Expression)
   : Result<Expr<Sym<'var>>, ExprError> =
     match e.Node with
-    (* First, if we have a variable, the type of expression is
-       determined by the type of the variable.  If the variable is
-       symbolic, then we have ambiguity. *)
+        (* First, if we have a variable, the type of expression is
+           determined by the type of the variable.  If the variable is
+           symbolic, then we have ambiguity. *)
         | Identifier v ->
             v
             |> wrapMessages Var (VarMap.lookup env)
@@ -572,6 +572,19 @@ let rec modelExpr
                 >> mapMessages BadSub)
         | Symbolic (sym, exprs) ->
             fail (AmbiguousSym sym)
+        (* If we have an array, then work out what the type of the array's
+           elements are, then walk back from there. *)
+        | ArraySubscript (arr, idx) ->
+            let arrResult = modelArrayExpr env varF arr
+            let idxResult = modelIntExpr env varF idx
+            lift2
+                (fun (eltype, length, arrE) idxE ->
+                    match eltype with
+                    | Int () -> Int (IIdx (eltype, length, arrE, idxE))
+                    | Bool () -> Bool (BIdx (eltype, length, arrE, idxE))
+                    | Array (ieltype, ilength, ()) ->
+                        Array (ieltype, ilength, AIdx (eltype, length, arrE, idxE)))
+                arrResult idxResult
         (* We can use the active patterns above to figure out whether we
          * need to treat this expression as arithmetic or Boolean.
          *)
@@ -581,7 +594,7 @@ let rec modelExpr
                 | _ -> failwith "unreachable[modelExpr]"
 
 /// <summary>
-///     Models a Starling integral expression as a <c>BoolExpr</c>.
+///     Models a Starling Boolean expression as a <c>BoolExpr</c>.
 ///
 ///     <para>
 ///         See <c>modelExpr</c> for more information.
@@ -597,23 +610,26 @@ let rec modelExpr
 ///     but before they are placed in <c>IVar</c>.  Use this to apply
 ///     markers on variables, etc.
 /// </param>
+/// <param name="expr">
+///     An expression previously judged as Boolean, to be modelled.
+/// </param>
 /// <typeparam name="var">
 ///     The type of variables in the <c>BoolExpr</c>, achieved by
 ///     applying <paramref name="varF"/> to <c>Var</c>s.
 /// </typeparam>
 /// <returns>
-///     A function, taking <c>Expression</c>s previously judged as
-///     Boolean.  This function will return a <c>Result</c>, over
-///     <c>ExprError</c>, containing the modelled <c>BoolExpr</c> on
-///     success.  The exact type parameters of the expression depend on
+///     A <c>Result</c>, over <c>ExprError</c>, containing the modelled
+///     <c>BoolExpr</c> on success.
+///     The exact type parameters of the expression depend on
 ///     <paramref name="varF"/>.
 /// </returns>
 and modelBoolExpr
   (env : VarMap)
   (varF : Var -> 'var)
-  : Expression -> Result<BoolExpr<Sym<'var>>, ExprError> =
+  (expr : Expression) : Result<BoolExpr<Sym<'var>>, ExprError> =
     let mi = modelIntExpr env varF
     let me = modelExpr env varF
+    let ma = modelArrayExpr env varF
 
     let rec mb e =
         match e.Node with
@@ -632,13 +648,22 @@ and modelBoolExpr
                             (VarBadType
                                 (v,
                                  TypeMismatch
-                                    (expected = Type.Bool (),
-                                     got = typeOf vr))))
+                                    (expected = "bool", got = typeOf vr))))
         | Symbolic (sym, args) ->
             args
             |> List.map me
             |> collect
             |> lift (func sym >> Sym >> BVar)
+        | ArraySubscript (arr, idx) ->
+            let arrResult = ma arr
+            let idxResult = mi idx
+            bind2
+                (fun (eltype, length, arrE) idxE ->
+                    match eltype with
+                    | Bool () -> ok (BIdx (eltype, length, arrE, idxE))
+                    | t ->
+                        fail (ExprBadType (TypeMismatch (expected = "bool[]", got = t))))
+                arrResult idxResult
         | BopExpr(BoolOp as op, l, r) ->
             match op with
             | ArithIn as o ->
@@ -665,10 +690,9 @@ and modelBoolExpr
                        | _ -> failwith "unreachable[modelBoolExpr::AnyIn]")
                       (me l)
                       (me r)
-        // TODO(CaptainHayashi): figure out what the actual type is here
         | _ ->
-            fail (ExprBadType (TypeMismatch (expected = Bool (), got = Int ())))
-    mb
+            fail (ExprBadType (TypeMismatch (expected = "bool", got = Int ())))
+    mb expr
 
 /// <summary>
 ///     Models a Starling integral expression as an <c>IntExpr</c>.
@@ -687,22 +711,25 @@ and modelBoolExpr
 ///     but before they are placed in <c>IVar</c>.  Use this to apply
 ///     markers on variables, etc.
 /// </param>
+/// <param name="expr">
+///     An expression previously judged as integral, to be modelled.
+/// </param>
 /// <typeparam name="var">
 ///     The type of variables in the <c>IntExpr</c>, achieved by
 ///     applying <paramref name="varF"/> to <c>Var</c>s.
 /// </typeparam>
 /// <returns>
-///     A function, taking <c>Expression</c>s previously judged as
-///     integral.  This function will return a <c>Result</c>, over
-///     <c>ExprError</c>, containing the modelled <c>IntExpr</c> on
-///     success.  The exact type parameters of the expression depend on
+///     A <c>Result</c>, over <c>ExprError</c>, containing the modelled
+///     <c>IntExpr</c> on success.
+///     The exact type parameters of the expression depend on
 ///     <paramref name="varF"/>.
 /// </returns>
 and modelIntExpr
   (env : VarMap)
   (varF : Var -> 'var)
-  : Expression -> Result<IntExpr<Sym<'var>>, ExprError> =
+  (expr : Expression) : Result<IntExpr<Sym<'var>>, ExprError> =
     let me = modelExpr env varF
+    let ma = modelArrayExpr env varF
 
     let rec mi e =
         match e.Node with
@@ -720,13 +747,22 @@ and modelIntExpr
                             (VarBadType
                                 (v,
                                  TypeMismatch
-                                    (expected = Type.Int (),
-                                     got = typeOf vr))))
+                                    (expected = "int", got = typeOf vr))))
         | Symbolic (sym, args) ->
             args
             |> List.map me
             |> collect
             |> lift (func sym >> Sym >> IVar)
+        | ArraySubscript (arr, idx) ->
+            let arrResult = ma arr
+            let idxResult = mi idx
+            bind2
+                (fun (eltype, length, arrE) idxE ->
+                    match eltype with
+                    | Int () -> ok (IIdx (eltype, length, arrE, idxE))
+                    | t ->
+                        fail (ExprBadType (TypeMismatch (expected = "int[]", got = t))))
+                arrResult idxResult
         | BopExpr(ArithOp as op, l, r) ->
             lift2 (match op with
                    | Mul -> mkMul2
@@ -737,10 +773,88 @@ and modelIntExpr
                    | _ -> failwith "unreachable[modelIntExpr]")
                   (mi l)
                   (mi r)
-        // TODO(CaptainHayashi): figure out what the actual type is here
         | _ ->
-            fail (ExprBadType (TypeMismatch (expected = Int (), got = Bool ())))
-    mi
+            fail (ExprBadType (TypeMismatch (expected = "int", got = Bool ())))
+    mi expr
+
+/// <summary>
+///     Models a Starling array expression as an <c>ArrayExpr</c>.
+///
+///     <para>
+///         See <c>modelExpr</c> for more information.
+///     </para>
+/// </summary>
+/// <param name="env">
+///     The <c>VarMap</c> of variables bound where this expression
+///     occurs.  Usually, but not always, these are the thread-local
+///     variables.
+/// </param>
+/// <param name="varF">
+///     A function to transform any variables after they are looked-up,
+///     but before they are placed in <c>AVar</c>.  Use this to apply
+///     markers on variables, etc.
+/// </param>
+/// <param name="expr">
+///     An expression previously judged as integral, to be modelled.
+/// </param>
+/// <typeparam name="var">
+///     The type of variables in the <c>ArrayExpr</c>, achieved by
+///     applying <paramref name="varF"/> to <c>Var</c>s.
+/// </typeparam>
+/// <returns>
+///     A <c>Result</c>, over <c>ExprError</c>, containing the modelled
+///     <c>ArrayExpr</c> on success.
+///     The exact type parameters of the expression depend on
+///     <paramref name="varF"/>.
+/// </returns>
+and modelArrayExpr
+  (env : VarMap)
+  (varF : Var -> 'var)
+  (expr : Expression)
+  : Result<Type * int option * ArrayExpr<Sym<'var>>, ExprError> =
+    let mi = modelIntExpr env varF
+
+    let rec ma e =
+        match e.Node with
+        | Identifier v ->
+            (* Look-up the variable to ensure it a) exists and b) is of an
+             * array type.
+             *)
+            v
+            |> wrapMessages Var (lookupVar env)
+            |> bind (function
+                     | Typed.Array (eltype, length, vn) ->
+                        ok (eltype, length, AVar (Reg (varF vn)))
+                     | vr ->
+                        fail
+                            (VarBadType
+                                (v,
+                                 TypeMismatch
+                                    (expected = "array", got = typeOf vr))))
+        | Symbolic (sym, _) ->
+            (* TODO(CaptainHayashi): a symbolic array is ambiguously typed.
+               Maybe when modelling we should take our 'best guess' at
+               eltype and length from any subscripting expression? *)
+            fail (AmbiguousSym sym)
+        | ArraySubscript (arr, idx) ->
+            let arrResult = ma arr
+            let idxResult = mi idx
+            bind2
+                (fun (eltype, length, arrE) idxE ->
+                    match eltype with
+                    | Array (eltype', length', ()) ->
+                        ok (eltype', length', AIdx (eltype, length, arrE, idxE))
+                    | t ->
+                        // TODO(CaptainHayashi): more sensible error?
+                        fail (ExprBadType (TypeMismatch (expected = "array[]", got = t))))
+                arrResult idxResult
+        | ArithExp' _ ->
+            fail (ExprBadType (TypeMismatch (expected = "array", got = Int ())))
+        | BoolExp' _ ->
+            fail (ExprBadType (TypeMismatch (expected = "array", got = Bool ())))
+        // We should have covered all expressions by here.
+        | _ -> failwith "unreachable?[modelArrayExpr]"
+    ma expr
 
 (*
  * Views
@@ -1219,7 +1333,13 @@ let modelCAS
         | d, t ->
             (* Oops, we have a type error.
                Arbitrarily single out test as the cause of it. *)
-            fail (BadType (test, TypeMismatch (typeOf d, typeOf t)))
+            fail
+                (BadType
+                    (test,
+                     TypeMismatch
+                        // TODO(CaptainHayashi): clean this up
+                        (Starling.Core.Pretty.printUnstyled
+                            (Starling.Core.TypeSystem.Pretty.printType (typeOf d)), typeOf t)))
 
     (* We need the unmarked version of dest and test for the outputs,
        and the marked version for the inputs. *)

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -414,7 +414,9 @@ module Pretty =
 (*
  * Starling imperative language semantics
  *)
-let prim (name : string) (results : TypedVar list) (args : TypedVar list)
+
+/// Creates a prim from a name, results list, and arguments list.
+let mkPrim (name : string) (results : TypedVar list) (args : TypedVar list)
   (body : Microcode<TypedVar, Var> list)
   : PrimSemantics =
     { Name = name; Results = results; Args = args; Body = body }
@@ -437,7 +439,7 @@ let coreSemantics : PrimSemanticsMap =
       (*
        * CAS
        *)
-      (prim "ICAS" [ Int "destA"; Int "testA" ] [ Int "destB"; Int "testB"; Int "set" ]
+      (mkPrim "ICAS" [ Int "destA"; Int "testA" ] [ Int "destB"; Int "testB"; Int "set" ]
            [ Branch
                 (iEq (IVar "destB") (IVar "testB"),
                  [ Assign (Int "destA", Int (IVar "set"))
@@ -445,7 +447,7 @@ let coreSemantics : PrimSemanticsMap =
                  [ Assign (Int "destA", Int (IVar "destB"))
                    Assign (Int "testA", Int (IVar "destB")) ] ) ] )
       // Boolean CAS
-      (prim "BCAS" [ Bool "destA"; Bool "testA" ] [ Bool "destB"; Bool "testB"; Bool "set" ]
+      (mkPrim "BCAS" [ Bool "destA"; Bool "testA" ] [ Bool "destB"; Bool "testB"; Bool "set" ]
            [ Branch
                 (bEq (BVar "destB") (BVar "testB"),
                  [ Assign (Bool "destA", Bool (BVar "set"))
@@ -456,29 +458,29 @@ let coreSemantics : PrimSemanticsMap =
        * Atomic load
        *)
       // Integer load
-      (prim "!ILoad"  [ Int "dest" ] [ Int "src" ]
+      (mkPrim "!ILoad"  [ Int "dest" ] [ Int "src" ]
             [ Assign (Int "dest", Int (IVar "src")) ] )
 
       // Integer load-and-increment
-      (prim "!ILoad++"  [ Int "dest"; Int "srcA" ] [ Int "srcB" ]
+      (mkPrim "!ILoad++"  [ Int "dest"; Int "srcA" ] [ Int "srcB" ]
             [ Assign (Int "dest", Int (IVar "srcB"))
               Assign (Int "srcA", Int (mkAdd2 (IVar "srcB") (IInt 1L))) ] )
 
       // Integer load-and-decrement
-      (prim "!ILoad--"  [ Int "dest"; Int "srcA" ] [ Int "srcB" ]
+      (mkPrim "!ILoad--"  [ Int "dest"; Int "srcA" ] [ Int "srcB" ]
             [ Assign (Int "dest", Int (IVar "srcB"))
               Assign (Int "srcA", Int (mkSub2 (IVar "srcB") (IInt 1L))) ] )
 
       // Integer increment
-      (prim "!I++"  [ Int "srcA" ] [ Int "srcB" ]
+      (mkPrim "!I++"  [ Int "srcA" ] [ Int "srcB" ]
             [ Assign (Int "srcA", Int (mkAdd2 (IVar "srcB") (IInt 1L))) ] )
 
       // Integer decrement
-      (prim "!I--"  [ Int "srcA" ] [ Int "srcB" ]
+      (mkPrim "!I--"  [ Int "srcA" ] [ Int "srcB" ]
             [ Assign (Int "srcA", Int (mkSub2 (IVar "srcB") (IInt 1L))) ] )
 
       // Boolean load
-      (prim "!BLoad"  [ Bool "dest" ] [ Bool "src" ]
+      (mkPrim "!BLoad"  [ Bool "dest" ] [ Bool "src" ]
             [ Assign (Bool "dest", Bool (BVar "src")) ] )
 
       (*
@@ -486,11 +488,11 @@ let coreSemantics : PrimSemanticsMap =
        *)
 
       // Integer store
-      (prim "!IStore" [ Int "dest" ] [ Int "src" ]
+      (mkPrim "!IStore" [ Int "dest" ] [ Int "src" ]
             [ Assign (Int "dest", Int (IVar "src")) ] )
 
       // Boolean store
-      (prim "!BStore" [ Bool "dest" ] [ Bool "src" ]
+      (mkPrim "!BStore" [ Bool "dest" ] [ Bool "src" ]
             [ Assign (Bool "dest", Bool (BVar "src")) ] )
 
       (*
@@ -498,11 +500,11 @@ let coreSemantics : PrimSemanticsMap =
        *)
 
       // Integer local set
-      (prim "!ILSet" [ Int "dest" ] [ Int "src" ]
+      (mkPrim "!ILSet" [ Int "dest" ] [ Int "src" ]
             [ Assign (Int "dest", Int (IVar "src")) ] )
 
       // Boolean store
-      (prim "!BLSet" [ Bool "dest" ] [ Bool "src" ]
+      (mkPrim "!BLSet" [ Bool "dest" ] [ Bool "src" ]
             [ Assign (Bool "dest", Bool (BVar "src")) ] )
 
       (*
@@ -510,10 +512,10 @@ let coreSemantics : PrimSemanticsMap =
        *)
 
       // Identity
-      (prim "Id" [] [] [])
+      (mkPrim "Id" [] [] [])
 
       // Assume
-      (prim "Assume" [] [Bool "expr"] [ Microcode.Assume (BVar "expr") ]) ]
+      (mkPrim "Assume" [] [Bool "expr"] [ Microcode.Assume (BVar "expr") ]) ]
 
 (*
  * Expression translation

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -156,6 +156,10 @@ module Types =
         | BadType of expr : AST.Types.Expression * err : TypeError
         /// A prim has no effect.
         | Useless
+        /// <summary>
+        ///     A prim is not yet implemented in Starling.
+        /// </summary>
+        | PrimNotImplemented of what : string
 
     /// Represents an error when converting a method.
     type MethodError =
@@ -357,6 +361,10 @@ module Pretty =
                 <+> quoted (printExpression expr)
                 <+> errorStr "has incorrect type"
             cmdHeaded header [ printTypeError err ]
+        | PrimNotImplemented what ->
+            errorStr "primitive command"
+            <+> quoted (String what)
+            <+> errorStr "not yet implemented"
 
 
     /// Pretty-prints method errors.
@@ -1242,10 +1250,14 @@ let modelFetch
             match (VarMap.tryLookup ctx.SharedVars v) with
             | Some (Typed.Int _) -> ok modelIntStore
             | Some (Typed.Bool _) -> ok modelBoolStore
+            | Some (Typed.Array (_))
+                -> fail (PrimNotImplemented "array fetch")
             | None ->
                 match (VarMap.tryLookup ctx.ThreadVars v) with
                 | Some (Typed.Int _) -> ok modelIntLoad
                 | Some (Typed.Bool _) -> ok modelBoolLoad
+                | Some (Typed.Array (_))
+                    -> fail (PrimNotImplemented "array fetch")
                 | None -> fail (BadExpr (dest, Var (v, NotFound v)))
         | ArraySubscript (arr, _) -> findModeller arr
         // TODO(CaptainHayashi): symbols
@@ -1276,6 +1288,7 @@ let modelPostfix (ctx : MethodContext) (operand : Expression) (mode : FetchMode)
             ok (command "!I++" [ opPost ] [ opPre ])
         | Decrement, Typed.Int _ ->
             ok (command "!I--" [ opPost ] [ opPre ])
+        | _, Typed.Array (_) -> fail (PrimNotImplemented "array postfix")
     bind2 modelWithOperand
         (modelLValue ctx.SharedVars MarkedVar.Before operand)
         (modelLValue ctx.SharedVars id operand)
@@ -1306,10 +1319,11 @@ and modelAssign
        We thus also have to make sure that src is the correct type. *)
     let modelWithDestAndSrc destPost srcPre =
         match destPost with
-        | Typed.Bool _ -> command "!BLSet" [ destPost ] [ srcPre ]
-        | Typed.Int _  -> command "!ILSet" [ destPost ] [ srcPre ]
+        | Typed.Bool _ -> ok (command "!BLSet" [ destPost ] [ srcPre ])
+        | Typed.Int _  -> ok (command "!ILSet" [ destPost ] [ srcPre ])
+        | Typed.Array (_) -> fail (PrimNotImplemented "array local assign")
 
-    lift2 modelWithDestAndSrc
+    bind2 modelWithDestAndSrc
         (modelLValue ctx.ThreadVars id dest)
         (wrapMessages BadExpr (modelExpr ctx.ThreadVars MarkedVar.Before) src)
 

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -97,9 +97,9 @@ module Types =
         /// <summary>
         ///     A variable in the expression failed the type checker.
         /// </summary>
-        | VarBadType of var : LValue * err : TypeError
+        | VarBadType of var : Var * err : TypeError
         /// A variable usage in the expression produced a `VarMapError`.
-        | Var of var : LValue * err : VarMapError
+        | Var of var : Var * err : VarMapError
         /// A substitution over the variable produced a `TraversalError`.
         | BadSub of err : TraversalError<unit>
         /// A symbolic expression appeared in an ambiguous position.
@@ -136,12 +136,10 @@ module Types =
 
     /// Represents an error when converting a prim.
     type PrimError =
-        /// A prim used a bad shared variable.
-        | BadSVar of var : LValue * err : VarMapError
-        /// A prim used a bad thread variable.
-        | BadTVar of var : LValue * err : VarMapError
-        /// A prim used a bad variable of ambiguous scope.
-        | BadIVar of var : LValue * err : VarMapError
+        /// <summary>
+        ///     A prim needed a lvalue but got a non-lvalue expression.
+        /// </summary>
+        | NeedLValue of expr : AST.Types.Expression
         /// A prim contained a bad expression.
         | BadExpr of expr : AST.Types.Expression * err : ExprError
         /// A prim tried to increment an expression.
@@ -155,15 +153,16 @@ module Types =
         /// A prim tried to atomic-load from a non-lvalue expression.
         | LoadNonLV of expr : AST.Types.Expression
         /// A prim had a type error in it.
-        | BadType of lv : LValue * err : TypeError
+        | BadType of expr : AST.Types.Expression * err : TypeError
         /// A prim has no effect.
         | Useless
 
     /// Represents an error when converting a method.
     type MethodError =
         /// The method contains a semantically invalid local assign.
-        | BadAssign of dest : LValue * src : AST.Types.Expression
-                                     * err : PrimError
+        | BadAssign of dest : AST.Types.Expression
+                     * src : AST.Types.Expression
+                     * err : PrimError
         /// The method contains a semantically invalid atomic action.
         | BadAtomic of atom : Atomic * err : PrimError
         /// The method contains a bad if-then-else condition.
@@ -276,9 +275,9 @@ module Pretty =
                 [ printTypeError err ]
         | VarBadType (lv, err) ->
             let header =
-                errorStr "type error in lvalue" <+> quoted (printLValue lv)
+                errorStr "type error in variable" <+> quoted (String lv)
             cmdHeaded header [ printTypeError err ]
-        | Var(var, err) -> wrapped "variable" (var |> printLValue) (err |> printVarMapError)
+        | Var(var, err) -> wrapped "variable" (var |> String) (err |> printVarMapError)
         | BadSub err ->
             fmt "Substitution error: {0}" [ printTraversalError (fun _ -> String "()") err ]
         | AmbiguousSym sym ->
@@ -330,14 +329,9 @@ module Pretty =
     /// Pretty-prints prim errors.
     let printPrimError (err : PrimError) : Doc =
         match err with
-        | BadSVar (var, err : VarMapError) ->
-            wrapped "shared lvalue" (printLValue var)
-                                    (printVarMapError err)
-        | BadTVar (var, err : VarMapError) ->
-            wrapped "thread-local lvalue" (printLValue var)
-                                          (printVarMapError err)
-        | BadIVar (var, err : VarMapError) ->
-            wrapped "lvalue" (printLValue var) (printVarMapError err)
+        | NeedLValue expr ->
+            errorStr "expected lvalue here, but got"
+            <+> quoted (printExpression expr)
         | BadExpr (expr, err : ExprError) ->
             wrapped "expression" (printExpression expr)
                                  (printExprError err)
@@ -357,10 +351,10 @@ module Pretty =
             fmt "cannot load from non-lvalue expression '{0}'"
                 [ printExpression expr ]
         | Useless -> String "command has no effect"
-        | BadType (lv, err) ->
+        | BadType (expr, err) ->
             let header =
-                errorStr "lvalue"
-                <+> quoted (printLValue lv)
+                errorStr "expression"
+                <+> quoted (printExpression expr)
                 <+> errorStr "has incorrect type"
             cmdHeaded header [ printTypeError err ]
 
@@ -560,7 +554,7 @@ let rec modelExpr
     (* First, if we have a variable, the type of expression is
        determined by the type of the variable.  If the variable is
        symbolic, then we have ambiguity. *)
-        | LV v ->
+        | Identifier v ->
             v
             |> wrapMessages Var (VarMap.lookup env)
             |> bind (
@@ -617,7 +611,7 @@ and modelBoolExpr
         match e.Node with
         | True -> BTrue |> ok
         | False -> BFalse |> ok
-        | LV v ->
+        | Identifier v ->
             (* Look-up the variable to ensure it a) exists and b) is of a
              * Boolean type.
              *)
@@ -705,7 +699,7 @@ and modelIntExpr
     let rec mi e =
         match e.Node with
         | Num i -> i |> IInt |> ok
-        | LV v ->
+        | Identifier v ->
             (* Look-up the variable to ensure it a) exists and b) is of an
              * arithmetic type.
              *)
@@ -1044,160 +1038,247 @@ let rec modelCView (ctx : MethodContext) : View -> Result<CView, ViewError> =
 // Axioms
 //
 
-let (|Shared|_|) ctx (lvalue : LValue) = VarMap.tryLookup ctx.SharedVars lvalue
-let (|Thread|_|) ctx (lvalue : LValue) = VarMap.tryLookup ctx.ThreadVars lvalue
+/// <summary>
+///     Models a Boolean lvalue given a potentially valid expression and
+///     environment.
+/// </summary>
+/// <param name="env">The environment of variables used for the lvalue.</param>
+/// <param name="marker">A function that marks (or doesn't mark) vars.</param>
+/// <param name="ex">The possible lvalue to model.</param>
+/// <returns>If the subject is a valid lvalue, the result expression.</returns>
+let modelBoolLValue (env : VarMap) (marker : Var -> 'Var) (ex : Expression)
+  : Result<BoolExpr<Sym<'Var>>, PrimError> =
+    match ex with
+    | RValue r -> fail (NeedLValue r)
+    | LValue l -> wrapMessages BadExpr (modelBoolExpr env marker) l
+
+/// <summary>
+///     Models an integer lvalue given a potentially valid expression and
+///     environment.
+/// </summary>
+/// <param name="env">The environment of variables used for the lvalue.</param>
+/// <param name="marker">A function that marks (or doesn't mark) vars.</param>
+/// <param name="ex">The possible lvalue to model.</param>
+/// <returns>If the subject is a valid lvalue, the result expression.</returns>
+let modelIntLValue (env : VarMap) (marker : Var -> 'Var) (ex : Expression)
+  : Result<IntExpr<Sym<'Var>>, PrimError> =
+    match ex with
+    | RValue r -> fail (NeedLValue r)
+    | LValue l -> wrapMessages BadExpr (modelIntExpr env marker) l
+
+/// <summary>
+///     Models an lvalue given a potentially valid expression and
+///     environment.
+/// </summary>
+/// <param name="env">The environment of variables used for the lvalue.</param>
+/// <param name="marker">A function that marks (or doesn't mark) vars.</param>
+/// <param name="ex">The possible lvalue to model.</param>
+/// <returns>If the subject is a valid lvalue, the result expression.</returns>
+let modelLValue (env : VarMap) (marker : Var -> 'Var) (ex : Expression)
+  : Result<Expr<Sym<'Var>>, PrimError> =
+    match ex with
+    | RValue r -> fail (NeedLValue r)
+    | LValue l -> wrapMessages BadExpr (modelExpr env marker) l
 
 /// Converts a Boolean load to a Prim.
-let modelBoolLoad : MethodContext -> Var -> Expression -> FetchMode -> Result<PrimCommand, PrimError> =
-    fun { SharedVars = svars } dest srcExpr mode ->
-    (* In a Boolean load, the destination must be LOCAL and Boolean;
-     *                    the source must be a GLOBAL Boolean lvalue;
-     *                    and the fetch mode must be Direct.
-     *)
-    match srcExpr.Node with
-    | LV srcLV ->
-        trial {
-            let! src = wrapMessages BadSVar (VarMap.lookup svars) srcLV
-            match src, mode with
-            | Typed.Bool s, Direct ->
-                return
-                    command
-                        "!BLoad"
-                            [ Bool dest ]
-                            [ s |> Before |> Reg |> BVar |> Expr.Bool ]
+let modelBoolLoad
+  (ctx : MethodContext)
+  (dest : Expression)
+  (src : Expression)
+  (mode : FetchMode)
+  : Result<PrimCommand, PrimError> =
+    (* In a Boolean load, the destination must be a THREAD Boolean lvalue;
+                          the source must be a SHARED Boolean lvalue;
+                          and the fetch mode must be Direct. *)
+    let modelWithExprs dstE srcE =
+        match mode with
+        | Direct -> ok (command "!BLoad" [ Bool dstE ] [ Bool srcE ])
+        | Increment -> fail (IncBool src)
+        | Decrement -> fail (DecBool src)
 
-            | Typed.Bool s, Increment -> return! fail (IncBool srcExpr)
-            | Typed.Bool s, Decrement -> return! fail (DecBool srcExpr)
-            | _ ->
-                return!
-                    (fail
-                        (BadType
-                            (srcLV,
-                             TypeMismatch (Type.Bool (), typeOf src))))
-        }
-    | _ -> fail (LoadNonLV srcExpr)
+    bind2 modelWithExprs
+        (modelBoolLValue ctx.ThreadVars id dest)
+        (modelBoolLValue ctx.SharedVars MarkedVar.Before src)
 
 /// Converts an integer load to a Prim.
-let modelIntLoad : MethodContext -> Var -> Expression -> FetchMode -> Result<PrimCommand, PrimError> =
-    fun { SharedVars = svars } dest srcExpr mode ->
-    (* In an integer load, the destination must be LOCAL and integral;
-     *                    the source must be a GLOBAL arithmetic lvalue;
-     *                    and the fetch mode is unconstrained.
-     *)
-    match srcExpr.Node with
-    | LV srcLV ->
-        trial {
-            let! src = wrapMessages BadSVar (VarMap.lookup svars) srcLV
-            match src, mode with
-            | Typed.Int s, Direct ->
-                return command "!ILoad" [ Int dest ] [ s |> Before |> Reg |> IVar |> Expr.Int ]
+let modelIntLoad
+  (ctx : MethodContext)
+  (dest : Expression)
+  (src : Expression)
+  (mode : FetchMode)
+  : Result<PrimCommand, PrimError> =
+    (* In an integer load, the destination must be a THREAD integral lvalue;
+                           the source must be a SHARED integral lvalue;
+                           and the fetch mode is unconstrained. *)
+    let modelWithExprs dstPost srcPre srcPost =
+        let cmd, reads =
+            match mode with
+            | Direct -> "!ILoad", [ dstPost ]
+            | Increment -> "!ILoad++", [ dstPost; srcPost ]
+            | Decrement -> "!ILoad--", [ dstPost; srcPost ]
+        command cmd (List.map Int reads) [ Int srcPre ]
 
-            | Typed.Int s, Increment ->
-                return command "!ILoad++" [ Int dest; Int s ] [ s |> Before |> Reg |> IVar |> Expr.Int ]
-
-            | Typed.Int s, Decrement ->
-                return command "!ILoad--" [ Int dest; Int s ] [ s |> Before |> Reg |> IVar |> Expr.Int ]
-
-            | _ -> return! fail (BadType (srcLV, TypeMismatch (Type.Int (), typeOf src)))
-        }
-    | _ -> fail (LoadNonLV srcExpr)
+    lift3 modelWithExprs
+        (modelIntLValue ctx.ThreadVars id dest)
+        (modelIntLValue ctx.SharedVars MarkedVar.Before src)
+        (modelIntLValue ctx.SharedVars id src)
 
 /// Converts a Boolean store to a Prim.
-let modelBoolStore : MethodContext -> Var -> Expression -> FetchMode -> Result<PrimCommand, PrimError> =
-    fun { ThreadVars = tvars } dest src mode ->
-    (* In a Boolean store, the destination must be GLOBAL and Boolean;
-     *                     the source must be LOCAL and Boolean;
-     *                     and the fetch mode must be Direct.
-     *)
-    trial {
-        let! sxp = wrapMessages BadExpr (modelBoolExpr tvars Before) src
+let modelBoolStore
+  (ctx : MethodContext)
+  (dest : Expression)
+  (src : Expression)
+  (mode : FetchMode)
+  : Result<PrimCommand, PrimError> =
+    (* In a Boolean store, the destination must a SHARED Boolean lvalue;
+                           the source must be THREAD Boolean;
+                           and the fetch mode must be Direct. *)
+    let modelWithExprs dstE srcE =
         match mode with
-        | Direct ->
-            return
-                command
-                    "!BStore"
-                    [ Bool dest ]
-                    [ sxp |> Expr.Bool ]
-        | Increment -> return! fail (IncBool src)
-        | Decrement -> return! fail (DecBool src)
-    }
+        | Direct -> ok (command "!BStore" [ Bool dstE ] [ Bool srcE ])
+        | Increment -> fail (IncBool src)
+        | Decrement -> fail (DecBool src)
+
+    bind2 modelWithExprs
+        (modelBoolLValue ctx.SharedVars id dest)
+        (wrapMessages BadExpr (modelBoolExpr ctx.ThreadVars MarkedVar.Before) src)
 
 /// Converts an integral store to a Prim.
-let modelIntStore : MethodContext -> Var -> Expression -> FetchMode -> Result<PrimCommand, PrimError> =
-    fun { ThreadVars = tvars } dest src mode ->
+let modelIntStore
+  (ctx : MethodContext)
+  (dest : Expression)
+  (src : Expression)
+  (mode : FetchMode)
+  : Result<PrimCommand, PrimError> =
     (* In an integral store, the destination must be GLOBAL and integral;
      *                       the source must be LOCAL and integral;
      *                       and the fetch mode must be Direct.
      *)
-    trial {
-        let! sxp =
-            wrapMessages BadExpr (modelIntExpr tvars MarkedVar.Before) src
-        match mode with
-        | Direct ->
-            return
-                command
-                    "!IStore"
-                    [ Int dest ]
-                    [ sxp |> Expr.Int ]
+    let modelWithExprs dstPost srcPre srcPost =
+        let cmd, reads =
+            match mode with
+            | Direct -> "!IStore", [ dstPost ]
+            | Increment -> "!IStore++", [ dstPost; srcPost ]
+            | Decrement -> "!IStore--", [ dstPost; srcPost ]
+        command cmd (List.map Int reads) [ Int srcPre ]
 
-        | Increment -> return! fail (IncExpr src)
-        | Decrement -> return! fail (DecExpr src)
-    }
+    lift3 modelWithExprs
+        (modelIntLValue ctx.SharedVars id dest)
+        (wrapMessages BadExpr (modelIntExpr ctx.ThreadVars MarkedVar.Before) src)
+        (wrapMessages BadExpr (modelIntExpr ctx.ThreadVars id) src)
 
 /// Converts a CAS to part-commands.
-let modelCAS : MethodContext -> LValue -> LValue -> Expression -> Result<PrimCommand, PrimError> =
-    fun { SharedVars = svars; ThreadVars = tvars } destLV testLV set ->
-    (* In a CAS, the destination must be SHARED;
-     *           the test variable must be THREADLOCAL;
-     *           and the to-set value must be a valid expression.
-     * dest, test, and set must agree on type.
-     * The type of dest and test influences how we interpret set.
-     *)
-    wrapMessages BadSVar (VarMap.lookup svars) destLV
-    >>= (fun dest ->
-             let v = wrapMessages BadTVar (VarMap.lookup tvars) testLV
-             lift (mkPair dest) v)
-    >>= (function
-         | (Bool d, Bool t) ->
-             set
-             |> wrapMessages BadExpr (modelBoolExpr tvars MarkedVar.Before)
-             |> lift
-                    (fun s ->
-                        command "BCAS"
-                            [ Bool d; Bool t ]
-                            [ d |> sbBefore |> Expr.Bool
-                              t |> sbBefore |> Expr.Bool
-                              s |> Expr.Bool ] )
-         | (Int d, Int t) ->
-            set
-            |> wrapMessages BadExpr (modelIntExpr tvars MarkedVar.Before)
-            |> lift
-                   (fun s ->
-                        command "ICAS"
-                            [ Int d; Int t ]
-                            [ d |> siBefore |> Expr.Int
-                              t |> siBefore |> Expr.Int
-                              s |> Expr.Int ] )
-         | (d, t) ->
-             // Oops, we have a type error.
-             // Arbitrarily single out test as the cause of it.
-             fail (BadType (testLV, TypeMismatch (typeOf d, typeOf t))))
+let modelCAS
+  (ctx : MethodContext)
+  (dest : Expression)
+  (test : Expression)
+  (set : Expression)
+  : Result<PrimCommand, PrimError> =
+    (* In a CAS, the destination must be a SHARED lvalue;
+                 the test variable must be a THREAD lvalue;
+                 and the to-set value must be a valid expression.
+
+       dest, test, and set must agree on type.
+       The type of dest and test influences how we interpret set. *)
+    let modelWithDestAndTest destPreLV destPostLV testPreLV testPostLV =
+        (* Determine from destPreLV and testPreLV what the type of the CAS is.
+           Assume that the post-states are of the same type. *)
+        match destPreLV, testPreLV with
+        | Bool dlPreB, Bool tlPreB ->
+            let setResult =
+                wrapMessages BadExpr
+                    (modelBoolExpr ctx.ThreadVars MarkedVar.Before)
+                    set
+
+            lift
+                (fun s ->
+                    command "BCAS"
+                        [ destPostLV; testPostLV ]
+                        [ Expr.Bool dlPreB; Bool tlPreB; Bool s ] )
+                setResult
+        | Int dlPreI, Int tlPreI ->
+            let setResult =
+                wrapMessages BadExpr
+                    (modelIntExpr ctx.ThreadVars MarkedVar.Before)
+                    set
+
+            lift
+                (fun s ->
+                    command "ICAS"
+                        [ destPostLV; testPostLV ]
+                        [ Int dlPreI; Int tlPreI; Int s ] )
+                setResult
+        | d, t ->
+            (* Oops, we have a type error.
+               Arbitrarily single out test as the cause of it. *)
+            fail (BadType (test, TypeMismatch (typeOf d, typeOf t)))
+
+    (* We need the unmarked version of dest and test for the outputs,
+       and the marked version for the inputs. *)
+    let toPost vars = modelLValue vars id
+    let toPre vars = modelLValue vars MarkedVar.Before
+    bind4 modelWithDestAndTest
+        (toPre  ctx.SharedVars dest)
+        (toPost ctx.SharedVars dest)
+        (toPre  ctx.ThreadVars test)
+        (toPost ctx.ThreadVars test)
 
 /// Converts an atomic fetch to a model command.
-let modelFetch : MethodContext -> LValue -> Expression -> FetchMode -> Result<PrimCommand, PrimError> =
-    fun ctx destLV srcExpr mode ->
+let modelFetch
+  (ctx : MethodContext)
+  (dest : Expression)
+  (test : Expression)
+  (mode : FetchMode)
+  : Result<PrimCommand, PrimError> =
     (* First, determine whether we have a fetch from shared to thread
      * (a load), or a fetch from thread to shared (a store).
      * Also figure out whether we have a Boolean or arithmetic
      * version.
      * We figure this out by looking at dest.
      *)
-    match destLV with
-    | Shared ctx (Typed.Int dest) -> modelIntStore ctx dest srcExpr mode
-    | Shared ctx (Typed.Bool dest) -> modelBoolStore ctx dest srcExpr mode
-    | Thread ctx (Typed.Int dest) -> modelIntLoad ctx dest srcExpr mode
-    | Thread ctx (Typed.Bool dest) -> modelBoolLoad ctx dest srcExpr mode
-    | lv -> fail (BadIVar(lv, NotFound (flattenLV lv)))
+    let rec findModeller d =
+        match d.Node with
+        | Identifier v ->
+            match (VarMap.tryLookup ctx.SharedVars v) with
+            | Some (Typed.Int _) -> ok modelIntStore
+            | Some (Typed.Bool _) -> ok modelBoolStore
+            | None ->
+                match (VarMap.tryLookup ctx.ThreadVars v) with
+                | Some (Typed.Int _) -> ok modelIntLoad
+                | Some (Typed.Bool _) -> ok modelBoolLoad
+                | None -> fail (BadExpr (dest, Var (v, NotFound v)))
+        | ArraySubscript (arr, _) -> findModeller arr
+        // TODO(CaptainHayashi): symbols
+        | _ -> fail (NeedLValue d)
+
+    bind (fun f -> f ctx dest test mode) (findModeller dest)
+
+/// <summary>
+///     Models a postfix expression as a primitive.
+/// </summary>
+/// <param name="ctx">The context of the modeller at this position.</param>
+/// <param name="operand">The postfixed expression.</param>
+/// <param name="mode">The mode representing the postfix operator.</param>
+/// <returns>If successful, the modelled expression.</returns>
+let modelPostfix (ctx : MethodContext) (operand : Expression) (mode : FetchMode)
+  : Result<PrimCommand, PrimError> =
+    (* A Postfix is basically a Fetch with no destination, at this point.
+       Thus, the source must be a SHARED LVALUE.
+       We don't allow the Direct fetch mode, as it is useless. *)
+    let modelWithOperand opPre opPost =
+        match mode, opPre with
+        | Direct, _ -> fail Useless
+        | Increment, Typed.Bool _ ->
+            fail (IncBool operand)
+        | Decrement, Typed.Bool _ ->
+            fail (DecBool operand)
+        | Increment, Typed.Int _ ->
+            ok (command "!I++" [ opPost ] [ opPre ])
+        | Decrement, Typed.Int _ ->
+            ok (command "!I--" [ opPost ] [ opPre ])
+    bind2 modelWithOperand
+        (modelLValue ctx.SharedVars MarkedVar.Before operand)
+        (modelLValue ctx.SharedVars id operand)
 
 /// Converts a single atomic command from AST to part-commands.
 let rec modelAtomic : MethodContext -> Atomic -> Result<PrimCommand, PrimError> =
@@ -1206,27 +1287,7 @@ let rec modelAtomic : MethodContext -> Atomic -> Result<PrimCommand, PrimError> 
         match a.Node with
         | CompareAndSwap(dest, test, set) -> modelCAS ctx dest test set
         | Fetch(dest, src, mode) -> modelFetch ctx dest src mode
-        | Postfix(operand, mode) ->
-            (* A Postfix is basically a Fetch with no destination, at this point.
-             * Thus, the source must be SHARED.
-             * We don't allow the Direct fetch mode, as it is useless.
-             *)
-            trial {
-                let! stype = wrapMessages BadSVar (VarMap.lookup ctx.SharedVars) operand
-                // TODO(CaptainHayashi): sort out lvalues...
-                let op = flattenLV operand
-                match mode, stype with
-                | Direct, _ ->
-                    return! fail Useless
-                | Increment, Typed.Bool _ ->
-                    return! fail (IncBool (freshNode <| LV operand))
-                | Decrement, Typed.Bool _ ->
-                    return! fail (DecBool (freshNode <| LV operand))
-                | Increment, Typed.Int _ ->
-                    return command "!I++" [ Int op ] [op |> Before |> Reg |> IVar |> Expr.Int ]
-                | Decrement, Typed.Int _ ->
-                    return command "!I--" [ Int op ] [op |> Before |> Reg |> IVar |> Expr.Int ]
-            }
+        | Postfix(operand, mode) -> modelPostfix ctx operand mode
         | Id -> ok (command "Id" [] [])
         | Assume e ->
             e
@@ -1235,32 +1296,22 @@ let rec modelAtomic : MethodContext -> Atomic -> Result<PrimCommand, PrimError> 
     lift (fun cmd -> { cmd with Node = Some a }) prim
 
 /// Converts a local variable assignment to a Prim.
-and modelAssign : MethodContext -> LValue -> Expression -> Result<PrimCommand, PrimError> =
-    fun { ThreadVars = tvars } lLV e ->
+and modelAssign
+  (ctx : MethodContext)
+  (dest : Expression)
+  (src : Expression)
+  : Result<PrimCommand, PrimError> =
     (* We model assignments as !ILSet or !BLSet, depending on the
-     * type of l, which _must_ be in the locals set..
-     * We thus also have to make sure that e is the correct type.
-     *)
-    trial {
-        let! l = wrapMessages BadTVar (VarMap.lookup tvars) lLV
-        match l with
-        | Typed.Bool ls ->
-            let! em =
-                wrapMessages BadExpr (modelBoolExpr tvars MarkedVar.Before) e
-            return
-                command
-                    "!BLSet"
-                    [ Bool ls ]
-                    [ em |> Expr.Bool ]
-        | Typed.Int ls ->
-            let! em =
-                wrapMessages BadExpr (modelIntExpr tvars MarkedVar.Before) e
-            return
-                command
-                    "!ILSet"
-                    [ Int ls ]
-                    [ em |> Expr.Int ]
-    }
+       type of dest, which _must_ be a thread lvalue.
+       We thus also have to make sure that src is the correct type. *)
+    let modelWithDestAndSrc destPost srcPre =
+        match destPost with
+        | Typed.Bool _ -> command "!BLSet" [ destPost ] [ srcPre ]
+        | Typed.Int _  -> command "!ILSet" [ destPost ] [ srcPre ]
+
+    lift2 modelWithDestAndSrc
+        (modelLValue ctx.ThreadVars id dest)
+        (wrapMessages BadExpr (modelExpr ctx.ThreadVars MarkedVar.Before) src)
 
 /// Creates a partially resolved axiom for an if-then-else.
 and modelITE

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -1264,12 +1264,12 @@ let modelIntLoad
                            the source must be a SHARED integral lvalue;
                            and the fetch mode is unconstrained. *)
     let modelWithExprs dstE srcE =
-        let cmd, reads =
+        let cmd, results =
             match mode with
             | Direct -> "!ILoad", [ dstE ]
             | Increment -> "!ILoad++", [ dstE; srcE ]
             | Decrement -> "!ILoad--", [ dstE; srcE ]
-        command cmd (List.map Int reads) [ Int srcE ]
+        command cmd (List.map Int results) [ Int srcE ]
 
     lift2 modelWithExprs
         (modelIntLValue ctx.ThreadVars ctx.ThreadVars id dest)

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -1250,7 +1250,7 @@ let modelBoolLoad
 
     bind2 modelWithExprs
         (modelBoolLValue ctx.ThreadVars ctx.ThreadVars id dest)
-        (modelBoolLValue ctx.SharedVars ctx.ThreadVars MarkedVar.Before src)
+        (modelBoolLValue ctx.SharedVars ctx.ThreadVars id src)
 
 /// Converts an integer load to a Prim.
 let modelIntLoad
@@ -1262,17 +1262,16 @@ let modelIntLoad
     (* In an integer load, the destination must be a THREAD integral lvalue;
                            the source must be a SHARED integral lvalue;
                            and the fetch mode is unconstrained. *)
-    let modelWithExprs dstPost srcPre srcPost =
+    let modelWithExprs dstE srcE =
         let cmd, reads =
             match mode with
-            | Direct -> "!ILoad", [ dstPost ]
-            | Increment -> "!ILoad++", [ dstPost; srcPost ]
-            | Decrement -> "!ILoad--", [ dstPost; srcPost ]
-        command cmd (List.map Int reads) [ Int srcPre ]
+            | Direct -> "!ILoad", [ dstE ]
+            | Increment -> "!ILoad++", [ dstE; srcE ]
+            | Decrement -> "!ILoad--", [ dstE; srcE ]
+        command cmd (List.map Int reads) [ Int srcE ]
 
-    lift3 modelWithExprs
+    lift2 modelWithExprs
         (modelIntLValue ctx.ThreadVars ctx.ThreadVars id dest)
-        (modelIntLValue ctx.SharedVars ctx.ThreadVars MarkedVar.Before src)
         (modelIntLValue ctx.SharedVars ctx.ThreadVars id src)
 
 /// Converts a Boolean store to a Prim.
@@ -1293,7 +1292,7 @@ let modelBoolStore
 
     bind2 modelWithExprs
         (modelBoolLValue ctx.SharedVars ctx.ThreadVars id dest)
-        (wrapMessages BadExpr (modelBoolExpr ctx.ThreadVars ctx.ThreadVars MarkedVar.Before) src)
+        (wrapMessages BadExpr (modelBoolExpr ctx.ThreadVars ctx.ThreadVars id) src)
 
 /// Converts an integral store to a Prim.
 let modelIntStore
@@ -1306,17 +1305,16 @@ let modelIntStore
      *                       the source must be LOCAL and integral;
      *                       and the fetch mode must be Direct.
      *)
-    let modelWithExprs dstPost srcPre srcPost =
+    let modelWithExprs dst src =
         let cmd, reads =
             match mode with
-            | Direct -> "!IStore", [ dstPost ]
-            | Increment -> "!IStore++", [ dstPost; srcPost ]
-            | Decrement -> "!IStore--", [ dstPost; srcPost ]
-        command cmd (List.map Int reads) [ Int srcPre ]
+            | Direct -> "!IStore", [ dst ]
+            | Increment -> "!IStore++", [ dst; src ]
+            | Decrement -> "!IStore--", [ dst; src ]
+        command cmd (List.map Int reads) [ Int src ]
 
-    lift3 modelWithExprs
+    lift2 modelWithExprs
         (modelIntLValue ctx.SharedVars ctx.ThreadVars id dest)
-        (wrapMessages BadExpr (modelIntExpr ctx.ThreadVars ctx.ThreadVars MarkedVar.Before) src)
         (wrapMessages BadExpr (modelIntExpr ctx.ThreadVars ctx.ThreadVars id) src)
 
 /// Converts a CAS to part-commands.
@@ -1332,33 +1330,33 @@ let modelCAS
 
        dest, test, and set must agree on type.
        The type of dest and test influences how we interpret set. *)
-    let modelWithDestAndTest destPreLV destPostLV testPreLV testPostLV =
+    let modelWithDestAndTest destLV testLV =
         (* Determine from destPreLV and testPreLV what the type of the CAS is.
            Assume that the post-states are of the same type. *)
-        match destPreLV, testPreLV with
-        | Bool dlPreB, Bool tlPreB ->
+        match destLV, testLV with
+        | Bool dlB, Bool tlB ->
             let setResult =
                 wrapMessages BadExpr
-                    (modelBoolExpr ctx.ThreadVars ctx.ThreadVars MarkedVar.Before)
+                    (modelBoolExpr ctx.ThreadVars ctx.ThreadVars id)
                     set
 
             lift
                 (fun s ->
                     command "BCAS"
-                        [ destPostLV; testPostLV ]
-                        [ Expr.Bool dlPreB; Bool tlPreB; Bool s ] )
+                        [ destLV; testLV ]
+                        [ Expr.Bool dlB; Bool tlB; Bool s ] )
                 setResult
-        | Int dlPreI, Int tlPreI ->
+        | Int dlI, Int tlI ->
             let setResult =
                 wrapMessages BadExpr
-                    (modelIntExpr ctx.ThreadVars ctx.ThreadVars MarkedVar.Before)
+                    (modelIntExpr ctx.ThreadVars ctx.ThreadVars id)
                     set
 
             lift
                 (fun s ->
                     command "ICAS"
-                        [ destPostLV; testPostLV ]
-                        [ Int dlPreI; Int tlPreI; Int s ] )
+                        [ destLV; testLV ]
+                        [ Int dlI; Int tlI; Int s ] )
                 setResult
         | d, t ->
             (* Oops, we have a type error.
@@ -1373,13 +1371,10 @@ let modelCAS
 
     (* We need the unmarked version of dest and test for the outputs,
        and the marked version for the inputs. *)
-    let toPost vars = modelLValue vars ctx.ThreadVars id
-    let toPre vars = modelLValue vars ctx.ThreadVars MarkedVar.Before
-    bind4 modelWithDestAndTest
-        (toPre  ctx.SharedVars dest)
-        (toPost ctx.SharedVars dest)
-        (toPre  ctx.ThreadVars test)
-        (toPost ctx.ThreadVars test)
+    let mdl vars = modelLValue vars ctx.ThreadVars id
+    bind2 modelWithDestAndTest
+        (mdl ctx.SharedVars dest)
+        (mdl ctx.ThreadVars test)
 
 /// <summary>
 ///     Gets the underlying variable of an lvalue.
@@ -1465,20 +1460,15 @@ let modelPostfix (ctx : MethodContext) (operand : Expression) (mode : FetchMode)
     (* A Postfix is basically a Fetch with no destination, at this point.
        Thus, the source must be a SHARED LVALUE.
        We don't allow the Direct fetch mode, as it is useless. *)
-    let modelWithOperand opPre opPost =
-        match mode, opPre with
+    let modelWithOperand opE =
+        match mode, opE with
         | Direct, _ -> fail Useless
-        | Increment, Typed.Bool _ ->
-            fail (IncBool operand)
-        | Decrement, Typed.Bool _ ->
-            fail (DecBool operand)
-        | Increment, Typed.Int _ ->
-            ok (command "!I++" [ opPost ] [ opPre ])
-        | Decrement, Typed.Int _ ->
-            ok (command "!I--" [ opPost ] [ opPre ])
+        | Increment, Typed.Bool _ -> fail (IncBool operand)
+        | Decrement, Typed.Bool _ -> fail (DecBool operand)
+        | Increment, Typed.Int _ -> ok (command "!I++" [ opE ] [ opE ])
+        | Decrement, Typed.Int _ -> ok (command "!I--" [ opE ] [ opE ])
         | _, Typed.Array (_) -> fail (PrimNotImplemented "array postfix")
-    bind2 modelWithOperand
-        (modelLValue ctx.SharedVars ctx.ThreadVars MarkedVar.Before operand)
+    bind modelWithOperand
         (modelLValue ctx.SharedVars ctx.ThreadVars id operand)
 
 /// Converts a single atomic command from AST to part-commands.
@@ -1492,7 +1482,7 @@ let rec modelAtomic : MethodContext -> Atomic -> Result<PrimCommand, PrimError> 
         | Id -> ok (command "Id" [] [])
         | Assume e ->
             e
-            |> wrapMessages BadExpr (modelBoolExpr ctx.ThreadVars ctx.ThreadVars MarkedVar.Before)
+            |> wrapMessages BadExpr (modelBoolExpr ctx.ThreadVars ctx.ThreadVars id)
             |> lift (Expr.Bool >> List.singleton >> command "Assume" [])
     lift (fun cmd -> { cmd with Node = Some a }) prim
 
@@ -1513,7 +1503,7 @@ and modelAssign
 
     bind2 modelWithDestAndSrc
         (modelLValue ctx.ThreadVars ctx.ThreadVars id dest)
-        (wrapMessages BadExpr (modelExpr ctx.ThreadVars ctx.ThreadVars MarkedVar.Before) src)
+        (wrapMessages BadExpr (modelExpr ctx.ThreadVars ctx.ThreadVars id) src)
 
 /// Creates a partially resolved axiom for an if-then-else.
 and modelITE

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -1520,10 +1520,17 @@ let modelViewProtos (protos : #(DesugaredViewProto seq))
 /// </returns>
 let convertTypedVar (lit : AST.Types.TypeLiteral) (name : string)
   : Result<TypedVar, TypeError> =
-    match lit with
-    | TInt -> ok (Int name)
-    | TBool -> ok (Bool name)
-    | TArray _ -> fail (ImpossibleType (lit, "arrays not yet implemented"))
+    let rec convType =
+        function
+        | TInt -> ok (Int ())
+        | TBool -> ok (Bool ())
+        | TArray (len, elt) ->
+            lift
+                (fun eltype -> Array (eltype, Some len, ()))
+                (convType elt)
+        (* At some point, this may (and once did) return ImpossibleType,
+           hence why it is a Result. *)
+    lift (fun ty -> withType ty name) (convType lit)
 
 /// <summary>
 ///     Converts a type-variable list to a variable map.

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -1231,6 +1231,44 @@ let modelCAS
         (toPre  ctx.ThreadVars test)
         (toPost ctx.ThreadVars test)
 
+/// <summary>
+///     Gets the underlying variable of an lvalue.
+/// </summary>
+/// <param name="lv">The lvalue-candidate whose type is needed.</param>
+/// <returns>
+///     The lvalue's variable; will crash if the expression is not an lvalue.
+/// </returns>
+let rec varOfLValue (lv : Expression) : string =
+    match lv.Node with
+    | Identifier i -> i
+    | ArraySubscript (arr, _) -> varOfLValue arr
+    | _ -> failwith "called varOfLValue with non-lvalue"
+
+/// <summary>
+///     Tries to get the type of an lvalue.
+/// </summary>
+/// <param name="env">The map in which the lvalue's variable exists.</param>
+/// <param name="lv">The lvalue-candidate whose type is needed.</param>
+/// <returns>
+///     If the lvalue has a valid type, the type of that lvalue; otherwise,
+///     None.
+/// </returns>
+let typeOfLValue (env : VarMap) (lv : Expression) : Type option =
+    let matchArray var =
+        match var with
+        | Array (eltype, _, _) -> Some eltype
+        | _ -> None
+
+    // First, we work out the type of the variable at the top of the lvalue.
+    let rec findIdxType lv matcher =
+        match lv.Node with
+        | Identifier v -> Option.bind (typeOf >> matcher) (VarMap.tryLookup env v)
+        | ArraySubscript (arr, _) ->
+            findIdxType arr (matcher >> Option.bind matchArray)
+        | _ -> None
+
+    findIdxType lv Some
+
 /// Converts an atomic fetch to a model command.
 let modelFetch
   (ctx : MethodContext)
@@ -1245,23 +1283,23 @@ let modelFetch
      * We figure this out by looking at dest.
      *)
     let rec findModeller d =
-        match d.Node with
-        | Identifier v ->
-            match (VarMap.tryLookup ctx.SharedVars v) with
+        match d with
+        | LValue _ ->
+            match (typeOfLValue ctx.SharedVars d) with
             | Some (Typed.Int _) -> ok modelIntStore
             | Some (Typed.Bool _) -> ok modelBoolStore
             | Some (Typed.Array (_))
                 -> fail (PrimNotImplemented "array fetch")
             | None ->
-                match (VarMap.tryLookup ctx.ThreadVars v) with
+                match (typeOfLValue ctx.ThreadVars d) with
                 | Some (Typed.Int _) -> ok modelIntLoad
                 | Some (Typed.Bool _) -> ok modelBoolLoad
                 | Some (Typed.Array (_))
                     -> fail (PrimNotImplemented "array fetch")
-                | None -> fail (BadExpr (dest, Var (v, NotFound v)))
-        | ArraySubscript (arr, _) -> findModeller arr
-        // TODO(CaptainHayashi): symbols
-        | _ -> fail (NeedLValue d)
+                | None ->
+                    let v = varOfLValue d
+                    fail (BadExpr (dest, Var (v, NotFound v)))
+        | RValue _ -> fail (NeedLValue d)
 
     bind (fun f -> f ctx dest test mode) (findModeller dest)
 

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -414,8 +414,10 @@ module Pretty =
 (*
  * Starling imperative language semantics
  *)
-let prim : string -> TypedVar list -> TypedVar list -> SVBoolExpr -> PrimSemantics =
-    fun name results args body -> { Name = name; Results = results; Args = args; Body = body }
+let prim (name : string) (results : TypedVar list) (args : TypedVar list)
+  (body : Microcode<TypedVar, Var> list)
+  : PrimSemantics =
+    { Name = name; Results = results; Args = args; Body = body }
 
 /// <summary>
 ///   The core semantic function for the imperative language.
@@ -431,53 +433,53 @@ let coreSemantics : PrimSemanticsMap =
     // TODO(CaptainHayashi): generic functions?
     // TODO(CaptainHayashi): add shared/local/expr qualifiers to parameters?
     List.fold (fun m (a : PrimSemantics) -> Map.add a.Name a m) Map.empty
-    <| [ (*
+    <| [
+      (*
        * CAS
        *)
-      (prim "ICAS" [ Int "destA"; Int "testA"; ] [ Int "destB"; Int "testB"; Int "set"; ]
-           <| mkAnd [ mkImplies (iEq (siVar "destB") (siVar "testB"))
-                             (mkAnd [ iEq (siVar "destA") (siVar "set")
-                                      iEq (siVar "testA") (siVar "testB") ] )
-                      mkImplies (mkNot (iEq (siVar "destB") (siVar "testB")))
-                                (mkAnd [ iEq (siVar "destA") (siVar "destB")
-                                         iEq (siVar "testA") (siVar "destB") ] ) ] )
+      (prim "ICAS" [ Int "destA"; Int "testA" ] [ Int "destB"; Int "testB"; Int "set" ]
+           [ Branch
+                (iEq (IVar "destB") (IVar "testB"),
+                 [ Assign (Int "destA", Int (IVar "set"))
+                   Assign (Int "testA", Int (IVar "testB")) ],
+                 [ Assign (Int "destA", Int (IVar "destB"))
+                   Assign (Int "testA", Int (IVar "destB")) ] ) ] )
       // Boolean CAS
-      (prim "BCAS" [Bool "destA"; Bool "testA"; ] [Bool "destB"; Bool "testB"; Bool "set"; ]
-           <| mkAnd [ mkImplies (bEq (sbVar "destB") (sbVar "testB"))
-                                (mkAnd [ bEq (sbVar "destA") (sbVar "set")
-                                         bEq (sbVar "testA") (sbVar "testB") ] )
-                      mkImplies (mkNot (bEq (sbVar "destB") (sbVar "testB")))
-                                (mkAnd [ bEq (sbVar "destA") (sbVar "destB")
-                                         bEq (sbVar "testA") (sbVar "destB") ] ) ] )
-
+      (prim "BCAS" [ Bool "destA"; Bool "testA" ] [ Bool "destB"; Bool "testB"; Bool "set" ]
+           [ Branch
+                (bEq (BVar "destB") (BVar "testB"),
+                 [ Assign (Bool "destA", Bool (BVar "set"))
+                   Assign (Bool "testA", Bool (BVar "testB")) ],
+                 [ Assign (Bool "destA", Bool (BVar "destB"))
+                   Assign (Bool "testA", Bool (BVar "destB")) ] ) ] )
       (*
        * Atomic load
        *)
       // Integer load
       (prim "!ILoad"  [ Int "dest" ] [ Int "src" ]
-           <| iEq (siVar "dest") (siVar "src"))
+            [ Assign (Int "dest", Int (IVar "src")) ] )
 
       // Integer load-and-increment
       (prim "!ILoad++"  [ Int "dest"; Int "srcA" ] [ Int "srcB" ]
-           <| mkAnd [ iEq (siVar "dest") (siVar "srcB")
-                      iEq (siVar "srcA") (mkAdd2 (siVar "srcB") (IInt 1L)) ])
+            [ Assign (Int "dest", Int (IVar "srcB"))
+              Assign (Int "srcA", Int (mkAdd2 (IVar "srcB") (IInt 1L))) ] )
 
       // Integer load-and-decrement
       (prim "!ILoad--"  [ Int "dest"; Int "srcA" ] [ Int "srcB" ]
-           <| mkAnd [ iEq (siVar "dest") (siVar "srcB")
-                      iEq (siVar "srcA") (mkSub2 (siVar "srcB") (IInt 1L)) ])
+            [ Assign (Int "dest", Int (IVar "srcB"))
+              Assign (Int "srcA", Int (mkSub2 (IVar "srcB") (IInt 1L))) ] )
 
       // Integer increment
       (prim "!I++"  [ Int "srcA" ] [ Int "srcB" ]
-           <| iEq (siVar "srcA") (mkAdd2 (siVar "srcB") (IInt 1L)))
+            [ Assign (Int "srcA", Int (mkAdd2 (IVar "srcB") (IInt 1L))) ] )
 
       // Integer decrement
       (prim "!I--"  [ Int "srcA" ] [ Int "srcB" ]
-           <| iEq (siVar "srcA") (mkSub2 (siVar "srcB") (IInt 1L)))
+            [ Assign (Int "srcA", Int (mkSub2 (IVar "srcB") (IInt 1L))) ] )
 
       // Boolean load
       (prim "!BLoad"  [ Bool "dest" ] [ Bool "src" ]
-           <| bEq (sbVar "dest") (sbVar "src"))
+            [ Assign (Bool "dest", Bool (BVar "src")) ] )
 
       (*
        * Atomic store
@@ -485,11 +487,11 @@ let coreSemantics : PrimSemanticsMap =
 
       // Integer store
       (prim "!IStore" [ Int "dest" ] [ Int "src" ]
-           <| iEq (siVar "dest") (siVar "src"))
+            [ Assign (Int "dest", Int (IVar "src")) ] )
 
       // Boolean store
       (prim "!BStore" [ Bool "dest" ] [ Bool "src" ]
-           <| bEq (sbVar "dest") (sbVar "src"))
+            [ Assign (Bool "dest", Bool (BVar "src")) ] )
 
       (*
        * Local set
@@ -497,21 +499,21 @@ let coreSemantics : PrimSemanticsMap =
 
       // Integer local set
       (prim "!ILSet" [ Int "dest" ] [ Int "src" ]
-           <| iEq (siVar "dest") (siVar "src"))
+            [ Assign (Int "dest", Int (IVar "src")) ] )
 
       // Boolean store
       (prim "!BLSet" [ Bool "dest" ] [ Bool "src" ]
-           <| bEq (sbVar "dest") (sbVar "src"))
+            [ Assign (Bool "dest", Bool (BVar "src")) ] )
 
       (*
        * Assumptions
        *)
 
       // Identity
-      (prim "Id" [] [] BTrue)
+      (prim "Id" [] [] [])
 
       // Assume
-      (prim "Assume" [] [Bool "expr"] <| sbVar "expr") ]
+      (prim "Assume" [] [Bool "expr"] [ Microcode.Assume (BVar "expr") ]) ]
 
 (*
  * Expression translation

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -1384,7 +1384,7 @@ let modelCAS
 /// <returns>
 ///     The lvalue's variable; will crash if the expression is not an lvalue.
 /// </returns>
-let rec varOfLValue (lv : Expression) : string =
+let rec varOfLValue (lv : Expression) : Var =
     match lv.Node with
     | Identifier i -> i
     | ArraySubscript (arr, _) -> varOfLValue arr

--- a/ModellerTests.fs
+++ b/ModellerTests.fs
@@ -113,7 +113,7 @@ module ArithmeticExprs =
 
     [<Test>]
     let ``test modelling (1 * 3) % 2`` ()=
-        check
+        check environ
             (freshNode <| BopExpr( Mod,
                                    freshNode <| BopExpr(Mul, freshNode (Num 1L), freshNode (Num 3L)),
                                    freshNode (Num 2L) ))

--- a/ModellerTests.fs
+++ b/ModellerTests.fs
@@ -92,8 +92,8 @@ module ViewFail =
                    (Int "t", Type.Bool ())) ])
 
 module ArithmeticExprs =
-    let check (ast : Expression) (expectedExpr : IntExpr<Sym<Var>>) =
-        let actualIntExpr = okOption <| modelIntExpr environ id ast
+    let check (env : VarMap) (ast : Expression) (expectedExpr : IntExpr<Sym<Var>>) =
+        let actualIntExpr = okOption <| modelIntExpr env environ id ast
         AssertAreEqual(Some expectedExpr, actualIntExpr)
 
     [<Test>]
@@ -107,7 +107,7 @@ module ArithmeticExprs =
 
     [<Test>]
     let ``test modelling (1 * 2) + 3`` ()=
-        check
+        check environ
             (freshNode <| BopExpr( Add,
                                    freshNode <| BopExpr(Mul, freshNode (Num 1L), freshNode (Num 2L)),
                                    freshNode (Num 3L) ))
@@ -115,13 +115,13 @@ module ArithmeticExprs =
             (IInt 5L)
 
 module BooleanExprs =
-    let check (ast : Expression) (expectedExpr : BoolExpr<Sym<Var>>) =
-        let actualBoolExpr = okOption <| modelBoolExpr environ id ast
+    let check (env : VarMap) (ast : Expression) (expectedExpr : BoolExpr<Sym<Var>>) =
+        let actualBoolExpr = okOption <| modelBoolExpr env environ id ast
         AssertAreEqual(Some expectedExpr, actualBoolExpr)
 
     [<Test>]
     let ``model (true || true) && false`` () =
-        check
+        check environ
             (freshNode <| BopExpr(And, freshNode <| BopExpr(Or, freshNode True, freshNode True), freshNode False))
             (BFalse : BoolExpr<Sym<Var>>)
 

--- a/ModellerTests.fs
+++ b/ModellerTests.fs
@@ -235,17 +235,14 @@ module Atomics =
             <| command' "!ILoad++"
                 ast
                 [ Int (siVar "foo"); Int (siVar "x") ]
-                [ "x" |> siBefore |> SMExpr.Int ]
+                [ Int (siVar "x") ]
 
     [<Test>]
     let ``model Boolean load primitive <baz = y>`` ()=
         let ast = freshNode (Fetch(freshNode (Identifier "baz"), freshNode (Identifier "y"), Direct))
         check
             ast
-            <| command' "!BLoad"
-                ast
-                [ Bool (sbVar "baz") ]
-                [ "y" |> sbBefore |> SMExpr.Bool ]
+            (command' "!BLoad" ast [ Bool (sbVar "baz") ] [ Bool (sbVar "y") ])
 
 
 module CommandAxioms =
@@ -272,7 +269,7 @@ module CommandAxioms =
             <| Prim ([ command' "!ILoad++"
                         ast
                         [ Int (siVar "foo"); Int (siVar "x") ]
-                        [ "x" |> siBefore |> SMExpr.Int ] ])
+                        [ Int (siVar "x") ] ])
 
     [<Test>]
     let ``modelling command <baz = y> passes`` () =
@@ -282,7 +279,7 @@ module CommandAxioms =
             <| Prim ([ command' "!BLoad"
                         ast
                         [ Bool (sbVar "baz") ]
-                        [ "y" |> sbBefore |> SMExpr.Bool ] ])
+                        [ Bool (sbVar "y") ] ])
 
 
 module ViewDefs =

--- a/MuZ3Backend.fs
+++ b/MuZ3Backend.fs
@@ -63,7 +63,10 @@ module Types =
         ///     One of our traversals bought the farm.
         /// </summary>
         | Traversal of err : TraversalError<Error>
-
+        /// <summary>
+        ///     Arrays were encountered: these are not yet supported.
+        /// </summary>
+        | ArraysNotSupported
 
     /// <summary>
     ///     Type of MuZ3 results.
@@ -148,12 +151,13 @@ module Pretty =
     let rec printError (err : Error) : Doc =
         match err with
         | CannotCheckDeferred (check, why) ->
-            error
-                (String "deferred sanity check '"
-                 <-> printDeferredCheck check
-                 <-> String "' failed:"
-                 <+> String why)
+            (errorStr "deferred sanity check"
+             <+> quoted (printDeferredCheck check)
+             <+> errorStr "failed:"
+             <+> String why)
         | Traversal err -> printTraversalError printError err
+        | ArraysNotSupported ->
+            errorStr "arrays are not yet supported in muZ3"
 
     /// Pretty-prints a MuSat.
     let printMuSat : MuSat -> Doc =
@@ -202,24 +206,6 @@ module Pretty =
 /// </summary>
 module Translator =
     open Starling.Core.Z3.Expr
-
-    /// <summary>
-    ///     Converts a type into a Z3 sort.
-    /// </summary>
-    /// <param name="reals">
-    ///     Whether to use Real instead of Int for integers.
-    /// </param>
-    /// <param name="ctx">
-    ///     The Z3 context to use to generate the sorts.
-    /// </param>
-    /// <returns>
-    ///     A function mapping types to sorts.
-    /// </returns>
-    let typeToSort (reals : bool) (ctx : Z3.Context) : Type -> Z3.Sort =
-        function
-        | Type.Int _ when reals -> ctx.MkRealSort () :> Z3.Sort
-        | Type.Int _ -> ctx.MkIntSort () :> Z3.Sort
-        | Type.Bool _ -> ctx.MkBoolSort () :> Z3.Sort
 
     (*
      * View definitions
@@ -611,6 +597,7 @@ module Translator =
         match v with
         | Int iv -> Int (IVar iv)
         | Bool bv -> Bool (BVar bv)
+        | Array (eltype, length, av) -> Array (eltype, length, AVar av)
 
     /// Converts a downclosure func into a guarded func, instantiating the
     /// variables directly as nonsymbolic unmarked vars.
@@ -770,20 +757,32 @@ module Translator =
             |> Map.toList
             |> List.map (fun (v, t) -> mkVarExp (withType t v))
 
+        let defaultVal =
+            function
+            | Expr.Int _ -> ok (Expr.Int (IInt 0L))
+            | Expr.Bool _ -> ok (Expr.Bool BFalse)
+            (* TODO(CaptainHayashi): this needs implementing.
+               Will requires array literal support. *)
+            | Expr.Array _ -> fail ArraysNotSupported
+
         // TODO(CaptainHayashi): actually get these initialisations from
         // somewhere.
-        let body =
+        let bodyResult =
             vpars
             |> List.map
-                   (fun v -> BEq (v,
-                                  match v with
-                                  | Expr.Int _ -> Expr.Int (IInt 0L)
-                                  | Expr.Bool _ -> Expr.Bool (BFalse)))
-            |> mkAnd
+                   (fun v ->
+                        let dResult = defaultVal v
+                        lift (fun d -> BEq (v, d)) dResult)
+            |> collect
+            |> lift mkAnd
 
         let head = { Name = "emp" ; Params = vpars }
 
-        let ruleResult = mkRule reals id ctx funcDecls body Multiset.empty head
+        let ruleResult =
+            bind
+                (fun body ->
+                    mkRule reals id ctx funcDecls body Multiset.empty head)
+                bodyResult
         lift (maybe Seq.empty (fun x -> Seq.singleton ("init", x))) ruleResult
 
 
@@ -920,7 +919,7 @@ module Run =
                       (fun (var : CTyped<Var>) ->
                           ctx.MkConst
                               (valueOf var,
-                               Translator.typeToSort shouldUseRealsForInts ctx (typeOf var)))
+                               typeToSort shouldUseRealsForInts ctx (typeOf var)))
                    >> Set.toArray)
                   varsR
 

--- a/MuZ3Backend.fs
+++ b/MuZ3Backend.fs
@@ -592,13 +592,6 @@ module Translator =
      * Deferred checks
      *)
 
-    // TODO(CaptainHayashi): clean this up?
-    let varToExpr (v : TypedVar) : Expr<Var> =
-        match v with
-        | Int iv -> Int (IVar iv)
-        | Bool bv -> Bool (BVar bv)
-        | Array (eltype, length, av) -> Array (eltype, length, AVar av)
-
     /// Converts a downclosure func into a guarded func, instantiating the
     /// variables directly as nonsymbolic unmarked vars.
     /// We map any instance of the iterator through f.

--- a/MuZ3Backend.fs
+++ b/MuZ3Backend.fs
@@ -537,14 +537,14 @@ module Translator =
             tliftToExprDest
                 (tliftOverCTyped (ignoreContext (toVar >> ok)))
         let toVarTravExpr = tliftToExprSrc toVarTrav
-        let toVarTravBool = tLiftToBoolSrc toVarTrav
+        let toVarTravBool = tliftToBoolSrc toVarTrav
         let toVarTravGView = tchainM (tliftOverGFunc toVarTravExpr) id
         let toVarTravVFunc = tliftOverFunc toVarTravExpr
 
         let findVarTrav : Traversal<TypedVar, Expr<Var>, Error> =
             tliftToExprDest collectVars
         let findVarTravExpr = tliftToExprSrc findVarTrav
-        let findVarTravBool = tLiftToBoolSrc findVarTrav
+        let findVarTravBool = tliftToBoolSrc findVarTrav
         let findVarTravGView = tchainM (tliftOverGFunc findVarTravExpr) id
         let findVarTravVFunc = tliftOverFunc findVarTravExpr
 
@@ -904,7 +904,7 @@ module Run =
 
         // TODO(CaptainHayashi): de-duplicate this with mkRule?
         let defVarsR =
-            findVars (tLiftToBoolSrc (tliftToExprDest collectVars)) def
+            findVars (tliftToBoolSrc (tliftToExprDest collectVars)) def
         let paramVarsR =
             findVars
                 (tchainL (tliftOverExpr collectVars) id)

--- a/Optimiser.fs
+++ b/Optimiser.fs
@@ -683,7 +683,7 @@ module Graph =
                        commands.  If this fails, give up on the optimisation. *)
                     let toBefore : BoolExpr<Var> -> Result<BoolExpr<MarkedVar>, _> =
                         mapTraversal
-                            (tLiftToBoolSrc
+                            (tliftToBoolSrc
                                 (tliftToExprDest
                                     (tliftOverCTyped
                                         (ignoreContext (Before >> ok)))))
@@ -971,7 +971,7 @@ module Term =
     let rec (|ConstantBoolFunction|_|) (x : BoolExpr<Sym<MarkedVar>>)
       : MarkedVar option =
         x
-        |> findMarkedVars (tLiftToBoolSrc (tliftToExprDest collectSymMarkedVars))
+        |> findMarkedVars (tliftToBoolSrc (tliftToExprDest collectSymMarkedVars))
         |> okOption |> Option.map (Seq.map valueOf) |> Option.bind onlyOne
 
     /// Partial pattern that matches a Boolean expression in terms of exactly one /
@@ -979,7 +979,7 @@ module Term =
     let rec (|ConstantIntFunction|_|) (x : IntExpr<Sym<MarkedVar>>)
       : MarkedVar option =
         x
-        |> findMarkedVars (tLiftToIntSrc (tliftToExprDest collectSymMarkedVars))
+        |> findMarkedVars (tliftToIntSrc (tliftToExprDest collectSymMarkedVars))
         |> okOption |> Option.map (Seq.map valueOf) |> Option.bind onlyOne
 
     /// Finds all instances of the pattern `x!after = f(x!before)` in an

--- a/Optimiser.fs
+++ b/Optimiser.fs
@@ -568,24 +568,18 @@ module Graph =
                         | Bad _ -> false
                         | Ok (sp, _) ->
                             // ...for all of the variables in said parameters...
-                            let getVars = tliftOverExpr collectMarkedVars
-                            match findMarkedVars getVars sp with
+                            let getVars = tliftOverExpr collectVars
+                            match findVars getVars sp with
                             | Bad _ -> false
                             | Ok (pvars, _) ->
                                 let pvseq = Set.toSeq pvars
                                 Seq.forall
                                     (// ...the variable is thread-local.
                                      valueOf
+                                     >> tVars.TryFind
                                      >> function
-                                        | (After x)
-                                        | (Before x)
-                                        | (Intermediate (_, x))
-                                        | (Goal (_, x)) ->
-                                            x
-                                            |> tVars.TryFind
-                                            |> function
-                                               | Some _ -> true
-                                               | _ -> false)
+                                        | Some _ -> true
+                                        | _ -> false)
                                     pvseq)
                      ps)
 
@@ -624,7 +618,7 @@ module Graph =
     /// <summary>
     ///     Partial active pattern matching <c>Sym</c>-less expressions.
     /// </summary>
-    let (|MNoSym|_|) : BoolExpr<Sym<MarkedVar>> -> BoolExpr<MarkedVar> option =
+    let (|NoSym|_|) : BoolExpr<Sym<Var>> -> BoolExpr<Var> option =
         mapTraversal (removeSymFromBoolExpr ignore) >> okOption
 
     /// <summary>
@@ -679,51 +673,40 @@ module Graph =
             fun node nView outEdges inEdges nk ->
                 match nView with
                 | InnerView(ITEGuards (xc, xv, yc, yv)) ->
-                    (* Translate xc and yc to pre-state, to match the
-                       commands.  If this fails, give up on the optimisation. *)
-                    let toBefore : BoolExpr<Var> -> Result<BoolExpr<MarkedVar>, _> =
-                        mapTraversal
-                            (tliftToBoolSrc
-                                (tliftToExprDest
-                                    (tliftOverCTyped
-                                        (ignoreContext (Before >> ok)))))
-                    match toBefore xc, toBefore yc with
-                    | Ok (xcPre, _), Ok (ycPre, _) ->
-                        match (Set.toList outEdges, Set.toList inEdges) with
-                        (* Are there only two out edges, and only one in edge?
-                           Are the out edges assumes, and are they non-symbolic? *)
-                        | ( [ { Dest = out1D
-                                Command = Assume (MNoSym out1P) } as out1
-                              { Dest = out2D
-                                Command = Assume (MNoSym out2P) } as out2
-                            ],
-                            [ inE ] )
-                            when (// Is the first one x and the second y?
-                                  (equivHolds
-                                       unmarkVar
-                                       (andEquiv (equiv out1P xcPre)
-                                                 (equiv out2P ycPre))
-                                   && nodeHasView out1D xv ctx.Graph
-                                   && nodeHasView out2D yv ctx.Graph)
-                                  // Or is the first one y and the second x?
-                                  || (equivHolds
-                                          unmarkVar
-                                          (andEquiv (equiv out2P xcPre)
-                                                    (equiv out1P ycPre))
-                                      && nodeHasView out2D xv ctx.Graph
-                                      && nodeHasView out1D yv ctx.Graph)) ->
-                            let xforms =
-                                seq { // Remove the existing edges first.
-                                      yield RmInEdge (inE, node)
-                                      yield RmOutEdge (node, out1)
-                                      yield RmOutEdge (node, out2)
-                                      // Then, remove the node.
-                                      yield RmNode node
-                                      // Then, add the new edges.
-                                      yield MkCombinedEdge (inE, out1)
-                                      yield MkCombinedEdge (inE, out2) }
-                            runTransforms xforms ctx
-                        | _ -> ctx
+                    match (Set.toList outEdges, Set.toList inEdges) with
+                    (* Are there only two out edges, and only one in edge?
+                       Are the out edges assumes, and are they non-symbolic? *)
+                    | ( [ { Dest = out1D
+                            Command = Assume (NoSym out1P) } as out1
+                          { Dest = out2D
+                            Command = Assume (NoSym out2P) } as out2
+                        ],
+                        [ inE ] )
+                        when (// Is the first one x and the second y?
+                              (equivHolds
+                                   id
+                                   (andEquiv (equiv out1P xc)
+                                             (equiv out2P yc))
+                               && nodeHasView out1D xv ctx.Graph
+                               && nodeHasView out2D yv ctx.Graph)
+                              // Or is the first one y and the second x?
+                              || (equivHolds
+                                      id
+                                      (andEquiv (equiv out2P xc)
+                                                (equiv out1P yc))
+                                  && nodeHasView out2D xv ctx.Graph
+                                  && nodeHasView out1D yv ctx.Graph)) ->
+                        let xforms =
+                            seq { // Remove the existing edges first.
+                                  yield RmInEdge (inE, node)
+                                  yield RmOutEdge (node, out1)
+                                  yield RmOutEdge (node, out2)
+                                  // Then, remove the node.
+                                  yield RmNode node
+                                  // Then, add the new edges.
+                                  yield MkCombinedEdge (inE, out1)
+                                  yield MkCombinedEdge (inE, out2) }
+                        runTransforms xforms ctx
                     | _ -> ctx
                 | _ -> ctx
 

--- a/Optimiser.fs
+++ b/Optimiser.fs
@@ -601,15 +601,19 @@ module Graph =
 
     /// Determines if some given Command is local with respect to the given
     /// map of thread-local variables
-    let isLocalResults : VarMap -> Command -> bool =
-        fun tvars ->
-        let localResults prim =
-            List.forall (fun v ->
-                match (tvars.TryFind <| valueOf v) with
-                | Some x -> typeOf v = x
-                | None   -> false
-                ) prim.Results
-        List.forall localResults
+    let isLocalResults (tvars : VarMap) (command : Command) : bool =
+        (* We need to see if any of the variables named in the results
+           are local.  This can fail, but currently the optimiser can't.
+           For now we just assume the command is _not_ local if the
+           variable getter failed. *)
+        let maybeVars = okOption (commandResultVars command)
+
+        let isVarLocal v =
+            maybe false (fun x -> typeOf v = x) (tvars.TryFind (valueOf v))
+
+        maybe false
+            (Set.toList >> List.forall isVarLocal)
+            maybeVars
 
     /// <summary>
     ///     Partial active pattern matching <c>Sym</c>-less expressions.
@@ -793,22 +797,22 @@ module Graph =
                         // (TODO: do something with the ViewExpr annotations?)
                         match (pViewexpr, qViewexpr) with
                         | InnerView pView, InnerView qView ->
-                        let varResultSet = Set.map iteratedGFuncVars (Multiset.toSet pView)
-                        let varsResults = lift Set.unionMany (collect varResultSet)
-                        let cmdVars = commandResults e.Command
-                        // TODO: Better equality?
-                        match varsResults with
-                        | Ok (vars, _) ->
+                            let varResultSet = Set.map iteratedGFuncVars (Multiset.toSet pView)
+                            let varsResults = lift Set.unionMany (collect varResultSet)
+                            let cmdVarsResults = commandResultVars e.Command
                             // TODO: Better equality?
-                            if pView = qView && disjoint cmdVars vars
-                            then
-                                (flip runTransforms) ctx
-                                <| seq {
-                                    yield RmOutEdge (node, e)
-                                    yield Unify (node, e.Dest, OnlyIfNoConnections)
-                                }
-                            else ctx
-                        | _ -> ctx
+                            match varsResults, cmdVarsResults with
+                            | Ok (vars, _), Ok (cmdVars, _) ->
+                                // TODO: Better equality?
+                                if pView = qView && disjoint (Set.toList cmdVars) vars
+                                then
+                                    (flip runTransforms) ctx
+                                    <| seq {
+                                        yield RmOutEdge (node, e)
+                                        yield Unify (node, e.Dest, OnlyIfNoConnections)
+                                    }
+                                else ctx
+                            | _, _ -> ctx
                     else ctx
                 Set.fold processEdge ctx outEdges
 
@@ -837,12 +841,12 @@ module Graph =
 
                     match (pViewexpr, qViewexpr, rViewexpr) with
                     | InnerView pView, InnerView qView, InnerView rView ->
-                        let cResults = Set.ofList <| commandResults c
-                        let dResults = Set.ofList <| commandResults d
-                        match (commandArgs d) with
-                        | Ok (dArgs, _) ->
-                            if Set.isSubset cResults dResults
-                                && disjoint cResults dArgs
+                        let cVarResult = commandResultVars c
+                        let dVarResult = commandResultVars d
+                        match (commandArgs d, cVarResult, dVarResult) with
+                        | Ok (dArgs, _), Ok (cVars, _), Ok (dVars, _) ->
+                            if Set.isSubset cVars dVars
+                                && disjoint cVars dArgs
                                 && isLocalResults locals c
                                 && not (hasAssume c)  // TODO: is this too broad?
                                 && not (hasAssume d)  // TODO: is this necessary?

--- a/OptimiserTests.fs
+++ b/OptimiserTests.fs
@@ -118,7 +118,7 @@ module AfterExprs =
     /// Test after-elimination of Booleans.
     let check expected case : unit =
         let trav =
-            tLiftToBoolSrc
+            tliftToBoolSrc
                 (tliftToTypedSymVarSrc
                     (afterSubs OptimiserTests.AfterArithSubs OptimiserTests.AfterBoolSubs))
         let result = mapTraversal trav case

--- a/Parser.fs
+++ b/Parser.fs
@@ -321,7 +321,18 @@ let parseViewLike basic join =
 
 /// Parses a type identifier.
 let parseType : Parser<TypeLiteral, unit> =
-    stringReturn "int" TInt <|> stringReturn "bool" TBool
+    let parsePrimType =
+        stringReturn "int" TInt <|> stringReturn "bool" TBool
+
+    let parseArray = inSquareBrackets pint32 |>> curry TArray
+    let parseSuffixes = many parseArray
+
+    let rec applySuffixes ty suffixes =
+        match suffixes with
+        | [] -> ty
+        | x::xs -> applySuffixes (x ty) xs
+
+    pipe2ws parsePrimType parseSuffixes applySuffixes
 
 /// Parses a parameter.
 let parseParam : Parser<Param, unit> =

--- a/ParserTests.fs
+++ b/ParserTests.fs
@@ -147,42 +147,64 @@ module ExpressionTests =
 module AtomicActionTests =
     [<Test>]
     let ``foo++``() =
-        check parseAtomic "foo++" <| Some ** node "" 1L 1L (Postfix(LVIdent "foo", Increment))
+        check parseAtomic "foo++"
+            (Some
+                (node "" 1L 1L <| Postfix
+                    (node "" 1L 1L (Identifier "foo"),
+                    Increment)))
 
     [<Test>]
     let ``foo--`` =
-        check parseAtomic "foo--" <| Some ** node "" 1L 1L (Postfix(LVIdent "foo", Decrement))
+        check parseAtomic "foo--"
+            (Some
+                (node "" 1L 1L <| Postfix
+                    (node "" 1L 1L (Identifier "foo"),
+                     Decrement)))
 
     [<Test>]
     let ``foo = bar`` =
-        check parseAtomic "foo = bar"  <| Some
-        ** node "" 1L 1L (Fetch(LVIdent "foo", node "" 1L 7L <| LV(LVIdent "bar"), Direct))
+        check parseAtomic "foo = bar"
+            (Some
+                (node "" 1L 1L <| Fetch
+                    (node "" 1L 1L (Identifier "foo"),
+                     node "" 1L 7L (Identifier "bar"),
+                     Direct)))
 
     [<Test>]
     let ``foo = bar++`` =
-        check parseAtomic "foo = bar++" <| Some
-        ** node "" 1L 1L (Fetch(LVIdent "foo", node "" 1L 7L <| LV(LVIdent "bar"), Increment))
+        check parseAtomic "foo = bar++"
+            (Some
+                (node "" 1L 1L <| Fetch
+                    (node "" 1L 1L (Identifier "foo"),
+                     node "" 1L 7L (Identifier "bar"),
+                     Increment)))
 
     [<Test>]
     let ``foo = bar--`` =
-        check parseAtomic "foo = bar--" <| Some
-        ** node "" 1L 1L (Fetch(LVIdent "foo", node "" 1L 7L <| LV(LVIdent "bar"), Decrement))
+        check parseAtomic "foo = bar--"
+            (Some
+                (node "" 1L 1L <| Fetch
+                    (node "" 1L 1L (Identifier "foo"),
+                     node "" 1L 7L (Identifier "bar"),
+                     Decrement)))
 
     [<Test>]
     let ``Compare and swap``() =
-        check parseAtomic "CAS(foo, bar, 2)" <| Some
-        ** node "" 1L 1L
-           (CompareAndSwap( LVIdent "foo",
-                            LVIdent "bar",
-                            node "" 1L 15L (Num 2L)))
+        check parseAtomic "CAS(foo, bar, 2)"
+            (Some
+                (node "" 1L 1L <| CompareAndSwap
+                    (node "" 1L 5L (Identifier "foo"),
+                     node "" 1L 10L (Identifier "bar"),
+                     node "" 1L 15L (Num 2L))))
 
 module AtomicSetTests =
     [<Test>]
     let ``<foo++>``() =
         check parseAtomicSet "<foo++>"
-        <| Some ** [
-            node "" 1L 2L (Postfix (LVIdent "foo", Increment))
-            ]
+            (Some
+                [ node "" 1L 2L <| Postfix
+                    (node "" 1L 2L (Identifier "foo"),
+                     Increment) ] )
 
     [<Test>]
     let ``Multiple outside block invalid``() =
@@ -191,17 +213,21 @@ module AtomicSetTests =
     [<Test>]
     let ``Single atomic block``() =
         check parseAtomicSet "<{ foo++; }>"
-        <| Some [
-            node "" 1L 4L (Postfix (LVIdent "foo", Increment))
-            ]
+            (Some
+                [ node "" 1L 4L <| Postfix
+                    (node "" 1L 4L (Identifier "foo"),
+                     Increment) ] )
 
     [<Test>]
     let ``Multiple in block valid``() =
         check parseAtomicSet "<{ foo++; bar--; }>"
-        <| Some [
-            node "" 1L 4L (Postfix (LVIdent "foo", Increment))
-            node "" 1L 11L (Postfix (LVIdent "bar", Decrement))
-            ]
+            (Some
+                [ node "" 1L 4L <| Postfix
+                    (node "" 1L 4L (Identifier "foo"),
+                     Increment)
+                  node "" 1L 11L <| Postfix
+                    (node "" 1L 11L (Identifier "bar"),
+                     Decrement) ] )
 
 module ConstraintTests =
     [<Test>]
@@ -216,11 +242,11 @@ module ConstraintTests =
                  Some
                    (node "" 1L 28L
                     <| BopExpr (Gt,
-                                node "" 1L 26L (LV(LVIdent "c")),
+                                node "" 1L 26L (Identifier "c"),
                                 node "" 1L 32L
                                 <| BopExpr(Add,
-                                       node "" 1L 30L (LV(LVIdent "a")),
-                                       node "" 1L 34L (LV(LVIdent "b"))))))
+                                       node "" 1L 30L (Identifier "a"),
+                                       node "" 1L 34L (Identifier "b")))))
 
     [<Test>]
     let ``Func(a,b) -> ?;``() =

--- a/Pretty.fs
+++ b/Pretty.fs
@@ -308,3 +308,8 @@ let printList pItem lst =
 /// Formats an error that is wrapping another error.
 let wrapped wholeDesc whole err =
     headed (sprintf "In %s '%s'" wholeDesc (print whole)) [ err ]
+
+/// <summary>
+///     Prints an integer.
+/// </summary>
+let printInt (i : int) : Doc = String (sprintf "%i" i)

--- a/PrettyTests.fs
+++ b/PrettyTests.fs
@@ -15,7 +15,7 @@ type PrettyTests() =
     /// Test cases for printExpression.
     static member Exprs =
         [ TestCaseData(freshNode <| Num 5L).Returns("5")
-          TestCaseData(freshNode <| BopExpr(Div, freshNode <| Num 6L, freshNode <| LV(LVIdent "bar"))).Returns("(6 / bar)")
+          TestCaseData(freshNode <| BopExpr(Div, freshNode <| Num 6L, freshNode <| Identifier "bar")).Returns("(6 / bar)")
 
           TestCaseData(freshNode <| BopExpr(Mul, freshNode <| BopExpr(Add, freshNode <| Num 1L, freshNode <| Num 2L), freshNode <| Num 3L)).Returns("((1 + 2) * 3)") ]
         |> List.map (fun d -> d.SetName(sprintf "Print expression %A" d.ExpectedResult))

--- a/Reifier.fs
+++ b/Reifier.fs
@@ -62,6 +62,10 @@ module Types =
         /// </summary>
         | TooManyIteratedFuncs of view : DView * amount : int
         /// <summary>
+        ///     An iterated func is being used in a non-iterated manner.
+        /// </summary>
+        | NoIteratorOnIterated of func : IteratedDFunc
+        /// <summary>
         ///     An non-iterated func is being used in an iterated manner.
         /// </summary>
         | IteratorOnNonIterated of func : IteratedDFunc
@@ -367,33 +371,45 @@ module Downclosure =
       : Result<DeferredCheck list, Error> =
         let (lhs, rhs) = def
 
-        trial {
-            (* First, we check the prototypes of the views in the lhs to see which
-               are iterated. *)
+        (* First, we check the uses of the views in the lhs to see which
+           are iterated in the definition. *)
+        let iterprotos, normprotos =
+            List.partition (fun func -> func.Iterator <> None) lhs
 
-            let iterprotos, normprotos =
-                List.partition (fun func -> func.Iterator <> None) lhs
+        (* Now, check that each iterated use matches up with an iterated
+           prototype, and vice versa. *)
+        let checkIterAgree shouldBeIterated error ifunc =
+            let iInfoResult = lookupFunc vprotos ifunc.Func
+            bind
+                (function
+                 | Some { IsIterated = ii } when ii = shouldBeIterated ->
+                    ok ifunc
+                 | Some _ -> fail (error ifunc)
+                 | None -> fail (NoSuchView ifunc.Func))
+                iInfoResult
 
-            match (iterprotos, normprotos) with
-            (* Correct non-iterated view definition.
-               No more checking necessary. *)
-            | [], _ -> return deferred
-            (* Correct iterated view definition, as long as i is actually an
-               iterated func.
-               Need to check inductive and base downclosure. *)
-            | [i], [] ->
-                let! iInfo = lookupFunc vprotos i.Func
-                return!
-                    (match iInfo with
-                     | Some { IsIterated = true } ->
-                        checkDownclosure i empDefn rhs deferred
-                     | Some { IsIterated = _ } -> fail (IteratorOnNonIterated i)
-                     | None -> fail (NoSuchView i.Func))
-            // Over-large iterated view definition (for now, anyway).
-            | xs, [] -> return! fail (TooManyIteratedFuncs (lhs, List.length xs))
-            // Mixed view definition (currently not allowed).
-            | _, _ -> return! fail (MixedFuncType lhs)
-        }
+        let iterProtoCheckedResult =
+            collect (Seq.map (checkIterAgree true IteratorOnNonIterated) iterprotos)
+        let normProtoCheckedResult =
+            collect (Seq.map (checkIterAgree false NoIteratorOnIterated) normprotos)
+
+        bind2
+            (fun ips nps ->
+                match (ips, nps) with
+                (* Correct non-iterated view definition.
+                   No more checking necessary. *)
+                | [], _ -> ok deferred
+                (* Correct iterated view definition, as long as i is actually an
+                   iterated func.
+                   Need to check inductive and base downclosure. *)
+                | [i], [] ->
+                    checkDownclosure i empDefn rhs deferred
+                // Over-large iterated view definition (for now, anyway).
+                | xs, [] -> fail (TooManyIteratedFuncs (lhs, List.length xs))
+                // Mixed view definition (currently not allowed).
+                | _, _ -> fail (MixedFuncType lhs))
+            iterProtoCheckedResult
+            normProtoCheckedResult
 
     /// <summary>
     ///     Performs all downclosure and well-formedness checking on iterated
@@ -772,12 +788,22 @@ module Pretty =
             wrapped "lookup for view"
                 (printDFunc func)
                 (err |> Core.Definer.Pretty.printError)
+        | NoIteratorOnIterated func ->
+            errorStr "view"
+            <+> quoted
+                    (printIteratedContainer
+                        printDFunc
+                        (maybe Nop printTypedVar)
+                        func)
+            <+> errorStr "is iterated, but used as non-iterated in a constraint"
         | IteratorOnNonIterated func ->
-            fmt "view '{0}' is not iterated, but used in an iterated constraint"
-                [ printIteratedContainer
-                    printDFunc
-                    (maybe Nop printTypedVar)
-                    func ]
+            errorStr "view"
+            <+> quoted
+                    (printIteratedContainer
+                        printDFunc
+                        (maybe Nop printTypedVar)
+                        func)
+            <+> errorStr "is not iterated, but used as iterated in a constraint"
         | BadIteratorType (view, ty) ->
             fmt "iterator on constraint '{0}' is of type {1}, should be int"
                 [ printDView view

--- a/Reifier.fs
+++ b/Reifier.fs
@@ -172,7 +172,7 @@ module Downclosure =
         let mapper =
             liftWithoutContext
                 fOnIter
-                (tliftToTypedSymVarSrc >> tLiftToBoolSrc)
+                (tliftToTypedSymVarSrc >> tliftToBoolSrc)
 
         mapMessages Traversal (mapper defn)
 

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -294,15 +294,17 @@ let normaliseAssigns (assigns : (Expr<Sym<Var>> * Expr<Sym<Var>>) list)
             // TODO(CaptainHayashi): proper errors.
             match lhs with
             | Array (eltype, length, alhs) ->
-                let addUpdate (index, value) lhs' =
+                let addUpdate
+                  (index : IntExpr<Sym<Var>>, value : Write) (lhs' : Expr<Sym<Var>>)
+                  : Result<Expr<Sym<Var>>, Error> =
                     (* Need to translate any further subscripts inside value.
                        But, to do that, we need to know what the LHS of those
                        subscripts is! *)
                     let vlhs = mkIdx eltype length alhs index
                     let vrhsResult = translateRhs vlhs value
                     lift
-                        (fun (vrhs) ->
-                            Array
+                        (fun vrhs ->
+                            Expr.Array
                                 (eltype, length,
                                  AUpd (eltype, length, alhs, index, vrhs)))
                         vrhsResult

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -188,7 +188,7 @@ let checkParamTypesPrim : PrimCommand -> PrimSemantics -> Result<PrimCommand, Er
     fun prim sem ->
     List.map2
         (fun fp dp ->
-            if typeOf fp = typeOf dp
+            if typesCompatible (typeOf fp) (typeOf dp)
             then ok ()
             else fail (TypeMismatch (dp, typeOf fp)))
         prim.Args

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -150,15 +150,14 @@ let markWrite (var : CTyped<Sym<Var>>) (idxPath : IntExpr<Sym<Var>> list)
             match idxPathRest with
             | [] ->
                 (* If there is no subscript, then we must be writing to this
-                   entire index, so mark it as Entire. *)
-                Entire value
+                   entire index, so mark it as Entire... if it isn't already
+                   written to. *)
+                match idxRec with
+                | Some _ -> failwith "markWriteIdx: tried to write twice with empty path"
+                | None -> Entire value
             | x::xs ->
                 match idxRec with
-                | Some (Entire _) ->
-                    (* If we're already writing to the entire index somewhere
-                       else, we probably have a problem!  Eventually we should
-                       report it, but for now we just clobber the value. *)
-                    Entire value
+                | Some (Entire _) -> failwith "markWriteIdx: tried to write twice with nonempty path"
                 | Some (Indices imap) -> markWriteIdx x xs imap
                 | None -> markWriteIdx x xs Map.empty
 
@@ -174,15 +173,13 @@ let markWrite (var : CTyped<Sym<Var>>) (idxPath : IntExpr<Sym<Var>> list)
         match idxPath with
         | [] ->
             (* If there is no subscript, then we must be writing to this entire
-               variable, so mark it as Entire. *)
-            Entire value
+               variable, so mark it as Entire... if it isn't already written to. *)
+            match varRec with
+            | Some _ -> failwith "markWrite: tried to write twice with empty path"
+            | None -> Entire value
         | (x::xs) ->
             match varRec with
-            | Some (Entire _) ->
-                (* If we're already writing to the entire index somewhere
-                   else, we probably have a problem!  Eventually we should
-                   report it, but for now we just clobber the value. *)
-                Entire value
+            | Some (Entire _) -> failwith "markWrite: tried to write twice with nonempty path"
             | Some (Indices imap) -> markWriteIdx x xs imap
             | None -> markWriteIdx x xs Map.empty
 

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -482,7 +482,6 @@ let microcodeToBool
         >> mapMessages Traversal
 
     let rec translateInstrs is =
-        // TODO(CaptainHayashi): do two-state conversion here, not earlier.
         // TODO(CaptainHayashi): convert to variable LVs.
         // TODO(CaptainHayashi): framing (currently done elsewhere).
         let translateInstr =

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -262,9 +262,9 @@ let mkIdx (eltype : Type) (length : int option) (arr : ArrayExpr<Sym<Var>>)
     let record = (eltype, length, arr, idx)
 
     match eltype with
-    | Int () -> Int (IIdx record)
-    | Bool () -> Bool (BIdx record)
-    | Array (eltype', length', ()) -> Array (eltype', length', AIdx record)
+    | Type.Int () -> Expr.Int (IIdx record)
+    | Type.Bool () -> Expr.Bool (BIdx record)
+    | Type.Array (eltype', length', ()) -> Expr.Array (eltype', length', AIdx record)
 
 /// <summary>
 ///     Normalises a list of assignments such that they represent

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -104,7 +104,7 @@ let frame svars tvars expr =
        We do this by finding _all_ variables, then filtering. *)
     let varsInExprResult =
         findMarkedVars
-            (tLiftToBoolSrc (tliftToExprDest collectSymMarkedVars))
+            (tliftToBoolSrc (tliftToExprDest collectSymMarkedVars))
             expr
     let untypedVarsInExprResult = lift (Seq.map valueOf) varsInExprResult
 
@@ -218,7 +218,7 @@ let instantiatePrim
         | Some s ->
             let subInTypedSym =
                     tliftToTypedSymVarSrc (primParamSubFun prim s)
-            let subInBool = tLiftToBoolSrc subInTypedSym
+            let subInBool = tliftToBoolSrc subInTypedSym
             let subbed = lift Some (mapTraversal subInBool s.Body)
             mapMessages Traversal subbed
 
@@ -283,7 +283,7 @@ let seqComposition (xs : BoolExpr<Sym<MarkedVar>> list)
             | v -> Reg v
 
         let xRewriteBool =
-            tLiftToBoolSrc
+            tliftToBoolSrc
                 (tliftToExprDest
                     (tliftOverCTyped
                         (tliftToSymSrc

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -207,6 +207,8 @@ let varAndIdxPath (expr : Expr<Sym<Var>>)
         match ax with
         | AVar v -> Some (v, path)
         | AIdx (_, _, a, i) -> getInArray a (i::path)
+        // TODO(CaptainHayashi): do something useful here.
+        | AUpd (_, _, a, i, _) -> None
 
     (* Because we've traversed from outside in, the path is actually the wrong
        way round, so we need to flip it! *)

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -138,31 +138,37 @@ let frame svars tvars expr =
 
     lift makeFrames evarsResult
 
-let paramToMExpr : TypedVar -> SMExpr =
-    function
-    | Int  i -> After i |> Reg |> IVar |> Int
-    | Bool b -> After b |> Reg |> BVar |> Bool
-
 let primParamSubFun
   ( cmd : PrimCommand )
   ( sem : PrimSemantics )
   : Traversal<TypedVar, Expr<Sym<MarkedVar>>, Error> =
     /// merge the pre + post conditions
-    let fres = List.map paramToMExpr cmd.Results
-    let fpars = cmd.Args @ fres
+    let paramToMExpr : Traversal<Expr<Sym<Var>>, Expr<Sym<MarkedVar>>, Error> =
+        tliftOverExpr (traverseTypedSymWithMarker After)
+
+    let fparsResult =
+        mapTraversal
+            (tchainL paramToMExpr (List.append cmd.Args))
+            cmd.Results
+
     let dpars = sem.Args @ sem.Results
 
-    let pmap = Map.ofSeq (Seq.map2 (fun par up -> valueOf par, up) dpars fpars)
+    let pmapResult =
+        lift
+            (Map.ofSeq << Seq.map2 (fun par up -> valueOf par, up) dpars)
+            fparsResult
 
-    ignoreContext
-        (function
-         | WithType (var, vtype) as v ->
-            match pmap.TryFind var with
-            | Some tvar ->
-                if vtype = typeOf tvar
-                then ok tvar
-                else fail (Inner (TypeMismatch (v, typeOf tvar)))
-            | None -> fail (Inner (FreeVarInSub v)))
+    let travFromMap (pmap : Map<Var, Expr<Sym<MarkedVar>>>) =
+        ignoreContext
+            (function
+             | WithType (var, vtype) as v ->
+                match pmap.TryFind var with
+                | Some tvar ->
+                    if vtype = typeOf tvar
+                    then ok tvar
+                    else fail (Inner (TypeMismatch (v, typeOf tvar)))
+                | None -> fail (Inner (FreeVarInSub v)))
+    fun ctx e -> bind (fun pmap -> travFromMap pmap ctx e) pmapResult
 
 let checkParamCountPrim : PrimCommand -> PrimSemantics option -> Result<PrimSemantics option, Error> =
     fun prim opt ->

--- a/SemanticsTests.fs
+++ b/SemanticsTests.fs
@@ -168,7 +168,7 @@ module CommandTests =
 
     [<Test>]
     let ``Semantically translate <serving++> using the ticket lock model``() =
-        check [ command "!I++" [ Int "serving" ] [ Expr.Int <| siBefore "serving" ] ]
+        check [ command "!I++" [ Int (siVar "serving") ] [ Expr.Int <| siBefore "serving" ] ]
         <| Some (Set.ofList
             [
                 iEq (siAfter "s") (siBefore "s")

--- a/SemanticsTests.fs
+++ b/SemanticsTests.fs
@@ -97,41 +97,36 @@ module Compositions =
 
 module WriteMaps =
     [<Test>]
-    let ``write map of x[3][i] = y[j]++ is correct`` () =
+    let ``write map of x[3][i] <- 3; y[j] <- 4 is correct`` () =
         Map.ofList
             [ (Reg "x",
                 Indices <| Map.ofList
                     [ (IVar (Reg "i"),
                         Indices <| Map.ofList
-                            [ (IInt 3L, Entire) ]) ] )
+                            [ (IInt 3L, Entire (Int (IInt 3L))) ]) ] )
               (Reg "y",
                 Indices <| Map.ofList
-                    [ (IVar (Reg "j"), Entire ) ] ) ]
+                    [ (IVar (Reg "j"), Entire (Int (IInt 4L))) ] ) ]
         ?=?
         makeWriteMap
-            (command "!ILoad++"
-                [ Int
-                    (IIdx
-                        (Int (),
-                         Some 320,
-                         AIdx
-                            (Array (Int (), Some 320, ()),
-                             Some 240,
-                             AVar (Reg "x"),
-                             IInt 3L),
-                         IVar (Reg "i")))
-                  Int
-                    (IIdx
-                        (Int (),
-                         Some 320,
-                         AVar (Reg "y"),
-                         (IVar (Reg "j")))) ]
-                [ Expr.Int
-                    (IIdx
-                        (Int (),
-                         Some 320,
-                         AVar (Reg (Before "y")),
-                         (siBefore "j"))) ])
+            [ (Int
+                (IIdx
+                    (Int (),
+                     Some 320,
+                     AIdx
+                        (Array (Int (), Some 320, ()),
+                         Some 240,
+                         AVar (Reg "x"),
+                         IInt 3L),
+                     IVar (Reg "i"))),
+               Int (IInt 3L))
+              (Int
+                (IIdx
+                    (Int (),
+                     Some 320,
+                     AVar (Reg "y"),
+                     (IVar (Reg "j")))),
+               Int (IInt 4L)) ]
 
 module Frames =
     let check var expectedFramedExpr =

--- a/SemanticsTests.fs
+++ b/SemanticsTests.fs
@@ -95,6 +95,44 @@ module Compositions =
                  iEq (siInter 0I "g") (siInter 1I "t") ]
 
 
+module WriteMaps =
+    [<Test>]
+    let ``write map of x[3][i] = y[j]++ is correct`` () =
+        Map.ofList
+            [ (Reg "x",
+                Indices <| Map.ofList
+                    [ (IVar (Reg "i"),
+                        Indices <| Map.ofList
+                            [ (IInt 3L, Entire) ]) ] )
+              (Reg "y",
+                Indices <| Map.ofList
+                    [ (IVar (Reg "j"), Entire ) ] ) ]
+        ?=?
+        makeWriteMap
+            (command "!ILoad++"
+                [ Int
+                    (IIdx
+                        (Int (),
+                         Some 320,
+                         AIdx
+                            (Array (Int (), Some 320, ()),
+                             Some 240,
+                             AVar (Reg "x"),
+                             IInt 3L),
+                         IVar (Reg "i")))
+                  Int
+                    (IIdx
+                        (Int (),
+                         Some 320,
+                         AVar (Reg "y"),
+                         (IVar (Reg "j")))) ]
+                [ Expr.Int
+                    (IIdx
+                        (Int (),
+                         Some 320,
+                         AVar (Reg (Before "y")),
+                         (siBefore "j"))) ])
+
 module Frames =
     let check var expectedFramedExpr =
         expectedFramedExpr ?=? (frameVar Before var)

--- a/Symbolic.fs
+++ b/Symbolic.fs
@@ -240,7 +240,7 @@ module Traversal =
     /// </returns>
     let removeSymFromBoolExpr (err : string -> 'Error)
       : Traversal<BoolExpr<Sym<'Var>>, BoolExpr<'Var>, 'Error> =
-        tLiftToBoolSrc
+        tliftToBoolSrc
             (tliftToExprDest
                 (tliftOverCTyped (removeSymFromVar err)))
 

--- a/Symbolic.fs
+++ b/Symbolic.fs
@@ -425,8 +425,6 @@ let markedSymExprVars (expr : Expr<Sym<MarkedVar>>)
     findMarkedVars (tliftOverExpr collectSymMarkedVars) expr
 
 /// Returns the set of all variables annotated with their types
-/// contained within the SMExpr
-let SMExprVars : SMExpr -> Result<Set<TypedVar>, TraversalError<'Error>> =
-    fun expr ->
-        let smvars = markedSymExprVars expr
-        lift (Set.map unmark) smvars
+/// contained within the SVExpr
+let SVExprVars (expr : SVExpr) : Result<Set<TypedVar>, TraversalError<'Error>> =
+    findVars (tliftOverExpr collectSymVars) expr

--- a/Symbolic.fs
+++ b/Symbolic.fs
@@ -320,16 +320,19 @@ module Traversal =
     let approx
       : Traversal<CTyped<Sym<MarkedVar>>, Expr<Sym<MarkedVar>>, unit> =
         let rec sub ctx =
+            // Only symbolic Booleans are handled specially.
             function
             | Bool (Sym x) ->
                 match ctx with
                 | Positions (position::_) ->
                     ok (ctx, position |> Context.underapprox |> Bool)
                 | c -> fail (ContextMismatch ("position context", c))
-            | Int (Sym { Name = body; Params = rs }) ->
-                tchainL rmap (sym body >> IVar >> Int) ctx rs
-            | Bool (Reg x) -> ok (ctx, x |> sbVar |> Bool)
-            | Int (Reg x) -> ok (ctx, x |> siVar |> Int)
+            (* Everything else just has approximation bubbled through
+               in a type-generic way. *)
+            | WithType (Sym { Name = body; Params = rs }, t) ->
+                tchainL rmap (sym body >> withType t >> mkVarExp) ctx rs
+            | WithType (Reg x, t) ->
+                ok (ctx, mkVarExp (withType t (Reg x)))
         and sf = tliftToExprSrc sub
         and rmap ctx = sf (Context.push id ctx)
 

--- a/SymbolicTests.fs
+++ b/SymbolicTests.fs
@@ -24,7 +24,7 @@ module PostStateRewrite =
     let checkInt (expected : IntExpr<Sym<MarkedVar>>) (expr : IntExpr<Sym<Var>>)
       : unit =
         let trav = tliftToExprDest (traverseTypedSymWithMarker After)
-        let res = mapTraversal (tLiftToIntSrc trav) expr
+        let res = mapTraversal (tliftToIntSrc trav) expr
 
         assertOkAndEqual expected res
             (printTraversalError (fun () -> String "?" ) >> printUnstyled)
@@ -59,7 +59,7 @@ module BoolApprox =
       (ctx : TraversalContext)
       (expr : BoolExpr<Sym<MarkedVar>>)
       : unit =
-        let result = tLiftToBoolSrc approx ctx expr
+        let result = tliftToBoolSrc approx ctx expr
         assertOkAndEqual (ctx, expected) result
             (printTraversalError (fun () -> String "?" ) >> printUnstyled)
 

--- a/TestStudies.fs
+++ b/TestStudies.fs
@@ -65,120 +65,62 @@ let pos l c node =
 
 /// The correct parsing of the ticket lock's lock method.
 let ticketLockLockMethodAST =
-    {Signature = {Name = "lock";
-                  Params = [];};
-           Body =
-            {Pre = Unmarked Unit;
-             Contents =
-              [{Command =
-                 pos 15L 5L
-                 <| Command'.Prim
-                     {PreAssigns = [];
-                      Atomics =
-                       [pos 15L 6L <|
-                          Fetch
-                            (LVIdent "t",
-                             pos 15L 10L <| LV (LVIdent "ticket"), Increment);];
-                      PostAssigns = [];};
+    { Signature = { Name = "lock"; Params = [] }
+      Body =
+        { Pre = Unmarked Unit;
+          Contents =
+            [ { Command =
+                    pos 15L 5L <| Command'.Prim
+                        { PreAssigns = []
+                          Atomics =
+                            [ pos 15L 6L <|
+                              Fetch
+                                (pos 15L 6L (Identifier "t"),
+                                 pos 15L 10L (Identifier "ticket"),
+                                 Increment) ]
+                          PostAssigns = [] }
                 Post =
-                 Unmarked
-                   (View.Func
-                      {Name = "holdTick";
-                       Params =
-                        [pos 16L 15L <| LV (LVIdent "t")] })};
-
-               {Command =
-                 {Position = {StreamName = "Examples/Pass/ticketLock.cvf";
-                              Line = 17L;
-                              Column = 5L;};
-                  Node =
-                   DoWhile
-                     ({Pre =
-                        Unmarked
-                          (View.Func
-                             {Name = "holdTick";
+                    Unmarked
+                        (View.Func
+                            { Name = "holdTick"
                               Params =
-                               [{Position =
-                                  {StreamName = "Examples/Pass/ticketLock.cvf";
-                                   Line = 18L;
-                                   Column = 19L;};
-                                 Node = LV (LVIdent "t");}];});
-                       Contents =
-                        [{Command =
-                           {Position =
-                             {StreamName = "Examples/Pass/ticketLock.cvf";
-                              Line = 19L;
-                              Column = 9L;};
-                            Node =
-                             Command'.Prim
-                               {PreAssigns = [];
-                                Atomics =
-                                 [{Position =
-                                    {StreamName =
-                                      "Examples/Pass/ticketLock.cvf";
-                                     Line = 19L;
-                                     Column = 10L;};
-                                   Node =
-                                    Fetch
-                                      (LVIdent "s",
-                                       {Position =
-                                         {StreamName =
-                                           "Examples/Pass/ticketLock.cvf";
-                                          Line = 19L;
-                                          Column = 14L;};
-                                        Node = LV (LVIdent "serving");},Direct);}];
-                                PostAssigns = [];};};
-                          Post =
-                           Unmarked
-                             (View.If
-                                ({Position =
-                                   {StreamName = "Examples/Pass/ticketLock.cvf";
-                                    Line = 20L;
-                                    Column = 15L;};
-                                  Node =
-                                   BopExpr
-                                     (Eq,
-                                      {Position =
-                                        {StreamName =
-                                          "Examples/Pass/ticketLock.cvf";
-                                         Line = 20L;
-                                         Column = 13L;};
-                                       Node = LV (LVIdent "s");},
-                                      {Position =
-                                        {StreamName =
-                                          "Examples/Pass/ticketLock.cvf";
-                                         Line = 20L;
-                                         Column = 18L;};
-                                       Node = LV (LVIdent "t");});},
-                                 View.Func {Name = "holdLock";
-                                       Params = [];},
-                                 View.Func
-                                   {Name = "holdTick";
-                                    Params =
-                                     [{Position =
-                                        {StreamName =
-                                          "Examples/Pass/ticketLock.cvf";
-                                         Line = 20L;
-                                         Column = 50L;};
-                                       Node = LV (LVIdent "t");}];}));}];},
-                      {Position = {StreamName = "Examples/Pass/ticketLock.cvf";
-                                   Line = 21L;
-                                   Column = 16L;};
-                       Node =
-                        BopExpr
-                          (Neq,
-                           {Position =
-                             {StreamName = "Examples/Pass/ticketLock.cvf";
-                              Line = 21L;
-                              Column = 14L;};
-                            Node = LV (LVIdent "s");},
-                           {Position =
-                             {StreamName = "Examples/Pass/ticketLock.cvf";
-                              Line = 21L;
-                              Column = 19L;};
-                            Node = LV (LVIdent "t");});});};
-                Post = Unmarked (View.Func {Name = "holdLock";
-                                       Params = [];});}];};};
+                                [ pos 16L 15L <| Identifier "t" ] })}
+              { Command =
+                    pos 17L 5L <| DoWhile
+                        ({ Pre =
+                            Unmarked
+                                (View.Func
+                                    { Name = "holdTick"
+                                      Params =
+                                        [ pos 18L 19L <| Identifier "t" ] })
+                           Contents =
+                            [ { Command =
+                                    pos 19L 9L <| Command'.Prim
+                                        { PreAssigns = []
+                                          Atomics =
+                                            [ pos 19L 10L <| Fetch
+                                                (pos 19L 10L <| Identifier "s",
+                                                 pos 19L 14L <| Identifier "serving",
+                                                 Direct) ]
+                                          PostAssigns = [] }
+                                Post =
+                                    Unmarked
+                                        (View.If
+                                            (pos 20L 15L <| BopExpr
+                                                (Eq,
+                                                 pos 20L 13L (Identifier "s"),
+                                                 pos 20L 18L (Identifier "t")),
+                                             View.Func { Name = "holdLock"; Params = [] },
+                                             View.Func
+                                               { Name = "holdTick"
+                                                 Params =
+                                                    [ pos 20L 50L (Identifier "t") ] }))}]},
+                         pos 21L 16L <| BopExpr
+                            (Neq,
+                             pos 21L 14L (Identifier "s"),
+                             pos 21L 19L (Identifier "t")))
+                Post =
+                    Unmarked (View.Func { Name = "holdLock"; Params = []})}]}}
 
 /// The correct parsing of the ticket lock's unlock method.
 let ticketLockUnlockMethodAST =
@@ -189,19 +131,13 @@ let ticketLockUnlockMethodAST =
                                Params = [];});
          Contents =
           [{Command =
-             {Position = {StreamName = "Examples/Pass/ticketLock.cvf";
-                          Line = 30L;
-                          Column = 5L;};
-              Node =
-               Command'.Prim
-                 {PreAssigns = [];
+             pos 30L 5L <| Command'.Prim
+                 {PreAssigns = []
                   Atomics =
-                   [{Position =
-                      {StreamName = "Examples/Pass/ticketLock.cvf";
-                       Line = 30L;
-                       Column = 6L;};
-                     Node = Postfix (LVIdent "serving",Increment);}];
-                  PostAssigns = [];};};
+                    [ pos 30L 6L <| Postfix
+                        (pos 30L 6L (Identifier "serving"),
+                         Increment) ]
+                  PostAssigns = [] }
             Post = Unmarked Unit;}];};};
 
 let ticketLockConstraint01 =
@@ -215,11 +151,11 @@ let ticketLockConstraint01 =
           (Ge,{Position = {StreamName = "Examples/Pass/ticketLock.cvf";
                            Line = 38L;
                            Column = 43L;};
-               Node = LV (LVIdent "ticket");},
+               Node = Identifier "ticket";},
            {Position = {StreamName = "Examples/Pass/ticketLock.cvf";
                         Line = 38L;
                         Column = 53L;};
-            Node = LV (LVIdent "serving");});})
+            Node = Identifier "serving";});})
 
 let ticketLockConstraint02 =
     (ViewSignature.Func {Name = "holdTick";
@@ -233,11 +169,11 @@ let ticketLockConstraint02 =
           (Gt,{Position = {StreamName = "Examples/Pass/ticketLock.cvf";
                            Line = 41L;
                            Column = 43L;};
-               Node = LV (LVIdent "ticket");},
+               Node = Identifier "ticket";},
            {Position = {StreamName = "Examples/Pass/ticketLock.cvf";
                         Line = 41L;
                         Column = 52L;};
-            Node = LV (LVIdent "t");});})
+            Node = Identifier "t";});})
 
 let ticketLockConstraint03 =
     (ViewSignature.Func {Name = "holdLock";
@@ -251,11 +187,11 @@ let ticketLockConstraint03 =
           (Neq,{Position = {StreamName = "Examples/Pass/ticketLock.cvf";
                             Line = 42L;
                             Column = 43L;};
-                Node = LV (LVIdent "ticket");},
+                Node = Identifier "ticket";},
            {Position = {StreamName = "Examples/Pass/ticketLock.cvf";
                         Line = 42L;
                         Column = 53L;};
-            Node = LV (LVIdent "serving");});})
+            Node = Identifier "serving";});})
 
 let ticketLockConstraint04 =
     (ViewSignature.Join (ViewSignature.Func {Name = "holdLock";
@@ -271,11 +207,11 @@ let ticketLockConstraint04 =
           (Neq,{Position = {StreamName = "Examples/Pass/ticketLock.cvf";
                             Line = 45L;
                             Column = 43L;};
-                Node = LV (LVIdent "serving");},
+                Node = Identifier "serving";},
            {Position = {StreamName = "Examples/Pass/ticketLock.cvf";
                         Line = 45L;
                         Column = 54L;};
-            Node = LV (LVIdent "t");});})
+            Node = Identifier "t";});})
 
 let ticketLockConstraint05 =
     (ViewSignature.Join (ViewSignature.Func {Name = "holdTick";
@@ -291,11 +227,11 @@ let ticketLockConstraint05 =
           (Neq,{Position = {StreamName = "Examples/Pass/ticketLock.cvf";
                             Line = 46L;
                             Column = 43L;};
-                Node = LV (LVIdent "ta");},
+                Node = Identifier "ta";},
            {Position = {StreamName = "Examples/Pass/ticketLock.cvf";
                         Line = 46L;
                         Column = 49L;};
-            Node = LV (LVIdent "tb");});})
+            Node = Identifier "tb";});})
 
 let ticketLockConstraint06 =
     (ViewSignature.Join (ViewSignature.Func {Name = "holdLock";
@@ -458,7 +394,7 @@ let ticketLockLock =
           Contents =
             [ { Command =
                     command "!ILoad++"
-                        [ Int "t"; Int "ticket" ]
+                        [ Int (siVar "t"); Int (siVar "ticket") ]
                         [ SMExpr.Int (siBefore "ticket") ]
                     |> List.singleton |> Prim
                 Post = Mandatory <| sing holdTick }
@@ -469,7 +405,7 @@ let ticketLockLock =
                                { Pre = Mandatory <| sing holdTick
                                  Contents =
                                      [ { Command =
-                                             command "!ILoad" [ Int "s" ]
+                                             command "!ILoad" [ Int (siVar "s") ]
                                                   [ SMExpr.Int (siBefore "serving") ]
                                              |> List.singleton |> Prim
                                          Post =
@@ -491,7 +427,7 @@ let ticketLockUnlock =
             // constraint holdTick(ta) * holdTick(tb) -> ta != tb;
             Contents =
                 [ { Command =
-                        command "!I++" [ Int "serving" ] [ SMExpr.Int (siBefore "serving") ]
+                        command "!I++" [ Int (siVar "serving") ] [ SMExpr.Int (siBefore "serving") ]
                         |> List.singleton |> Prim
                     Post = Mandatory <| Multiset.empty }]}}
 
@@ -509,7 +445,7 @@ let ticketLockGuardedLock : GuarderMethod =
             Contents =
                 [ { Command =
                         command "!ILoad++"
-                             [ Int "t"; Int "ticket" ]
+                             [ Int (siVar "t"); Int (siVar "ticket") ]
                              [ SMExpr.Int (siBefore "t");
                                SMExpr.Int (siBefore "ticket"); ]
                         |> List.singleton |> Prim
@@ -522,7 +458,7 @@ let ticketLockGuardedLock : GuarderMethod =
                                      Contents =
                                          [ { Command =
                                                  command "!ILoad"
-                                                      [ Int "s" ]
+                                                      [ Int (siVar "s") ]
                                                       [ SMExpr.Int (siBefore "serving"); ]
                                                  |> List.singleton |> Prim
                                              Post =
@@ -539,7 +475,7 @@ let ticketLockGuardedUnlock : GuarderMethod =
           { Pre = Mandatory <| sing (gHoldLock BTrue)
             Contents =
                 [ { Command =
-                        command "!I++" [ Int "serving" ] [ Expr.Int (siBefore "serving") ]
+                        command "!I++" [ Int (siVar "serving") ] [ Expr.Int (siBefore "serving") ]
                         |> List.singleton |> Prim
                     Post = Mandatory <| Multiset.empty } ] } }
 

--- a/TestStudies.fs
+++ b/TestStudies.fs
@@ -395,7 +395,7 @@ let ticketLockLock =
             [ { Command =
                     command "!ILoad++"
                         [ Int (siVar "t"); Int (siVar "ticket") ]
-                        [ SMExpr.Int (siBefore "ticket") ]
+                        [ Int (siVar "ticket") ]
                     |> List.singleton |> Prim
                 Post = Mandatory <| sing holdTick }
               { Command =
@@ -406,7 +406,7 @@ let ticketLockLock =
                                  Contents =
                                      [ { Command =
                                              command "!ILoad" [ Int (siVar "s") ]
-                                                  [ SMExpr.Int (siBefore "serving") ]
+                                                  [ Int (siVar "serving") ]
                                              |> List.singleton |> Prim
                                          Post =
                                             { Func =
@@ -427,7 +427,7 @@ let ticketLockUnlock =
             // constraint holdTick(ta) * holdTick(tb) -> ta != tb;
             Contents =
                 [ { Command =
-                        command "!I++" [ Int (siVar "serving") ] [ SMExpr.Int (siBefore "serving") ]
+                        command "!I++" [ Int (siVar "serving") ] [ Int (siVar "serving") ]
                         |> List.singleton |> Prim
                     Post = Mandatory <| Multiset.empty }]}}
 
@@ -446,8 +446,8 @@ let ticketLockGuardedLock : GuarderMethod =
                 [ { Command =
                         command "!ILoad++"
                              [ Int (siVar "t"); Int (siVar "ticket") ]
-                             [ SMExpr.Int (siBefore "t");
-                               SMExpr.Int (siBefore "ticket"); ]
+                             [ Int (siVar "t");
+                               Int (siVar "ticket"); ]
                         |> List.singleton |> Prim
                     Post = Mandatory <| sing (gHoldTick BTrue) }
                   { Command =
@@ -459,7 +459,7 @@ let ticketLockGuardedLock : GuarderMethod =
                                          [ { Command =
                                                  command "!ILoad"
                                                       [ Int (siVar "s") ]
-                                                      [ SMExpr.Int (siBefore "serving"); ]
+                                                      [ Int (siVar "serving"); ]
                                                  |> List.singleton |> Prim
                                              Post =
                                                  Mandatory <|
@@ -475,7 +475,7 @@ let ticketLockGuardedUnlock : GuarderMethod =
           { Pre = Mandatory <| sing (gHoldLock BTrue)
             Contents =
                 [ { Command =
-                        command "!I++" [ Int (siVar "serving") ] [ Expr.Int (siBefore "serving") ]
+                        command "!I++" [ Int (siVar "serving") ] [ Int (siVar "serving") ]
                         |> List.singleton |> Prim
                     Post = Mandatory <| Multiset.empty } ] } }
 

--- a/Traversal.fs
+++ b/Traversal.fs
@@ -451,7 +451,7 @@ let tchain3
 ///     Converts a traversal from typed variables to expressions to one from
 ///     Boolean expressions to Boolean expressions.
 /// </summary>
-let rec tLiftToBoolSrc
+let rec tliftToBoolSrc
     (sub : Traversal<CTyped<'SrcVar>, Expr<'DstVar>, 'Error>)
     : Traversal<BoolExpr<'SrcVar>, BoolExpr<'DstVar>, 'Error> =
     // TODO(CaptainHayashi): proper doc comment.
@@ -459,9 +459,10 @@ let rec tLiftToBoolSrc
     // We do some tricky inserting and removing of positions on the stack
     // to ensure the correct position appears in the correct place, and
     // is removed when we pop back up the expression stack.
-    let bsv f x = Context.changePos f (tLiftToBoolSrc sub) x
-    let isv x = Context.changePos id (tLiftToIntSrc sub) x
+    let bsv f x = Context.changePos f (tliftToBoolSrc sub) x
+    let isv x = Context.changePos id (tliftToIntSrc sub) x
     let esv x = Context.changePos id (tliftToExprSrc sub) x
+    let asv x = Context.changePos id (tliftToArraySrc sub) x
 
     let neg = Context.negate
 
@@ -472,6 +473,22 @@ let rec tLiftToBoolSrc
             |> CTyped.Bool
             |> Context.changePos id sub ctx
             |> bind (uncurry (ignoreContext expectBool))
+        | BIdx (eltype, length, arr, ix) ->
+            // TODO(CaptainHayashi): this is awful.
+            let originalType = Array (eltype, length, ())
+
+            (* Ensure the traversal doesn't change eltype or length to something
+               we're not expecting. *)
+            let assemble ((eltype', length', arr'), ix') =
+                let newType = Array (eltype', length', ())
+                if typesCompatible originalType newType
+                then ok (BIdx (eltype, length, arr', ix'))
+                else fail (BadType (expected = originalType, got = newType))
+            let tResult =
+                tchain2 asv isv assemble ctx ((eltype, length, arr), ix)
+
+            // Remove the nested result.
+            bind (uncurry (ignoreContext id)) tResult
         | BTrue -> ok (ctx, BTrue)
         | BFalse -> ok (ctx, BFalse)
         | BAnd xs -> tchainL (bsv id) BAnd ctx xs
@@ -489,10 +506,11 @@ let rec tLiftToBoolSrc
 ///     Converts a traversal from typed variables to expressions to one from
 ///     integral expressions to integral expressions.
 /// </summary>
-and tLiftToIntSrc
+and tliftToIntSrc
   (sub : Traversal<CTyped<'SrcVar>, Expr<'DstVar>, 'Error>)
   : Traversal<IntExpr<'SrcVar>, IntExpr<'DstVar>, 'Error> =
-    let isv x = Context.changePos id (tLiftToIntSrc sub) x
+    let isv x = Context.changePos id (tliftToIntSrc sub) x
+    let asv x = Context.changePos id (tliftToArraySrc sub) x
     // TODO(CaptainHayashi): proper doc comment.
 
     fun ctx ->
@@ -502,6 +520,22 @@ and tLiftToIntSrc
             |> CTyped.Int
             |> Context.changePos id sub ctx
             |> bind (uncurry (ignoreContext expectInt))
+        | IIdx (eltype, length, arr, ix) ->
+            // TODO(CaptainHayashi): this is awful.
+            let originalType = Array (eltype, length, ())
+
+            (* Ensure the traversal doesn't change eltype or length to something
+               we're not expecting. *)
+            let assemble ((eltype', length', arr'), ix') =
+                let newType = Array (eltype', length', ())
+                if typesCompatible originalType newType
+                then ok (IIdx (eltype, length, arr', ix'))
+                else fail (BadType (expected = originalType, got = newType))
+            let tResult =
+                tchain2 asv isv assemble ctx ((eltype, length, arr), ix)
+
+            // Remove the nested result.
+            bind (uncurry (ignoreContext id)) tResult
         | IInt i -> ok (ctx, IInt i)
         | IAdd xs -> tchainL isv IAdd ctx xs
         | ISub xs -> tchainL isv ISub ctx xs
@@ -513,11 +547,14 @@ and tLiftToIntSrc
 ///     Converts a traversal from typed variables to expressions to one from
 ///     array expressions to array expressions.
 /// </summary>
-and tLiftToArraySrc
+and tliftToArraySrc
   (sub : Traversal<CTyped<'SrcVar>, Expr<'DstVar>, 'Error>)
   : Traversal<(Type * int option * ArrayExpr<'SrcVar>),
               (Type * int option * ArrayExpr<'DstVar>), 'Error> =
     // TODO(CaptainHayashi): proper doc comment.
+    let isv x = Context.changePos id (tliftToIntSrc sub) x
+    let asv x = Context.changePos id (tliftToArraySrc sub) x
+
     fun ctx (eltype, length, arrayExpr) ->
         let arrayExprResult =
             match arrayExpr with
@@ -529,6 +566,22 @@ and tLiftToArraySrc
                 bind
                     (uncurry (ignoreContext (expectArray eltype length)))
                     exprResult
+            | AIdx (eltype, length, arr, ix) ->
+                // TODO(CaptainHayashi): this is awful.
+                let originalType = Array (eltype, length, ())
+
+                (* Ensure the traversal doesn't change eltype or length to something
+                   we're not expecting. *)
+                let assemble ((eltype', length', arr'), ix') =
+                    let newType = Array (eltype', length', ())
+                    if typesCompatible originalType newType
+                    then ok (AIdx (eltype, length, arr', ix'))
+                    else fail (BadType (expected = originalType, got = newType))
+                let tResult =
+                    tchain2 asv isv assemble ctx ((eltype, length, arr), ix)
+
+                // Remove the nested result.
+                bind (uncurry (ignoreContext id)) tResult
         lift (fun (ctx, ex) -> (ctx, (eltype, length, ex))) arrayExprResult
 
 and tliftToExprSrc
@@ -537,12 +590,12 @@ and tliftToExprSrc
     // TODO(CaptainHayashi): proper doc comment.
     fun ctx ->
         function
-        | Bool b -> b |> tLiftToBoolSrc sub ctx |> lift (pairMap id Bool)
-        | Int i -> i |> tLiftToIntSrc sub ctx |> lift (pairMap id Int)
+        | Bool b -> b |> tliftToBoolSrc sub ctx |> lift (pairMap id Bool)
+        | Int i -> i |> tliftToIntSrc sub ctx |> lift (pairMap id Int)
         | Array (eltype, length, a) ->
             lift
                 (fun (ctx', ela) -> (ctx', Array ela))
-                (tLiftToArraySrc sub ctx (eltype, length, a))
+                (tliftToArraySrc sub ctx (eltype, length, a))
 
 /// <summary>
 ///     Adapts an expression traversal to work on Boolean expressions.

--- a/Traversal.fs
+++ b/Traversal.fs
@@ -351,14 +351,14 @@ let tliftOverCTyped
     // TODO(CaptainHayashi): proper doc comment.
     fun ctx ->
         function
-        | Int i -> lift (pairMap id Int) (sub ctx i)
-        | Bool b -> lift (pairMap id Bool) (sub ctx b)
-        | Array (eltype, length, a) ->
+        | CTyped.Int i -> lift (pairMap id Int) (sub ctx i)
+        | CTyped.Bool b -> lift (pairMap id Bool) (sub ctx b)
+        | CTyped.Array (eltype, length, a) ->
             lift (pairMap id (fun a -> Array (eltype, length, a))) (sub ctx a)
 
 /// <summary>
 ///     Tries to extract an <see cref="ArrayExpr"/> out of an
-///     <see cref="ArrayExpr"/>, failing if the expression is not of that type
+///     <see cref="Expr"/>, failing if the expression is not of that type
 ///     or the element type or array is wrong.
 /// </summary>
 let expectArray
@@ -368,7 +368,7 @@ let expectArray
   : Result<ArrayExpr<'Var>, TraversalError<_>> =
     // TODO(CaptainHayashi): proper doc comment.
     match expr with
-    | Typed.Array (_, _, ae)
+    | Expr.Array (_, _, ae)
         when typesCompatible (Type.Array (eltype, length, ())) (typeOf expr) ->
         ok ae
     | _ ->

--- a/Traversal.fs
+++ b/Traversal.fs
@@ -71,6 +71,10 @@ module Context =
         ///     A context for searching for <c>MarkedVar</c>s.
         /// </summary>
         | MarkedVars of CTyped<MarkedVar> list
+        /// <summary>
+        ///     A context for checking whether we've entered an array index.
+        /// </summary>
+        | InIndex of bool
         override this.ToString () = sprintf "%A" this
 
 
@@ -122,6 +126,40 @@ module Context =
         | Positions [] -> failwith "empty position stack"
         | Positions (x::xs) -> Positions ((f x)::x::xs)
         | x -> x
+
+    /// <summary>
+    ///     Sets IsIndex to true for the duration of a traversal.
+    /// </summary>
+    /// <param name="trav">The traversal to modify.</param>
+    /// <param name="ctx">The current context.</param>
+    /// <typeparam name="Src">
+    ///     The input type of <paramref name="trav"/>, less the context.
+    /// </typeparam>
+    /// <typeparam name="Dst">
+    ///     The return type of <paramref name="trav"/>, less the context.
+    /// </typeparam>
+    /// <returns>
+    ///     A function over a <c>TraversalContext</c>, which behaves as
+    ///     <paramref name="trav"/>, but, if the <c>TraversalContext</c> is
+    ///     <c>InIndex</c>, has this set to true for the duration of the
+    ///     traversal.
+    /// </returns>
+    let inIndex
+      (g : TraversalContext -> 'Src -> Result<TraversalContext * 'Dst, 'Error>)
+      (ctx : TraversalContext)
+      : 'Src -> Result<TraversalContext * 'Dst, 'Error> =
+        let ctx' =
+            match ctx with
+            | InIndex _ -> InIndex true
+            | x -> x
+
+        let travResult = g ctx'
+        let resetCtx ctx'' =
+            match ctx'' with
+            | InIndex _ -> ctx
+            | x -> x
+        
+        g ctx' >> lift (pairMap resetCtx id)
 
     /// <summary>
     ///     If the context is position-based, pop the position stack.
@@ -485,7 +523,7 @@ let rec tliftToBoolSrc
                 then ok (BIdx (eltype, length, arr', ix'))
                 else fail (BadType (expected = originalType, got = newType))
             let tResult =
-                tchain2 asv isv assemble ctx ((eltype, length, arr), ix)
+                tchain2 asv (Context.inIndex isv) assemble ctx ((eltype, length, arr), ix)
 
             // Remove the nested result.
             bind (uncurry (ignoreContext id)) tResult
@@ -532,7 +570,7 @@ and tliftToIntSrc
                 then ok (IIdx (eltype, length, arr', ix'))
                 else fail (BadType (expected = originalType, got = newType))
             let tResult =
-                tchain2 asv isv assemble ctx ((eltype, length, arr), ix)
+                tchain2 asv (Context.inIndex isv) assemble ctx ((eltype, length, arr), ix)
 
             // Remove the nested result.
             bind (uncurry (ignoreContext id)) tResult
@@ -578,7 +616,7 @@ and tliftToArraySrc
                     then ok (AIdx (eltype, length, arr', ix'))
                     else fail (BadType (expected = originalType, got = newType))
                 let tResult =
-                    tchain2 asv isv assemble ctx ((eltype, length, arr), ix)
+                    tchain2 asv (Context.inIndex isv) assemble ctx ((eltype, length, arr), ix)
 
                 // Remove the nested result.
                 bind (uncurry (ignoreContext id)) tResult
@@ -803,6 +841,8 @@ module Pretty =
 
         function
         | NoCtx -> String "(no context)"
+        | InIndex true -> String "in index"
+        | InIndex false -> String "not in index"
         | Positions [] -> String "(empty position stack)"
         | Positions xs -> colonSep [ String "position stack"
                                      hjoin (List.map printPosition xs) ]

--- a/TypeSystem.fs
+++ b/TypeSystem.fs
@@ -99,7 +99,7 @@ type Type = CTyped<unit>
 ///     True if <paramref name="x"/> can be made compatible with
 ///     <paramref name="y"/>, or vice versa; false otherwise.
 /// </returns>
-let typesCompatible (x : Type) (y : Type) : bool =
+let rec typesCompatible (x : Type) (y : Type) : bool =
     (* Technically, if this was proper unification, we'd want to return a
        record of the substitutions made. *)
     match (x, y) with
@@ -108,9 +108,9 @@ let typesCompatible (x : Type) (y : Type) : bool =
     | (Type.Array (ex, Some _ , ()), Type.Array (ey, None   , ()))
     | (Type.Array (ex, None   , ()), Type.Array (ey, Some _ , ()))
     | (Type.Array (ex, None   , ()), Type.Array (ey, None   , ())) ->
-        ex = ey
+        typesCompatible ex ey
     | (Type.Array (ex, Some lx, x), Typed.Array (ey, Some ly, y)) ->
-        ex = ey && lx = ly
+        typesCompatible ex ey && lx = ly
     // For primitive types, structural equality suffices.
     | x, y -> x = y
 

--- a/Utils.fs
+++ b/Utils.fs
@@ -271,6 +271,20 @@ let bind3
             let! cv = c
             return! f av bv cv }
 
+/// Extends bind to functions of 4 arguments.
+let bind4
+  (f: 'A -> 'B -> 'C -> 'D -> Result<'Value, 'Error>)
+  (a : Result<'A, 'Error>)
+  (b : Result<'B, 'Error>)
+  (c : Result<'C, 'Error>)
+  (d : Result<'D, 'Error>)
+  : Result<'Value, 'Error> =
+    trial { let! av = a
+            let! bv = b
+            let! cv = c
+            let! dv = d
+            return! f av bv cv dv }
+
 /// Extends lift to functions of 3 arguments.
 let lift3
   (f: 'A -> 'B -> 'C -> 'Value)

--- a/Var.fs
+++ b/Var.fs
@@ -118,6 +118,13 @@ let unmarkVar : MarkedVar -> Var =
     | Intermediate(i, c) -> sprintf "V%sINT%A" c i
     | Goal(i, c) -> sprintf "V%sGOAL%A" c i
 
+// TODO(CaptainHayashi): clean this up?
+let varToExpr (v : TypedVar) : Expr<Var> =
+    match v with
+    | Int iv -> Int (IVar iv)
+    | Bool bv -> Bool (BVar bv)
+    | Array (eltype, length, av) -> Array (eltype, length, AVar av)
+
 /// <summary>
 ///     Pretty printers for variables.
 /// </summary>

--- a/Var.fs
+++ b/Var.fs
@@ -49,14 +49,6 @@ module Types =
         | Intermediate of bigint * Var
 
     /// <summary>
-    ///     An lvalue.
-    ///     This is given a separate type in case we add to it later.
-    /// </summary>
-    type LValue =
-        // TODO(CaptainHayashi): add support for non-variable LValues.
-        | LVIdent of string
-
-    /// <summary>
     ///     A variable reference with an associated type.
     ///     This is usually a formal parameter or variable declaration.
     /// </summary>
@@ -168,13 +160,6 @@ module Pretty =
     let printMIntExpr = printIntExpr printMarkedVar
 
 
-/// Flattens a LV to a string.
-let rec flattenLV =
-    // TODO(CaptainHayashi): this is completely wrong, but we don't
-    // have a semantics for it yet.
-    function
-    | LVIdent s -> s
-
 module VarMap =
     /// Makes a variable map from a sequence of typed variables.
     /// Can fail if there are duplicates.
@@ -200,20 +185,14 @@ module VarMap =
 
     /// Tries to look up a variable record in a variable map.
     /// Failures are in terms of Some/None.
-    let tryLookup
-      (env : VarMap)
-      : LValue -> CTyped<string> option =
-        function
-        | LVIdent s ->
-            Option.map (fun ty -> withType ty s) (env.TryFind s)
+    let tryLookup (env : VarMap) (var : Var) : CTyped<string> option =
+        Option.map (fun ty -> withType ty var) (env.TryFind var)
 
     /// Looks up a variable record in a variable map.
     /// Failures are in terms of VarMapError.
-    let lookup
-      (env : VarMap)
-      (s : LValue)
+    let lookup (env : VarMap) (var : Var)
       : Result<CTyped<string>, VarMapError> =
-        failIfNone (NotFound (flattenLV s)) (tryLookup env s)
+        failIfNone (NotFound var) (tryLookup env var)
 
     /// <summary>
     ///     Converts a variable map to a sequence of typed variables.

--- a/ViewDesugar.fs
+++ b/ViewDesugar.fs
@@ -34,7 +34,7 @@ let makeFreshView (tvars : VarMap) (fg : FreshGen) : View * DesugaredViewProto =
     let viewName =
         fg |> getFresh |> sprintf "%A"
     let viewArgs =
-        tvars |> Map.toSeq |> Seq.map (fst >> LVIdent >> LV >> fun l -> freshNode l)
+        tvars |> Map.toSeq |> Seq.map (fst >> Identifier >> fun l -> freshNode l)
     let viewParams = VarMap.toTypedVarSeq tvars
 
     (Func (func viewName viewArgs), NoIterator (func viewName viewParams, false))
@@ -216,7 +216,7 @@ module Tests =
         static member ViewDesugars =
             [TestCaseData(Unknown : Marked<View>)
               .Returns((Func
-                            (func "0" [ freshNode <| LV (LVIdent "s") ; freshNode <| LV (LVIdent "t") ]),
+                            (func "0" [ freshNode <| Identifier "s" ; freshNode <| Identifier "t" ]),
                         Seq.singleton <| func "0" [ (Int, "s"), (Int, "t") ]))
               .SetName("Desugaring an unknown view creates a fresh view\
                         with a fresh name and all locals as parameters") ]

--- a/Z3.fs
+++ b/Z3.fs
@@ -93,7 +93,7 @@ module Expr =
                 // TODO(CaptainHayashi): ensure eltype is Bool?
                 let arrZ3 = arrayToZ3 reals toStr ctx eltype arr
                 let idxZ3 = intToZ3 reals toStr ctx idx
-                // TODO(CaptainHayashi): make this not crash if the select is not an ArithExpr.
+                // TODO(CaptainHayashi): make this not crash if the select is not a BoolExpr.
                 ctx.MkSelect (arrZ3, idxZ3) :?> Z3.BoolExpr
             | BTrue -> ctx.MkTrue ()
             | BFalse -> ctx.MkFalse ()
@@ -126,8 +126,14 @@ module Expr =
             // TODO(CaptainHayashi): ensure eltype is Array?
             let arrZ3 = arrayToZ3 reals toStr ctx eltype arr
             let idxZ3 = intToZ3 reals toStr ctx idx
-            // TODO(CaptainHayashi): make this not crash if the select is not an ArithExpr.
+            // TODO(CaptainHayashi): make this not crash if the select is not an ArrayExpr.
             ctx.MkSelect (arrZ3, idxZ3) :?> Z3.ArrayExpr
+        | AUpd (eltype, _, arr, idx, upd) ->
+            let arrZ3 = arrayToZ3 reals toStr ctx eltype arr
+            let idxZ3 = intToZ3 reals toStr ctx idx
+            let updZ3 = exprToZ3 reals toStr ctx upd
+            ctx.MkStore (arrZ3, idxZ3, updZ3)
+
 
     /// Converts a Starling expression to a Z3 Expr.
     and exprToZ3

--- a/Z3.fs
+++ b/Z3.fs
@@ -49,7 +49,7 @@ module Expr =
         | Type.Bool () -> ctx.MkBoolSort () :> Z3.Sort
         | Type.Array (eltype, _, ()) ->
             let elZ3 = typeToSort reals ctx eltype
-            ctx.MkArraySort (domain = elZ3, range = ctx.MkIntSort ()) :> Z3.Sort
+            ctx.MkArraySort (range = ctx.MkIntSort (), domain = elZ3) :> Z3.Sort
 
     /// Converts a Starling arithmetic expression to a Z3 ArithExpr.
     let rec intToZ3

--- a/Z3.fs
+++ b/Z3.fs
@@ -120,8 +120,8 @@ module Expr =
         | AVar c ->
             ctx.MkArrayConst
                 (name = toStr c,
-                 domain = typeToSort reals ctx eltype,
-                 range = ctx.MkIntSort ())
+                 domain = ctx.MkIntSort (),
+                 range = typeToSort reals ctx eltype)
         | AIdx (eltype, _, arr, idx) ->
             // TODO(CaptainHayashi): ensure eltype is Array?
             let arrZ3 = arrayToZ3 reals toStr ctx eltype arr

--- a/testresults
+++ b/testresults
@@ -1,5 +1,6 @@
 ./Examples/Fail/badInc.cvf: badInc_C000_000
 ./Examples/Fail/badInc2.cvf: badInc_C000_000
+./Examples/Fail/petersonArrayBadTurns.cvf: lock_C001_005
 ./Examples/Fail/petersonBadTurns.cvf: lockA_C001_019 lockB_C001_018
 ./Examples/Fail/ticketLockBad.cvf: unlock_C000_002 unlock_C000_003
 ./Examples/Fail/ticketLockBad2.cvf: lock_C000_000 lock_C000_002 unlock_C000_000
@@ -7,6 +8,7 @@
 ./Examples/Pass/arc.cvf:
 ./Examples/Pass/multicounter.cvf:
 ./Examples/Pass/peterson.cvf:
+./Examples/Pass/petersonArray.cvf:
 ./Examples/Pass/petersonInt.cvf:
 ./Examples/Pass/petersonIntMissingSynthesised.cvf:
 ./Examples/Pass/petersonMultiCmd.cvf:


### PR DESCRIPTION
**I recommend merging #100 first.  This PRQ is based on top of and thus includes #100.**

This fairly big PRQ implements arrays for Starling.  It also splits a lot of the type system logic previously shared by the AST and Starling core for cleanliness, and pushes through a few type system overhauls to allow lvalues to be things other than variables.