### PR TITLE
PLDI benchmarker

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -13,7 +13,7 @@ sed -e 's/#.*$//' -e '/^$/d' ./benchmarks.in | while read category name path z3 
 	if [ "${category}" != "${cat}" ];
 	then
 		echo "\\midrule"
-		echo "${category}&&&&&&&&"
+		echo "${category}&&&&&&&&"'\\\\'
 		cat="$category"
 	fi
 

--- a/bench.sh
+++ b/bench.sh
@@ -12,7 +12,8 @@ sed -e 's/#.*$//' -e '/^$/d' ./benchmarks.in | while read category name path z3 
 	# Print category header if we're on a new category.
 	if [ "${category}" != "${cat}" ];
 	then
-		echo "${category}&&&&&&"
+		echo "\\midrule"
+		echo "${category}&&&&&&&&"
 		cat="$category"
 	fi
 

--- a/bench.sh
+++ b/bench.sh
@@ -1,10 +1,8 @@
 #!/bin/sh
 #
-# Runs Starling in Z3 mode on each passing and failing example N times, and
-# reports the results.
+# Runs `benchone.sh` on each example specified in `benchmarks.in`.
+# See those files for more information.
 #
-# The results are in the form 'FILENAME RUN TIME', and can be awked into a
-# proper benchmark set.
 
 IFS=:
 cat=""

--- a/bench.sh
+++ b/bench.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# Runs Starling in Z3 mode on each passing and failing example N times, and
+# reports the results.
+#
+# The results are in the form 'FILENAME RUN TIME', and can be awked into a
+# proper benchmark set.
+
+IFS=:
+cat=""
+sed -e 's/#.*$//' -e '/^$/d' ./benchmarks.in | while read category name path z3 hsf oz3 ohsf; do
+	# Print category header if we're on a new category.
+	if [ "${category}" != "${cat}" ];
+	then
+		echo "${category}&&&&&&"
+		cat="$category"
+	fi
+
+	>&2 echo "--- ${category} : ${name} (${path}) ---"
+
+	./benchone.sh "${name}" "${path}" "${z3}" "${hsf}" "${oz3}" "${ohsf}"
+done

--- a/benchmarks.in
+++ b/benchmarks.in
@@ -1,5 +1,14 @@
-# Examples for PLDI paper benchmarks
-# Group:name:dir:Z3?:HSF?:Optimised Z3?:Optimised HSF?:
+# This file tells `bench.sh` which benchmarks to run.
+#
+# Each line is formatted as follows:
+#
+# Group:Name:Path:Run unoptimised Z3?:Run unoptimised HSF?:Run optimised Z3?:Run optimised HSF?
+#
+# Benchmarks are emitted as a LaTeX table, sorted alphabetically and grouped by Group.
+#
+# For the last four fields, type 'yes' to enable, and 'no' to disable (case sensitive).
+#
+# Lines starting with # are discarded.  Whitespace is significant.
 Ticket lock:with conditional view:Examples/Pass/ticketLock.cvf:yes:no:yes:no
 Ticket lock:without conditional view:Examples/Pass/ticketLockNoIf.cvf:yes:no:yes:no
 Ticket lock:with integers and indefinite views:Examples/PassHSF/ticketLockIndefinite.cvf:no:no:no:yes

--- a/benchmarks.in
+++ b/benchmarks.in
@@ -8,6 +8,6 @@ Peterson:double methods:Examples/Pass/peterson.cvf:yes:no:yes:no
 Peterson:double methods and ints:Examples/Pass/petersonInt.cvf:yes:no:yes:yes
 ARC:definite, Boolean free, no init:Examples/Pass/arc.cvf:yes:no:yes:no
 ARC:definite, integer free, no init:Examples/Pass/arcInt.cvf:yes:yes:yes:yes
-ARC:indefinite, integer free:Examples/WIP/arcIndefinitePLDI.cvf:yes:yes:yes:yes
+ARC:indefinite, integer free:Examples/WIP/arcIndefinitePLDI.cvf:no:yes:no:yes
 Spin lock:definite, Boolean lock:Examples/Pass/spinLock.cvf:yes:no:yes:no
 Spin lock:definite, integer lock:Examples/Pass/spinLockInt.cvf:yes:no:yes:no

