### PR TITLE
Removed redundant [n] in iterated view declarations

### DIFF
--- a/AST.fs
+++ b/AST.fs
@@ -138,7 +138,7 @@ module Types =
         /// <summary>
         ///     An iterated view prototype; cannot be anonymous
         /// </summary>
-        | WithIterator of Func: Func<'Param> //  * Iterator: string
+        | WithIterator of Func: Func<'Param>
 
     /// A view prototype with Param parameters.
     type ViewProto = GeneralViewProto<Param>

--- a/AST.fs
+++ b/AST.fs
@@ -138,7 +138,7 @@ module Types =
         /// <summary>
         ///     An iterated view prototype; cannot be anonymous
         /// </summary>
-        | WithIterator of Func: Func<'Param> * Iterator: string
+        | WithIterator of Func: Func<'Param> //  * Iterator: string
 
     /// A view prototype with Param parameters.
     type ViewProto = GeneralViewProto<Param>
@@ -464,8 +464,8 @@ module Pretty =
         match vp with
         | NoIterator (Func = { Name = n; Params = ps }; IsAnonymous = _) ->
             func n (List.map pParam ps)
-        | WithIterator (Func = { Name = n; Params = ps }; Iterator = i) ->
-            (String "iter" <-> squared (String i))
+        | WithIterator (Func = { Name = n; Params = ps }) ->
+            (String "iter")
             <+> func n (List.map pParam ps)
 
     /// Pretty-prints a view prototype.

--- a/Examples/Pass/arc.cvf
+++ b/Examples/Pass/arc.cvf
@@ -39,7 +39,7 @@ method drop() {
 }
 
 view error();
-view iter[n] arc();
+view iter arc();
 view noCnt();
 
 // These views just add free=f and count=c to the final proof predicates

--- a/Examples/Pass/singleWriterMultiReaderLock.cvf
+++ b/Examples/Pass/singleWriterMultiReaderLock.cvf
@@ -81,7 +81,7 @@ view holdTick(int t);
 view holdInnerLock();
 view holdWriteLock();
 view canHoldReadLock();
-view iter[n] holdReadLock();
+view iter holdReadLock();
 
 // Invariant
 constraint emp                                  -> ticket >= serving && readCount >= 0 && maxCount > 0;

--- a/Examples/WIP/arcIndefinite.cvf
+++ b/Examples/WIP/arcIndefinite.cvf
@@ -42,7 +42,7 @@ method drop() {
 }
 
 view error();
-view iter[n] arc();
+view iter arc();
 view noCnt();
 view noArc();
 

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -1648,7 +1648,7 @@ let modelMethod
 let checkViewProtoDuplicates (proto : DesugaredViewProto)
   : Result<DesugaredViewProto, ViewProtoError> =
     match proto with
-    | NoIterator (f, _) | WithIterator (f, _) ->
+    | NoIterator (f, _) | WithIterator f ->
         f.Params
         |> Seq.map valueOf
         |> findDuplicates
@@ -1667,7 +1667,7 @@ let modelViewProtos (protos : #(DesugaredViewProto seq))
                (function
                 | NoIterator (f, isAnonymous) ->
                     (f, { IsIterated = false; IsAnonymous = isAnonymous; } )
-                | WithIterator (f, _) ->
+                | WithIterator f ->
                     (f, { IsIterated = true; IsAnonymous = false; } ))
 
     protos
@@ -1742,8 +1742,8 @@ let convertViewProtos (vps : ViewProto list)
         match vp with
         | NoIterator (func, isAnonymous) ->
             lift (fun f -> NoIterator (f, isAnonymous)) (convertViewFunc vp func)
-        | WithIterator (func, iterator) ->
-            lift (fun f -> WithIterator (f, iterator)) (convertViewFunc vp func)
+        | WithIterator func ->
+            lift (fun f -> WithIterator f) (convertViewFunc vp func)
 
     collect (List.map convertViewProto vps)
 

--- a/Parser.fs
+++ b/Parser.fs
@@ -468,12 +468,9 @@ do parseViewSignatureRef := parseViewLike parseBasicViewSignature ViewSignature.
 /// Parses a view prototype (a LHS followed optionally by an iterator).
 let parseViewProto =
     // TODO (CaptainHayashi): so much backtracking...
-    // (parseIteratedContainer
-    //     (parseFunc parseParam)
-    //     (fun i f -> WithIterator (f, i))) 
     (pstring "iter" >>. ws >>. 
       (parseFunc parseParam
-         |>> (fun lhs -> WithIterator (lhs)))) 
+         |>> (fun lhs -> WithIterator lhs))) 
     <|> 
       (parseFunc parseParam
          |>> (fun lhs -> NoIterator (lhs, false)))

--- a/Parser.fs
+++ b/Parser.fs
@@ -468,10 +468,14 @@ do parseViewSignatureRef := parseViewLike parseBasicViewSignature ViewSignature.
 /// Parses a view prototype (a LHS followed optionally by an iterator).
 let parseViewProto =
     // TODO (CaptainHayashi): so much backtracking...
-    parseIteratedContainer
-        (parseFunc parseParam)
-        (fun i f -> WithIterator (f, i))
-    <|> (parseFunc parseParam
+    // (parseIteratedContainer
+    //     (parseFunc parseParam)
+    //     (fun i f -> WithIterator (f, i))) 
+    (pstring "iter" >>. ws >>. 
+      (parseFunc parseParam
+         |>> (fun lhs -> WithIterator (lhs)))) 
+    <|> 
+      (parseFunc parseParam
          |>> (fun lhs -> NoIterator (lhs, false)))
 
 /// Parses a set of one or more view prototypes.


### PR DESCRIPTION
This means:
* modifying the parser
* Changing `WithIterator` to remove the redundant arg string
* fixing the examples. 

This PRQ resolves issue #84. 