### PR TITLE
Grasshopper backend (minus variable types and commands) 

### DIFF
--- a/Examples/WIP/lclist-grasshopper.cvf
+++ b/Examples/WIP/lclist-grasshopper.cvf
@@ -11,21 +11,19 @@ thread int curr;
 thread int v;
 thread int cv;
 
-thread int _;   // Does this give the right semantics? 
-
 view isHead(int node); 
 view isVal(int v, int node);
 view isList(int v);
 view has1Lock(int x, int y);
+view has1LockDangle(int x);
 view has2Lock(int x, int y);
-// view dangleNode(int x);
 
-method deleteVal(v) {
+method deleteVal(int v) {
   {| isList(v) |}
     <prev = head>;
   {| isList(v) * isHead(prev) |} 
    <{ lheap = heap; heap = (%{ takeLock(#2) }(lheap, prev)); }>;
-  {| isList(v) * has1Lock(prev, _) * isHead(prev) |}
+  {| isList(v) * has1LockDangle(prev) * isHead(prev) |}
    <lheap = heap>; curr = (%{ #2.next }(lheap, curr)); 
   {| isList(v) * has1Lock(prev, curr) |}
    <{ lheap = heap; heap = (%{ takeLock(#2) }(lheap, curr)); }>;
@@ -35,7 +33,7 @@ method deleteVal(v) {
     while (cv < v ) {
       {| isList(v) * has2Lock(prev, curr) * isVal(curr, cv) |}
         <{ lheap = heap; heap = (%{ releaseLock(#2) }(lheap, prev)); }>; 
-      {| isList(v) * has1Lock(curr, _) * isVal(curr, cv) |}
+      {| isList(v) * has1LockDangle(curr) * isVal(curr, cv) |}
         prev = curr;
         <lheap = heap>; curr = (%{ #2->next }(lheap, curr));  
       {| isList(v) * has1Lock(prev, curr) * isVal(prev,cv) |}
@@ -51,14 +49,14 @@ method deleteVal(v) {
         <{ lheap = heap; 
            heap = (%{ #2.next := #3.next }(lheap, prev, curr)); 
            lheap = heap; heap = (%{ disposeNode(#2) }(lheap, curr)); }>; 
-      {| isList(v) * has1Lock(prev, _) |}
+      {| isList(v) * has1LockDangle(prev) |}
     } 
     else {
       {| has1Lock(prev, curr) |}
         <{ lheap = heap; heap = (%{ releaseLock(#1)}(curr)); }>; 
-      {| has1Lock(prev, _) |}
+      {| has1LockDangle(prev) |}
     }
-  {| has1Lock(prev, _) |}
+  {| has1LockDangle(prev) |}
     <{ lheap = heap; heap = (%{ releaseLock(#2) }(lheap, prev)); }>; 
   {| emp |}
 }
@@ -69,22 +67,21 @@ constraint isList(v) -> %{ isListG(head,ub,#1) }(v);
 
 constraint has1Lock(a,b) -> %{ has1LockG(head,#1,#2) }(a, b);
 
+constraint has1LockDangle(a) -> %{ exists e: Node :: has1LockG(head,#1,e) }(a);
+
 constraint has2Lock(a,b)  -> %{ has2LockG(head,#1,#2) }(a, b);
 
 constraint isVal(node, v) -> %{ isValG(head, #1, #2) &*& #2 < ub }(node, v);
 
-// constraint dangleNode(a) -> 
-//  %{ dangleNodeG(#1) }(a);
 
-
-// Are the constraints below necessary? 
-
-// Constraints on views
-constraint has1Lock(a,b) * has1Lock(c,d)   -> a != c;
-constraint has1Lock(a,b) * has2Lock(c,d)   -> a != c && a != d;
-constraint has2Lock(a,b) * has2Lock(c,d)   -> a != c && a != d && b != c && b != d;
-// constraint has1Lock(a,b) * dangleNode(c)   -> a != c;
-// constraint has2Lock(a,b) * dangleNode(c)   -> a != c && b != c;
-
-// // Could maybe replace some of the constraints above?
-// constraint has2Lock(a,b) -> %{ has1Lock(#1,_) &*& has1Lock(#2,_) }(a, b);
+// // Are the constraints below necessary? 
+// 
+// // Constraints on views
+// constraint has1Lock(a,b) * has1Lock(c,d)   -> a != c;
+// constraint has1Lock(a,b) * has2Lock(c,d)   -> a != c && a != d;
+// constraint has2Lock(a,b) * has2Lock(c,d)   -> a != c && a != d && b != c && b != d;
+// // constraint has1Lock(a,b) * dangleNode(c)   -> a != c;
+// // constraint has2Lock(a,b) * dangleNode(c)   -> a != c && b != c;
+// 
+// // // Could maybe replace some of the constraints above?
+// // constraint has2Lock(a,b) -> %{ has1Lock(#1,_) &*& has1Lock(#2,_) }(a, b);

--- a/Grasshopper.fs
+++ b/Grasshopper.fs
@@ -4,27 +4,30 @@
 module Starling.Backends.Grasshopper 
 
 open Chessie.ErrorHandling
+
+open Starling 
 open Starling.Collections
 open Starling.Utils
 open Starling.Core.TypeSystem
 open Starling.Core.Var
 open Starling.Core.Expr
-// open Starling.Core.Sub
 open Starling.Core.Model
 open Starling.Core.Instantiate
 open Starling.Core.GuardedView
 
 [<AutoOpen>] 
 module Types =
-    type Query = unit  
+    type Grass = Backends.Z3.Types.ZModel  
     type Error = unit 
 
 module Pretty = 
-    let printQuery g = 
-        failwith "not implemented yet" 
+    let printQuery = 
+        Backends.Z3.Pretty.printZTerm
+        // failwith "not implemented yet" 
 
     let printGrassError e = 
         failwith "not implemented yet" 
 
-let grassModel i = 
-    failwith "not implemented yet" 
+let grassModel (i : Backends.Z3.Types.ZModel) : Result<Grass,Error>  = 
+  ok i 
+  // failwith "not implemented yet" 

--- a/Grasshopper.fs
+++ b/Grasshopper.fs
@@ -23,6 +23,7 @@ module Types =
 
 module Pretty = 
     open Starling.Core.Pretty
+    open Starling.Core.Expr.Pretty
     open Starling.Core.Model.Pretty
     open Starling.Core.Symbolic.Pretty
 
@@ -85,7 +86,7 @@ module Pretty =
     let printQuery (zterm : Backends.Z3.Types.ZTerm) : Doc = 
         headed "Grasshopper terms" <| 
           [ printTerm
-              (fun x -> String "Cmd printing not implemented yet.") 
+              (Core.Expr.Pretty.printBoolExpr (printSym printMarkedVar)) 
               printExprGrass 
               printExprGrass 
               zterm.SymBool ]

--- a/Grasshopper.fs
+++ b/Grasshopper.fs
@@ -1,0 +1,30 @@
+﻿/// <summary>
+///     Backend for emitting verification conditions in Grasshopper format
+/// </summary>
+module Starling.Backends.Grasshopper 
+
+open Chessie.ErrorHandling
+open Starling.Collections
+open Starling.Utils
+open Starling.Core.TypeSystem
+open Starling.Core.Var
+open Starling.Core.Expr
+// open Starling.Core.Sub
+open Starling.Core.Model
+open Starling.Core.Instantiate
+open Starling.Core.GuardedView
+
+[<AutoOpen>] 
+module Types =
+    type Query = unit  
+    type Error = unit 
+
+module Pretty = 
+    let printQuery g = 
+        failwith "not implemented yet" 
+
+    let printGrassError e = 
+        failwith "not implemented yet" 
+
+let grassModel i = 
+    failwith "not implemented yet" 

--- a/Grasshopper.fs
+++ b/Grasshopper.fs
@@ -12,22 +12,86 @@ open Starling.Core.TypeSystem
 open Starling.Core.Var
 open Starling.Core.Expr
 open Starling.Core.Model
+open Starling.Core.Symbolic
 open Starling.Core.Instantiate
 open Starling.Core.GuardedView
 
 [<AutoOpen>] 
 module Types =
-    type Grass = Backends.Z3.Types.ZModel  
+    type Grass = Backends.Z3.Types.ZModel // Just piggyback on Z3 for now.  
     type Error = unit 
 
 module Pretty = 
-    let printQuery = 
-        Backends.Z3.Pretty.printZTerm
-        // failwith "not implemented yet" 
+    open Starling.Core.Pretty
+    open Starling.Core.Model.Pretty
+    open Starling.Core.Symbolic.Pretty
+
+    let printMarkedVar =
+        function
+        | Before s -> String "before_" <-> String s 
+        | After s -> String "after_" <-> String s
+        | Intermediate (i, s) -> String "inter_" <-> String (sprintf "%A_" i) <-> String s 
+        | Goal (i, s) -> String "goal_" <-> String (sprintf "%A_" i) <-> String s 
+
+    // Print infix operator across multiple lines
+    let infexprV (op : string) (pxs : 'x -> Doc) (xs : seq<'x>) : Doc = 
+        let mapped = Seq.map pxs xs 
+        let resseq = Seq.map (fun x -> vsep [(String op); Indent x]) (Seq.tail mapped) 
+        hsep [Seq.head mapped; (hsep resseq)] 
+        |> parened 
+
+    // Print infix operator on one line
+    let infexpr (op : string) (pxs : 'x -> Doc) (xs : seq<'x>) : Doc = 
+        let mapped = Seq.map pxs xs 
+        let resseq = Seq.map (fun x -> hsep [(String op); x]) (Seq.tail mapped) 
+        hsep [Seq.head mapped; (hsep resseq)] 
+        |> parened 
+
+    /// Pretty-prints an arithmetic expression.
+    let rec printIntExpr (pVar : 'Var -> Doc) : IntExpr<'Var> -> Doc =
+        function
+        | IVar c -> pVar c
+        | _ -> failwith "Unimplemented" 
+
+    /// Pretty-prints a Boolean expression.
+    and printBoolExpr (pVar : 'Var -> Doc) : BoolExpr<'Var> -> Doc =
+        function
+        | BAnd xs -> infexprV "&&" (printBoolExpr pVar) xs
+        | BOr xs -> infexprV "||" (printBoolExpr pVar) xs
+        | BVar c -> pVar c
+        | BImplies (x, y) -> infexprV "==>" (printBoolExpr pVar)  [x; y]
+        | BNot (BEq (x, y)) -> infexpr "!=" (printExpr pVar) [x; y]
+        | BEq (x, y) -> infexpr "==" (printExpr pVar) [x; y]
+        | _ -> failwith "Unimplemented" 
+
+    /// Pretty-prints an expression.
+    and printExpr (pVar : 'Var -> Doc) : Expr<'Var> -> Doc =
+        function
+        | Int i -> printIntExpr pVar i
+        | Bool b -> printBoolExpr pVar b
+        | _ -> failwith "Unimplemented" 
+
+    let rec printSym (pReg : 'Reg -> Doc) (sym : Sym<'Reg>) : Doc =
+        match sym with
+        | Reg r -> pReg r
+        | Sym { Sentence = ws; Args = xs } ->
+            let pArg = printExpr (printSym pReg)
+            parened
+                (printInterpolatedSymbolicSentence pArg ws xs)
+
+    let printExprGrass a = 
+        printBoolExpr (printSym printMarkedVar) a 
+
+    let printQuery (zterm : Backends.Z3.Types.ZTerm) : Doc = 
+        headed "Grasshopper terms" <| 
+          [ printTerm
+              (fun x -> String "Cmd printing not implemented yet.") 
+              printExprGrass 
+              printExprGrass 
+              zterm.SymBool ]
 
     let printGrassError e = 
         failwith "not implemented yet" 
 
 let grassModel (i : Backends.Z3.Types.ZModel) : Result<Grass,Error>  = 
   ok i 
-  // failwith "not implemented yet" 

--- a/Grasshopper.fs
+++ b/Grasshopper.fs
@@ -28,6 +28,7 @@ module Pretty =
     open Starling.Core.Model.Pretty
     open Starling.Core.Symbolic.Pretty
 
+    /// Prints a marked Var 
     let printMarkedVar (v : MarkedVar) : Doc =
         match v with 
         | Before s -> String "before_" <-> String s 
@@ -73,6 +74,7 @@ module Pretty =
         | Bool b -> printBoolExpr pVar b
         | _ -> failwith "Unimplemented for Grasshopper backend." 
 
+    /// Pretty-prints a symbolic sentence 
     let rec printSym (pReg : 'Reg -> Doc) (sym : Sym<'Reg>) : Doc =
         match sym with
         | Reg r -> pReg r
@@ -85,6 +87,7 @@ module Pretty =
         printBoolExpr (printSym printMarkedVar) a 
 
     let findVarsGrass (zterm : Backends.Z3.Types.ZTerm) : seq<MarkedVar> = 
+        // TODO @(septract) Should this conjoin the command as well? 
         BAnd [zterm.SymBool.WPre; zterm.SymBool.Goal] 
         |> findMarkedVars (tliftToBoolSrc (tliftToExprDest collectSymMarkedVars)) 
         |> lift (Set.map valueOf) 
@@ -109,19 +112,6 @@ module Pretty =
                String "{}"   
                headed "Command" (cmdprint |> Seq.singleton)
              ]  
-
-
-    // let printQuery (zterm : Backends.Z3.Types.ZTerm) : Doc = 
-    //    vsep  
-    //        [ headed "Variables" <|
-    //              List.map printMarkedVar (findVarsGrass zterm)
-    //          headed "Grasshopper terms" <| 
-    //              [ printTerm
-    //                  (Core.Expr.Pretty.printBoolExpr (printSym printMarkedVar)) 
-    //                  printExprGrass 
-    //                  printExprGrass 
-    //                  zterm.SymBool ]
-    //        ]
 
     let printGrassError e = 
         failwith "not implemented yet" 

--- a/Grasshopper.fs
+++ b/Grasshopper.fs
@@ -29,19 +29,17 @@ module Pretty =
     open Starling.Core.Model.Pretty
     open Starling.Core.Symbolic.Pretty
 
-    // Print infix operator across multiple lines
+    /// Print infix operator across multiple lines
     let infexprV (op : string) (pxs : 'x -> Doc) (xs : seq<'x>) : Doc = 
         let mapped = Seq.map pxs xs 
         let resseq = Seq.map (fun x -> vsep [(String op); Indent x]) (Seq.tail mapped) 
-        hsep [Seq.head mapped; (hsep resseq)] 
-        |> parened 
+        parened (hsep [Seq.head mapped; (hsep resseq)]) 
 
-    // Print infix operator on one line
+    /// Print infix operator on one line
     let infexpr (op : string) (pxs : 'x -> Doc) (xs : seq<'x>) : Doc = 
         let mapped = Seq.map pxs xs 
         let resseq = Seq.map (fun x -> hsep [(String op); x]) (Seq.tail mapped) 
-        hsep [Seq.head mapped; (hsep resseq)] 
-        |> parened 
+        parened (hsep [Seq.head mapped; (hsep resseq)]) 
 
     /// Prints a marked Var 
     let printMarkedVarGrass (v : MarkedVar) : Doc =
@@ -96,8 +94,7 @@ module Pretty =
         // TODO @(septract) Should this conjoin the command as well? 
         BAnd [zterm.SymBool.WPre; zterm.SymBool.Goal] 
         |> findMarkedVars (tliftToBoolSrc (tliftToExprDest collectSymMarkedVars)) 
-        |> lift (Set.map valueOf) 
-        |> lift (Set.toSeq) 
+        |> lift (Set.map valueOf >> Set.toSeq) 
         |> returnOrFail
 
     /// Print a single Grasshopper query from a ZTerm 
@@ -113,7 +110,7 @@ module Pretty =
                        |> (fun x -> VSep(x,String ",")) 
                        |> Indent 
 
-        // Print the requires / ensures clauses 
+        /// Print the requires / ensures clauses 
         let wpreprint = zterm.SymBool.WPre 
                         |> printBoolExprG (printSymGrass printMarkedVarGrass) 
         let goalprint = zterm.SymBool.Goal 
@@ -138,7 +135,7 @@ module Pretty =
         |> Seq.map (fun (name,term) -> printZTermGrass model.SharedVars name term) 
         |> vsep
 
-    /// Print a Grasshopper error. 
+    /// Print a Grasshopper error (not implemented yet)
     let printGrassError e = failwith "not implemented yet" 
 
 /// Generate a grasshopper model (currently doesn't do anything) 

--- a/Main.fs
+++ b/Main.fs
@@ -208,7 +208,7 @@ type Response =
     /// The result of HSF processing.
     | HSF of Backends.Horn.Types.Horn list
     /// The results of Grasshopper 
-    | Grasshopper of Backends.Grasshopper.Types.Query 
+    | Grasshopper of Backends.Grasshopper.Types.Grass 
 
 
 /// Pretty-prints a response.
@@ -249,7 +249,7 @@ let printResponse (mview : ModelView) : Response -> Doc =
     | SMTProof z -> Backends.Z3.Pretty.printResponse mview z
     | MuZ3 z -> Backends.MuZ3.Pretty.printResponse mview z
     | HSF h -> Backends.Horn.Pretty.printHorns h
-    | Grasshopper g -> Backends.Grasshopper.Pretty.printQuery g
+    | Grasshopper g -> printUModel Backends.Grasshopper.Pretty.printQuery g 
 
 
 /// A top-level program error.
@@ -521,7 +521,7 @@ let runStarling (request : Request)
     let eliminate : Result<Model<_, _>, Error> -> Result<Model<_, _>, Error>  =
         lift (Backends.Z3.runZ3OnModel shouldUseRealsForInts)
 
-    let backend m =
+    let backend (m : Result<Backends.Z3.Types.ZModel, Error>) : Result<Response,Error>  =
         let phase op response =
             let time = System.Diagnostics.Stopwatch.StartNew()
             op m

--- a/Main.fs
+++ b/Main.fs
@@ -69,6 +69,8 @@ type Request =
     | MuZ3 of Backends.MuZ3.Types.Request
     /// Run the HSF backend (experimental).
     | HSF
+    /// Run the Grasshopper backend (experimental) 
+    | Grasshopper 
 
 /// Map of -s stage names to Request items.
 let requestList : (string * (string * Request)) list =
@@ -146,7 +148,10 @@ let requestList : (string * (string * Request)) list =
         Request.MuZ3 Backends.MuZ3.Types.Request.Sat))
       ("hsf",
        ("Outputs a proof in HSF format.",
-        Request.HSF)) ]
+        Request.HSF)) 
+      ("grass",
+       ("Outputs a proof in Grasshopper format.",
+        Request.Grasshopper))]
 
 /// Converts an optional -s stage name to a request item.
 /// If none is given, the latest stage is selected.
@@ -202,6 +207,8 @@ type Response =
     | MuZ3 of Backends.MuZ3.Types.Response
     /// The result of HSF processing.
     | HSF of Backends.Horn.Types.Horn list
+    /// The results of Grasshopper 
+    | Grasshopper of Backends.Grasshopper.Types.Query 
 
 
 /// Pretty-prints a response.
@@ -242,6 +249,7 @@ let printResponse (mview : ModelView) : Response -> Doc =
     | SMTProof z -> Backends.Z3.Pretty.printResponse mview z
     | MuZ3 z -> Backends.MuZ3.Pretty.printResponse mview z
     | HSF h -> Backends.Horn.Pretty.printHorns h
+    | Grasshopper g -> Backends.Grasshopper.Pretty.printQuery g
 
 
 /// A top-level program error.
@@ -254,6 +262,8 @@ type Error =
     ///     An error occurred in the HSF backend.
     /// </summary>
     | HSF of Backends.Horn.Types.Error
+    /// An error occurred in the Grasshopper backend. 
+    | Grasshopper of Backends.Grasshopper.Types.Error
     /// <summary>
     ///     An error occurred in the MuZ3 backend.
     /// </summary>
@@ -320,6 +330,7 @@ let rec printError (err : Error) : Doc =
     | IterLowerError e ->
         headed "Iterator lowering failed"
                [ TermGen.Iter.printError e ]
+    | Grasshopper e -> Backends.Grasshopper.Pretty.printGrassError e 
     | ModelFilterError e ->
         headed "View definitions are incompatible with this backend"
                [ Core.Instantiate.Pretty.printError e ]
@@ -477,6 +488,9 @@ let runStarling (request : Request)
         bind (Starling.Semantics.translate
               >> mapMessages Error.Semantics)
     let axiomatise = lift Starling.Core.Graph.axiomatise
+    let grasshopper = 
+        bind (Backends.Grasshopper.grassModel 
+              >> mapMessages Error.Grasshopper) 
 
     // Prepares a model for insertion into a Horn clause solver, by trying to
     // throw away symbols and removing already-proven-by-Z3 clauses.
@@ -519,6 +533,7 @@ let runStarling (request : Request)
         // TODO: plug eliminate into HSF
         | Request.HSF         -> phase (prepareForHorn >> hsf) Response.HSF
         | Request.MuZ3 rq     -> phase (prepareForHorn >> muz3 rq) Response.MuZ3
+        | Request.Grasshopper -> phase grasshopper Response.Grasshopper  
         | _                   -> fail (Error.Other "Internal")
 
     //Build a phase with
@@ -588,3 +603,5 @@ let main (argv : string[]) : int =
     | _ ->
         printfn "parse result of unknown type"
         3
+
+

--- a/Main.fs
+++ b/Main.fs
@@ -208,7 +208,7 @@ type Response =
     /// The result of HSF processing.
     | HSF of Backends.Horn.Types.Horn list
     /// The results of Grasshopper 
-    | Grasshopper of Backends.Grasshopper.Types.Grass 
+    | Grasshopper of Backends.Grasshopper.Types.GrassModel
 
 
 /// Pretty-prints a response.
@@ -249,7 +249,7 @@ let printResponse (mview : ModelView) : Response -> Doc =
     | SMTProof z -> Backends.Z3.Pretty.printResponse mview z
     | MuZ3 z -> Backends.MuZ3.Pretty.printResponse mview z
     | HSF h -> Backends.Horn.Pretty.printHorns h
-    | Grasshopper g -> printUModel Backends.Grasshopper.Pretty.printQuery g 
+    | Grasshopper g -> Backends.Grasshopper.Pretty.printQuery g 
 
 
 /// A top-level program error.

--- a/starling.fsproj
+++ b/starling.fsproj
@@ -24,7 +24,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <Optimize>false</Optimize>
     <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <Externalconsole>true</Externalconsole>

--- a/starling.fsproj
+++ b/starling.fsproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -23,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <Optimize>false</Optimize>
     <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <Externalconsole>true</Externalconsole>
@@ -99,6 +99,7 @@
     <Compile Include="OptimiserTests.fs" />
     <Compile Include="HornTests.fs" />
     <Compile Include="CommandTests.fs" />
+    <Compile Include="Grasshopper.fs" />
     <Compile Include="Main.fs" />
     <None Include="packages.config" />
     <None Include="Examples\Pass\arc.cvf" />

--- a/starling.fsproj
+++ b/starling.fsproj
@@ -1,4 +1,6 @@
-﻿<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>


### PR DESCRIPTION
This PRQ is the first step towards addressing #98 - by passing the `grass` stage, we get a list of Grasshopper procedures, each of which correspond to a ZTerm. 

To test it out, run:
> `$ ./starling.sh -s grass Examples/WIP/lclist-grasshopper.cvf`