--- a/benchmarks.in
+++ b/benchmarks.in
@@ -12,11 +12,8 @@
 Ticket lock:with conditional view:Examples/Pass/ticketLock.cvf:yes:no:yes:no
 Ticket lock:without conditional view:Examples/Pass/ticketLockNoIf.cvf:yes:no:yes:no
 Ticket lock:with integers and indefinite views:Examples/PassHSF/ticketLockIndefinite.cvf:no:no:no:yes
-Peterson:flag array:Examples/Pass/petersonArray.cvf:yes:no:yes:no
 Peterson:double methods:Examples/Pass/peterson.cvf:yes:no:yes:no
 Peterson:double methods and ints:Examples/Pass/petersonInt.cvf:yes:no:yes:yes
 ARC:definite, Boolean free, no init:Examples/Pass/arc.cvf:yes:no:yes:no
-ARC:definite, integer free, no init:Examples/Pass/arcInt.cvf:yes:yes:yes:yes
-ARC:indefinite, integer free:Examples/WIP/arcIndefinitePLDI.cvf:no:yes:no:yes
 Spin lock:definite, Boolean lock:Examples/Pass/spinLock.cvf:yes:no:yes:no
 Spin lock:definite, integer lock:Examples/Pass/spinLockInt.cvf:yes:yes:yes:yes

--- a/benchmarks.in
+++ b/benchmarks.in
@@ -6,7 +6,6 @@ Ticket lock:with integers and indefinite views:Examples/PassHSF/ticketLockIndefi
 Peterson:flag array:Examples/Pass/petersonArray.cvf:yes:no:yes:no
 Peterson:double methods:Examples/Pass/peterson.cvf:yes:no:yes:no
 Peterson:double methods and ints:Examples/Pass/petersonInt.cvf:yes:no:yes:yes
-Peterson:double methods, ints, indefinite views:Examples/PassHSF/petersonIntIndefinite.cvf:no:no:no:yes
 ARC:definite, Boolean free, no init:Examples/Pass/arc.cvf:yes:no:yes:no
 ARC:definite, integer free, no init:Examples/Pass/arcInt.cvf:yes:yes:yes:yes
 ARC:indefinite, integer free:Examples/WIP/arcIndefinitePLDI.cvf:yes:yes:yes:yes

--- a/benchmarks.in
+++ b/benchmarks.in
@@ -1,0 +1,11 @@
+# Examples for PLDI paper benchmarks
+# Group:name:dir:Z3?:HSF?:Optimised Z3?:Optimised HSF?:
+Ticket lock:with conditional view:Examples/Pass/ticketLock.cvf:yes:no:yes:no
+Ticket lock:without conditional view:Examples/Pass/ticketLockNoIf.cvf:yes:no:yes:no
+Ticket lock:with integers and indefinite views:Examples/PassHSF/ticketLockIndefinite.cvf:no:yes:no:yes
+Peterson:flag array:Examples/Pass/petersonArray.cvf:yes:no:yes:no
+Peterson:double methods:Examples/Pass/peterson.cvf:yes:no:yes:no
+Peterson:double methods and ints:Examples/Pass/petersonInt.cvf:yes:no:yes:yes
+Peterson:double methods, ints, indefinite views:Examples/PassHSF/petersonIndefinite.cvf:no:yes:no:yes
+ARC:definite, Boolean free, no init:Examples/Pass/arc.cvf:yes:no:yes:no
+ARC:definite, integer free, no init:Examples/Pass/arcInt.cvf:yes:yes:yes:yes

--- a/benchmarks.in
+++ b/benchmarks.in
@@ -10,4 +10,4 @@ ARC:definite, Boolean free, no init:Examples/Pass/arc.cvf:yes:no:yes:no
 ARC:definite, integer free, no init:Examples/Pass/arcInt.cvf:yes:yes:yes:yes
 ARC:indefinite, integer free:Examples/WIP/arcIndefinitePLDI.cvf:no:yes:no:yes
 Spin lock:definite, Boolean lock:Examples/Pass/spinLock.cvf:yes:no:yes:no
-Spin lock:definite, integer lock:Examples/Pass/spinLockInt.cvf:yes:no:yes:no
+Spin lock:definite, integer lock:Examples/Pass/spinLockInt.cvf:yes:yes:yes:yes

--- a/benchmarks.in
+++ b/benchmarks.in
@@ -2,10 +2,13 @@
 # Group:name:dir:Z3?:HSF?:Optimised Z3?:Optimised HSF?:
 Ticket lock:with conditional view:Examples/Pass/ticketLock.cvf:yes:no:yes:no
 Ticket lock:without conditional view:Examples/Pass/ticketLockNoIf.cvf:yes:no:yes:no
-Ticket lock:with integers and indefinite views:Examples/PassHSF/ticketLockIndefinite.cvf:no:yes:no:yes
+Ticket lock:with integers and indefinite views:Examples/PassHSF/ticketLockIndefinite.cvf:no:no:no:yes
 Peterson:flag array:Examples/Pass/petersonArray.cvf:yes:no:yes:no
 Peterson:double methods:Examples/Pass/peterson.cvf:yes:no:yes:no
 Peterson:double methods and ints:Examples/Pass/petersonInt.cvf:yes:no:yes:yes
-Peterson:double methods, ints, indefinite views:Examples/PassHSF/petersonIndefinite.cvf:no:yes:no:yes
+Peterson:double methods, ints, indefinite views:Examples/PassHSF/petersonIntIndefinite.cvf:no:no:no:yes
 ARC:definite, Boolean free, no init:Examples/Pass/arc.cvf:yes:no:yes:no
 ARC:definite, integer free, no init:Examples/Pass/arcInt.cvf:yes:yes:yes:yes
+ARC:indefinite, integer free:Examples/WIP/arcIndefinitePLDI.cvf:yes:yes:yes:yes
+Spin lock:definite, Boolean lock:Examples/Pass/spinLock.cvf:yes:no:yes:no
+Spin lock:definite, integer lock:Examples/Pass/spinLockInt.cvf:yes:no:yes:no

--- a/benchone.sh
+++ b/benchone.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+
+NZ3=1
+NHSF=1
+
+name=$1
+path=$2
+z3=$3
+hsf=$4
+oz3=$5
+ohsf=$6
+
+terms=$(./starling.sh -Ono-all "$path" | wc -l)
+>&2 echo "non-optimised terms: ${terms}"
+
+oterms=$(./starling.sh "$path" | wc -l)
+>&2 echo "optimised terms: ${oterms}"
+
+if [ "$z3" = "yes" ];
+then 
+	>&2 echo "Z3: no optimisations"
+
+	z3total="0"
+	
+	for i in $(seq 1 "${NZ3}");
+	do
+		time=$(/usr/bin/time ./starling.sh -Ono-all "$path" 2>&1 >/dev/null | awk '/real/ { print $3 }')
+		z3total=$(dc -e "2 k ${z3total} ${time} + p")
+
+		>&2 echo "- run ${i}: ${time}s, total so far ${z3total}"
+	done
+
+	z3final=$(dc -e "2 k $z3total $NZ3 / p")
+	>&2 echo "Z3: no optimisations RESULT: ${z3final}s"
+else
+	>&2 echo "Z3: no optimisations SKIPPED"
+
+	z3final="--"
+fi
+
+if [ "$oz3" = "yes" ];
+then 
+	>&2 echo "Z3: optimisations"
+
+	oz3total="0"
+	
+	for i in $(seq 1 "${NZ3}");
+	do
+		time=$(/usr/bin/time ./starling.sh "$path" 2>&1 >/dev/null | awk '/real/ { print $3 }')
+		oz3total=$(dc -e "2 k ${oz3total} ${time} + p")
+
+		>&2 echo "- run ${i}: ${time}s, total so far ${oz3total}"
+	done
+
+	oz3final=$(dc -e "2 k $oz3total $NZ3 / p")
+	>&2 echo "Z3: optimisations RESULT: ${oz3final}s"
+else
+	>&2 echo "Z3: optimisations SKIPPED"
+
+	oz3final="--"
+fi
+
+if [ "$hsf" = "yes" ];
+then 
+	>&2 echo "HSF: no optimisations"
+
+	hsftotal="0"
+	
+	for i in $(seq 1 "${NHSF}");
+	do
+		rm -f hsf.tmp
+		time=$(/usr/bin/time ./starling-hsf.sh "$path" -Ono-all 2>&1 >/dev/null | awk '/real/ { print $3 }')
+		hsftotal=$(dc -e "2 k ${hsftotal} ${time} + p")
+
+		>&2 echo "- run ${i}: ${time}s, total so far ${hsftotal}"
+	done
+
+	hsffinal=$(dc -e "2 k $hsftotal $NHSF / p")
+	>&2 echo "HSF: no optimisations RESULT: ${hsffinal}s"
+else
+	>&2 echo "HSF: no optimisations SKIPPED"
+
+	hsffinal="--"
+fi
+
+if [ "$ohsf" = "yes" ];
+then 
+	>&2 echo "HSF: optimisations"
+
+	ohsftotal="0"
+	
+	for i in $(seq 1 "${NHSF}");
+	do
+		rm -f hsf.tmp
+		time=$(/usr/bin/time ./starling-hsf.sh "$path" 2>&1 >/dev/null | awk '/real/ { print $3 }')
+		ohsftotal=$(dc -e "2 k ${ohsftotal} ${time} + p")
+
+		>&2 echo "- run ${i}: ${time}s, total so far ${ohsftotal}"
+	done
+
+	ohsffinal=$(dc -e "2 k $ohsftotal $NHSF / p")
+	>&2 echo "HSF: optimisations RESULT: ${ohsffinal}s"
+else
+	>&2 echo "HSF: optimisations SKIPPED"
+
+	ohsffinal="--"
+fi
+
+echo "--${name}&${terms}&${z3final}&${hsffinal}&${oterms}&${oz3final}&${ohsffinal}\\"

--- a/benchone.sh
+++ b/benchone.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 # Number of times to run ProofGen, Z3, and HSF per subject
-NPG=1
-NZ3=1
-NHSF=1
+NPG=10
+NZ3=10
+NHSF=10
 
 name=$1
 path=$2
@@ -152,4 +152,4 @@ else
 	ohsffinal="--"
 fi
 
-echo "--${name}&${terms}&${pgfinal}&${z3final}&${hsffinal}&${oterms}&${opgfinal}&${oz3final}&${ohsffinal}\\\\"
+echo "--${name}&${terms}&${pgfinal}&${z3final}&${hsffinal}&${oterms}&${opgfinal}&${oz3final}&${ohsffinal}"'\\\\'

--- a/benchone.sh
+++ b/benchone.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# Number of times to run ProofGen, Z3, and HSF per subject
+NPG=1
 NZ3=1
 NHSF=1
 
@@ -10,11 +12,54 @@ hsf=$4
 oz3=$5
 ohsf=$6
 
-terms=$(./starling.sh -Ono-all "$path" | wc -l)
+# Flag for removing optimisations
+NOPTS="-Ono-all"
+
+# Stage for proofgen
+PGSTAGE="-ssymproof"
+
+terms=$(./starling.sh ${NOPTS} "$path" | wc -l)
 >&2 echo "non-optimised terms: ${terms}"
 
 oterms=$(./starling.sh "$path" | wc -l)
 >&2 echo "optimised terms: ${oterms}"
+
+OPTS=""
+
+#
+# Proofgen
+#
+
+>&2 echo "Proofgen: no optimisations"
+pgtotal="0"
+	
+for i in $(seq 1 "${NPG}");
+do
+	time=$(/usr/bin/time ./starling.sh ${NOPTS} ${PGSTAGE} "$path" 2>&1 >/dev/null | awk '/real/ { print $3 }')
+	pgtotal=$(dc -e "2 k ${pgtotal} ${time} + p")
+
+	>&2 echo "- run ${i}: ${time}s, total so far ${pgtotal}"
+done
+pgfinal=$(dc -e "2 k $pgtotal $NPG / p")
+>&2 echo "Proofgen: no optimisations RESULT: ${pgfinal}s"
+
+>&2 echo "Proofgen: optimisations"
+opgtotal="0"
+	
+for i in $(seq 1 "${NPG}");
+do
+	time=$(/usr/bin/time ./starling.sh ${PGSTAGE} "$path" 2>&1 >/dev/null | awk '/real/ { print $3 }')
+	opgtotal=$(dc -e "2 k ${opgtotal} ${time} + p")
+
+	>&2 echo "- run ${i}: ${time}s, total so far ${opgtotal}"
+done
+opgfinal=$(dc -e "2 k $opgtotal $NPG / p")
+>&2 echo "Proofgen: no optimisations RESULT: ${opgfinal}s"
+
+
+#
+# Z3
+#
 
 if [ "$z3" = "yes" ];
 then 
@@ -24,12 +69,11 @@ then
 	
 	for i in $(seq 1 "${NZ3}");
 	do
-		time=$(/usr/bin/time ./starling.sh -Ono-all "$path" 2>&1 >/dev/null | awk '/real/ { print $3 }')
+		time=$(/usr/bin/time ./starling.sh ${NOPTS} "$path" 2>&1 >/dev/null | awk '/real/ { print $3 }')
 		z3total=$(dc -e "2 k ${z3total} ${time} + p")
 
 		>&2 echo "- run ${i}: ${time}s, total so far ${z3total}"
 	done
-
 	z3final=$(dc -e "2 k $z3total $NZ3 / p")
 	>&2 echo "Z3: no optimisations RESULT: ${z3final}s"
 else
@@ -51,7 +95,6 @@ then
 
 		>&2 echo "- run ${i}: ${time}s, total so far ${oz3total}"
 	done
-
 	oz3final=$(dc -e "2 k $oz3total $NZ3 / p")
 	>&2 echo "Z3: optimisations RESULT: ${oz3final}s"
 else
@@ -59,6 +102,11 @@ else
 
 	oz3final="--"
 fi
+
+
+#
+# HSF
+#
 
 if [ "$hsf" = "yes" ];
 then 
@@ -69,12 +117,11 @@ then
 	for i in $(seq 1 "${NHSF}");
 	do
 		rm -f hsf.tmp
-		time=$(/usr/bin/time ./starling-hsf.sh "$path" -Ono-all 2>&1 >/dev/null | awk '/real/ { print $3 }')
+		time=$(/usr/bin/time ./starling-hsf.sh "$path" ${NOPTS} 2>&1 >/dev/null | awk '/real/ { print $3 }')
 		hsftotal=$(dc -e "2 k ${hsftotal} ${time} + p")
 
 		>&2 echo "- run ${i}: ${time}s, total so far ${hsftotal}"
 	done
-
 	hsffinal=$(dc -e "2 k $hsftotal $NHSF / p")
 	>&2 echo "HSF: no optimisations RESULT: ${hsffinal}s"
 else
@@ -97,7 +144,6 @@ then
 
 		>&2 echo "- run ${i}: ${time}s, total so far ${ohsftotal}"
 	done
-
 	ohsffinal=$(dc -e "2 k $ohsftotal $NHSF / p")
 	>&2 echo "HSF: optimisations RESULT: ${ohsffinal}s"
 else
@@ -106,4 +152,4 @@ else
 	ohsffinal="--"
 fi
 
-echo "--${name}&${terms}&${z3final}&${hsffinal}&${oterms}&${oz3final}&${ohsffinal}\\"
+echo "--${name}&${terms}&${pgfinal}&${z3final}&${hsffinal}&${oterms}&${opgfinal}&${oz3final}&${ohsffinal}\\\\"


### PR DESCRIPTION
This small PRQ, split off `mw-pldi-experimental`, adds a quick and dirty benchmark script that was used to generate benchmarks for the PLDI paper attempt.

It comes with a benchmark set that may, depending on order of PRQs, reference nonexistent examples.  Otherwise this is independent of the other PRQs.  I can fix this before merger if people want.

Tested on macOS, needs testing on Linux/BSD, probably won't work on Windows.