### PR TITLE
Microcode internal changes: havocs, new framing, and push through

### DIFF
--- a/Command.fs
+++ b/Command.fs
@@ -21,12 +21,24 @@ open Starling.Core.Traversal
 [<AutoOpen>]
 module Types =
     /// <summary>
-    ///     A command.
-    ///
-    ///     <para>
-    ///         A command is a list, representing a sequential composition
-    ///         of primitives represented as <c>PrimCommand</c>s.
-    ///     </para>
+    ///     Mid-level register transfer logic used to encode Starling
+    ///     commands.
+    /// </summary>
+    /// <typeparam name="L">The type of lvalues.</typeparam>
+    /// <typeparam name="RV">The type of rvalue variables.</typeparam>
+    type Microcode<'L, 'RV> when 'RV : equality =
+        /// <summary>An assignment, perhaps nondeterministic.</summary>
+        | Assign of lvalue : 'L * rvalue : Expr<'RV> option
+        /// <summary>A diverging assertion.</summary>
+        | Assume of assumption : BoolExpr<'RV>
+        /// <summary>A conditional.</summary>
+        | Branch of conditional : BoolExpr<'RV>
+                  * ifTrue : Microcode<'L, 'RV> list
+                  * ifFalse : Microcode<'L, 'RV> list
+        override this.ToString() = sprintf "%A" this
+
+    /// <summary>
+    ///     A reference into the model's atomic commands table.
     /// </summary>
     /// <remarks>
     ///     <para>
@@ -43,11 +55,26 @@ module Types =
           Node : AST.Types.Atomic option }
         override this.ToString() = sprintf "%A" this
 
+    /// <summary>
+    ///     A command.
+    ///
+    ///     <para>
+    ///         A command is a list, representing a sequential composition
+    ///         of primitives represented as <c>PrimCommand</c>s.
+    ///     </para>
+    /// </summary>
     type Command = PrimCommand list
 
-    /// The Semantics of a Command is a pair of the original command and its boolean expr
+    /// <summary>
+    ///     A command, coupled with its various semantic translations.
+    /// </summary>
     type CommandSemantics<'Semantics> =
-        { Cmd : Command; Semantics : 'Semantics }
+        { /// <summary>The original command.</summary>
+          Cmd : Command
+          /// <summary>The command's microcode instantiation.</summary>
+          Microcode : Microcode<CTyped<MarkedVar>, Sym<MarkedVar>> list list
+          /// <summary>The Boolean translation.</summary>
+          Semantics : 'Semantics }
         override this.ToString() = sprintf "%A" this
 
 /// <summary>
@@ -80,8 +107,8 @@ module Traversal =
       : Traversal<CommandSemantics<BoolExpr<'SrcVar>>,
                   CommandSemantics<BoolExpr<'DstVar>>,
                   'Error, 'Var> =
-        fun ctx { Cmd = c; Semantics = s } ->
-            let swapSemantics s' = { Cmd = c; Semantics = s' }
+        fun ctx { Cmd = c; Microcode = m; Semantics = s } ->
+            let swapSemantics s' = { Cmd = c; Microcode = m; Semantics = s' }
             let result = traverseBoolAsExpr traversal ctx s
             lift (pairMap id swapSemantics) result
 

--- a/Command.fs
+++ b/Command.fs
@@ -73,6 +73,13 @@ module Types =
           Cmd : Command
           /// <summary>The command's microcode instantiation.</summary>
           Microcode : Microcode<CTyped<MarkedVar>, Sym<MarkedVar>> list list
+          /// <summary>
+          ///     The assignment map for the command.
+          ///     This maps the post-state of each variable reachable by the
+          ///     command to the last assignment made in Microcode for that
+          ///     variable.
+          /// <summary>
+          Assigns : Map<TypedVar, MarkedVar>
           /// <summary>The Boolean translation.</summary>
           Semantics : 'Semantics }
         override this.ToString() = sprintf "%A" this
@@ -107,8 +114,9 @@ module Traversal =
       : Traversal<CommandSemantics<BoolExpr<'SrcVar>>,
                   CommandSemantics<BoolExpr<'DstVar>>,
                   'Error, 'Var> =
-        fun ctx { Cmd = c; Microcode = m; Semantics = s } ->
-            let swapSemantics s' = { Cmd = c; Microcode = m; Semantics = s' }
+        fun ctx { Cmd = c; Microcode = m; Assigns = a; Semantics = s } ->
+            let swapSemantics s' =
+                { Cmd = c; Microcode = m; Assigns = a; Semantics = s' }
             let result = traverseBoolAsExpr traversal ctx s
             lift (pairMap id swapSemantics) result
 

--- a/Model.fs
+++ b/Model.fs
@@ -59,8 +59,8 @@ module Types =
     /// <typeparam name="L">The type of lvalues.</typeparam>
     /// <typeparam name="RV">The type of rvalue variables.</typeparam>
     type Microcode<'L, 'RV> when 'RV : equality =
-        /// <summary>An assignment.</summary>
-        | Assign of lvalue : 'L * rvalue : Expr<'RV>
+        /// <summary>An assignment, perhaps nondeterministic.</summary>
+        | Assign of lvalue : 'L * rvalue : Expr<'RV> option
         /// <summary>A diverging assertion.</summary>
         | Assume of assumption : BoolExpr<'RV>
         /// <summary>A conditional.</summary>
@@ -198,6 +198,19 @@ module Types =
           ///     A log of any deferred checks the backend must do.
           /// </summary>
           DeferredChecks : DeferredCheck list }
+
+
+/// <summary>
+///     Creates a deterministic assign.
+/// </summary>
+let ( *<- ) (lv : 'L) (rv : Expr<'RV>) : Microcode<'L, 'RV> =
+    Assign (lv, Some rv)
+
+/// <summary>
+///     Creates a nondeterministic assign.
+/// </summary>
+let havoc (lv : 'L) : Microcode<'L, 'RV> =
+    Assign (lv, None)
 
 
 /// <summary>

--- a/Model.fs
+++ b/Model.fs
@@ -52,23 +52,6 @@ open Starling.Core.Command
 /// </summary>
 [<AutoOpen>]
 module Types =
-    /// <summary>
-    ///     Mid-level register transfer logic used to encode Starling
-    ///     commands.
-    /// </summary>
-    /// <typeparam name="L">The type of lvalues.</typeparam>
-    /// <typeparam name="RV">The type of rvalue variables.</typeparam>
-    type Microcode<'L, 'RV> when 'RV : equality =
-        /// <summary>An assignment, perhaps nondeterministic.</summary>
-        | Assign of lvalue : 'L * rvalue : Expr<'RV> option
-        /// <summary>A diverging assertion.</summary>
-        | Assume of assumption : BoolExpr<'RV>
-        /// <summary>A conditional.</summary>
-        | Branch of conditional : BoolExpr<'RV>
-                  * ifTrue : Microcode<'L, 'RV> list
-                  * ifFalse : Microcode<'L, 'RV> list
-        override this.ToString() = sprintf "%A" this
-
     (*
      * Terms
      *)

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -421,6 +421,7 @@ let mkPrim (name : string) (results : TypedVar list) (args : TypedVar list)
   : PrimSemantics =
     { Name = name; Results = results; Args = args; Body = body }
 
+
 /// <summary>
 ///   The core semantic function for the imperative language.
 /// </summary>
@@ -442,46 +443,46 @@ let coreSemantics : PrimSemanticsMap =
       (mkPrim "ICAS" [ Int "destA"; Int "testA" ] [ Int "destB"; Int "testB"; Int "set" ]
            [ Branch
                 (iEq (IVar "destB") (IVar "testB"),
-                 [ Assign (Int "destA", Int (IVar "set"))
-                   Assign (Int "testA", Int (IVar "testB")) ],
-                 [ Assign (Int "destA", Int (IVar "destB"))
-                   Assign (Int "testA", Int (IVar "destB")) ] ) ] )
+                 [ Int "destA" *<- Int (IVar "set")
+                   Int "testA" *<- Int (IVar "testB") ],
+                 [ Int "destA" *<- Int (IVar "destB")
+                   Int "testA" *<- Int (IVar "destB") ] ) ] )
       // Boolean CAS
       (mkPrim "BCAS" [ Bool "destA"; Bool "testA" ] [ Bool "destB"; Bool "testB"; Bool "set" ]
            [ Branch
                 (bEq (BVar "destB") (BVar "testB"),
-                 [ Assign (Bool "destA", Bool (BVar "set"))
-                   Assign (Bool "testA", Bool (BVar "testB")) ],
-                 [ Assign (Bool "destA", Bool (BVar "destB"))
-                   Assign (Bool "testA", Bool (BVar "destB")) ] ) ] )
+                 [ Bool "destA" *<- Bool (BVar "set")
+                   Bool "testA" *<- Bool (BVar "testB") ],
+                 [ Bool "destA" *<- Bool (BVar "destB")
+                   Bool "testA" *<- Bool (BVar "destB") ] ) ] )
       (*
        * Atomic load
        *)
       // Integer load
       (mkPrim "!ILoad"  [ Int "dest" ] [ Int "src" ]
-            [ Assign (Int "dest", Int (IVar "src")) ] )
+            [ Int "dest" *<- Int (IVar "src") ] )
 
       // Integer load-and-increment
       (mkPrim "!ILoad++"  [ Int "dest"; Int "srcA" ] [ Int "srcB" ]
-            [ Assign (Int "dest", Int (IVar "srcB"))
-              Assign (Int "srcA", Int (mkAdd2 (IVar "srcB") (IInt 1L))) ] )
+            [ Int "dest" *<- Int (IVar "srcB")
+              Int "srcA" *<- Int (mkAdd2 (IVar "srcB") (IInt 1L)) ] )
 
       // Integer load-and-decrement
       (mkPrim "!ILoad--"  [ Int "dest"; Int "srcA" ] [ Int "srcB" ]
-            [ Assign (Int "dest", Int (IVar "srcB"))
-              Assign (Int "srcA", Int (mkSub2 (IVar "srcB") (IInt 1L))) ] )
+            [ Int "dest" *<- Int (IVar "srcB")
+              Int "srcA" *<- Int (mkSub2 (IVar "srcB") (IInt 1L)) ] )
 
       // Integer increment
       (mkPrim "!I++"  [ Int "srcA" ] [ Int "srcB" ]
-            [ Assign (Int "srcA", Int (mkAdd2 (IVar "srcB") (IInt 1L))) ] )
+            [ Int "srcA" *<- Int (mkAdd2 (IVar "srcB") (IInt 1L)) ] )
 
       // Integer decrement
       (mkPrim "!I--"  [ Int "srcA" ] [ Int "srcB" ]
-            [ Assign (Int "srcA", Int (mkSub2 (IVar "srcB") (IInt 1L))) ] )
+            [ Int "srcA" *<- Int (mkSub2 (IVar "srcB") (IInt 1L)) ] )
 
       // Boolean load
       (mkPrim "!BLoad"  [ Bool "dest" ] [ Bool "src" ]
-            [ Assign (Bool "dest", Bool (BVar "src")) ] )
+            [ Bool "dest" *<- Bool (BVar "src") ] )
 
       (*
        * Atomic store
@@ -489,11 +490,11 @@ let coreSemantics : PrimSemanticsMap =
 
       // Integer store
       (mkPrim "!IStore" [ Int "dest" ] [ Int "src" ]
-            [ Assign (Int "dest", Int (IVar "src")) ] )
+            [ Int "dest" *<- Int (IVar "src") ] )
 
       // Boolean store
       (mkPrim "!BStore" [ Bool "dest" ] [ Bool "src" ]
-            [ Assign (Bool "dest", Bool (BVar "src")) ] )
+            [ Bool "dest" *<- Bool (BVar "src") ] )
 
       (*
        * Local set
@@ -501,11 +502,11 @@ let coreSemantics : PrimSemanticsMap =
 
       // Integer local set
       (mkPrim "!ILSet" [ Int "dest" ] [ Int "src" ]
-            [ Assign (Int "dest", Int (IVar "src")) ] )
+            [ Int "dest" *<- Int (IVar "src") ] )
 
       // Boolean store
       (mkPrim "!BLSet" [ Bool "dest" ] [ Bool "src" ]
-            [ Assign (Bool "dest", Bool (BVar "src")) ] )
+            [ Bool "dest" *<- Bool (BVar "src") ] )
 
       (*
        * Assumptions

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -98,11 +98,6 @@ module Pretty =
         | Traversal err ->
             Starling.Core.Traversal.Pretty.printTraversalError printSemanticsError err
 
-/// Generates a framing relation for a given variable.
-let frameVar ctor (par : CTyped<Var>) : SMBoolExpr =
-    BEq (par |> mapCTyped (After >> Reg) |> mkVarExp,
-         par |> mapCTyped (ctor >> Reg) |> mkVarExp)
-
 /// <summary>
 ///     A write record for an variable.
 ///

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -665,9 +665,10 @@ let semanticsOfCommand
 
     // Finally, collect all of these results into a CommandSemantics record.
     lift2
-        (fun (processed, _) semantics ->
+        (fun (processed, assigns) semantics ->
             { Cmd = cmd
               Microcode = processed
+              Assigns = assigns
               Semantics = semantics })
         processedR
         semanticsR

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -524,12 +524,27 @@ let makeFrame (states : Map<TypedVar, MarkedVar>) : BoolExpr<Sym<MarkedVar>> =
     mkAnd (List.choose maybeFrame (Map.toList states))
 
 /// <summary>
-///     Converts a microcode routine into a two-state Boolean predicate.
+///     Normalises and marks an entire microcode routine with variable states.
 /// </summary>
-let microcodeRoutineToBool
+/// <param name="vars">The list of variables available to the routine.</param>
+/// <param name="routine">The routine to mark.</param>
+/// <returns>
+///     A Chessie result, containing, on success, a pair of the marked
+///     microcode routine and a map from variable post-states to their last
+///     assignment in the microcode routine.  The latter is useful for
+///     calculating frames.
+///     The order of the routine is not guaranteed (but is no longer relevant
+///     after processing anyway).
+/// </returns>
+let processMicrocodeRoutine
   (vars : TypedVar list)
   (routine : Microcode<Expr<Sym<Var>>, Sym<Var>> list list)
-  : Result<BoolExpr<Sym<MarkedVar>>, Error> =
+  : Result<( Microcode<CTyped<MarkedVar>, Sym<MarkedVar>> list list
+             * Map<TypedVar, MarkedVar> ),
+           Error> =
+    // TODO(CaptainHayashi): flatten into a single list
+    // TODO(CaptainHayashi): compose array accesses properly
+
     (* Each item in 'routine' represents a stage in the sequential composition
        of microcode listings.  Each stage has a corresponding variable state:
        the first is Intermediate 0, the second Intermediate 1, and so on until
@@ -558,7 +573,7 @@ let microcodeRoutineToBool
 
        This way, 'state' always tells us which values were assigned in the last
        stage, several stages ago, or not at all. *)
-    let listingToBool (listing, marker) (state, xs) =
+    let processListing (listing, marker) (xs, state) =
         (* First, normalise the listing.
            This ensures only whole variables are written to, which allows us to
            track the assignment later. *)
@@ -576,17 +591,21 @@ let microcodeRoutineToBool
             bind makeAware normalisedR
 
         (* Finally, we need to repopulate the table with all assignments made
-           in this command, and actually translate the listing to a Boolean. *)
+           in this command, and return the listing. *)
         lift
-            (fun stateAware ->
-                (updateState state stateAware, markedMicrocodeToBool stateAware :: xs))
+            (fun stateAware -> (stateAware :: xs, updateState state stateAware))
             stateAwareR
-    let processedR = seqBind listingToBool (initialState, []) markedStages
-    (* Finally, decide the frame and conjoin it with the listings.
-       The frame is (x!after = x!z) where x!z is the last assignment of x and
-       z is not after. *)
-    lift (fun (assigns, bools) -> mkAnd (makeFrame assigns :: bools))
-        processedR 
+    seqBind processListing ([], initialState) markedStages
+
+/// <summary>
+///     Converts a processed microcode routine into a two-state Boolean predicate.
+/// </summary>
+let microcodeRoutineToBool
+  (routine : Microcode<CTyped<MarkedVar>, Sym<MarkedVar>> list list)
+  (assignMap : Map<TypedVar, MarkedVar>)
+  : BoolExpr<Sym<MarkedVar>> =
+    let bools = List.map markedMicrocodeToBool routine
+    mkAnd (makeFrame assignMap :: bools)
 
 /// <summary>
 ///     Converts a primitive command to its representation as a disjoint
@@ -630,7 +649,7 @@ let semanticsOfCommand
     // First, get the microcode representation of each part of the command.
     let microcodeR = collect (Seq.map (instantiateToMicrocode semantics) cmd)
 
-    (* Then, translate the microcode to a framed Boolean expression.
+    (* Then, normalise and mark the microcode, and get the assign map.
        This requires us to provide all variables in the environment for framing
        purposes. *)
     let vars =
@@ -638,10 +657,20 @@ let semanticsOfCommand
             (Seq.append
                 (VarMap.toTypedVarSeq svars)
                 (VarMap.toTypedVarSeq tvars))
-    let semanticsR = bind (microcodeRoutineToBool vars) microcodeR
+
+    let processedR = bind (processMicrocodeRoutine vars) microcodeR
+
+    // Finally, convert the microcode and assign map to a framed expression.
+    let semanticsR = lift (uncurry microcodeRoutineToBool) processedR
 
     // Finally, collect all of these results into a CommandSemantics record.
-    lift (fun semantics -> { Cmd = cmd; Semantics = semantics }) semanticsR
+    lift2
+        (fun (processed, _) semantics ->
+            { Cmd = cmd
+              Microcode = processed
+              Semantics = semantics })
+        processedR
+        semanticsR
 
 open Starling.Core.Axiom.Types
 /// Translate a model over Prims to a model over semantic expressions.

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -348,47 +348,6 @@ let rec normaliseMicrocode
         branches'Result
         assigns'Result
 
-/// Generates a frame for a given expression.
-/// The frame is a relation a!after = a!before for every a not mentioned in the expression.
-let frame svars tvars expr =
-    (* First, we need to find all the bound post-variables in the expression.
-       We do this by finding _all_ variables, then filtering. *)
-    let varsInExprResult =
-        findVars
-            (tliftToBoolSrc (tliftToExprDest collectSymVars))
-            expr
-    let untypedVarsInExprResult = lift (Seq.map valueOf) varsInExprResult
-
-    let aftersInExprResult =
-        lift (Seq.choose (function After x -> Some x | _ -> None))
-            untypedVarsInExprResult
-
-    let evarsResult = lift Set.ofSeq aftersInExprResult
-
-
-    (* Then, for all of the variables in the model, choose those not in evars,
-       and make frame expressions for them. *)
-    let allVars = Seq.append (Map.toSeq svars) (Map.toSeq tvars)
-
-    let makeFrames evars =
-    // TODO(CaptainHayashi): this is fairly inefficient.
-        let varsNotInEvars =
-            Seq.filter (fun (name, _) -> not (Set.contains name evars)) allVars
-
-        let markedVarsNotInEvars =
-            Seq.map
-                (fun (name, ty) ->
-                    let next = getBoolIntermediate name expr
-                    match next with
-                    | None   -> (name, ty, Before)
-                    | Some i -> (name, ty, (fun x -> (Intermediate(i, x)))))
-                varsNotInEvars
-
-        Seq.map (fun (name, ty, ctor) -> frameVar ctor (withType ty name))
-            markedVarsNotInEvars
-
-    lift makeFrames evarsResult
-
 let primParamSubFun
   (cmd : PrimCommand)
   (sem : PrimSemantics)
@@ -410,19 +369,18 @@ let primParamSubFun
                 else fail (Inner (TypeMismatch (v, typeOf tvar)))
             | None -> fail (Inner (FreeVarInSub v)))
 
-let checkParamCountPrim (prim : PrimCommand) (opt : PrimSemantics option) : Result<PrimSemantics option, Error> =
-    match opt with
-    | None -> ok None
-    | Some def ->
-        let fn = List.length prim.Args
-        let dn = List.length def.Args
-        if fn = dn then ok (Some def) else CountMismatch (fn, dn) |> fail
+let checkParamCountPrim (prim : PrimCommand) (def : PrimSemantics) : Result<PrimSemantics, Error> =
+    let fn = List.length prim.Args
+    let dn = List.length def.Args
+    if fn = dn then ok def else fail (CountMismatch (fn, dn))
 
-let lookupPrim (prim : PrimCommand) (map : PrimSemanticsMap) : Result<PrimSemantics option, Error>  =
-    checkParamCountPrim prim
-    <| Map.tryFind prim.Name map
+let lookupPrim (prim : PrimCommand) (map : PrimSemanticsMap) : Result<PrimSemantics, Error>  =
+    maybe
+        (fail (MissingDef prim))
+        (checkParamCountPrim prim)
+        (map.TryFind prim.Name)
 
-let checkParamTypesPrim (prim : PrimCommand) (sem : PrimSemantics) : Result<PrimCommand, Error> =
+let checkParamTypesPrim (prim : PrimCommand) (sem : PrimSemantics) : Result<PrimSemantics, Error> =
     List.map2
         (fun fp dp ->
             if typesCompatible (typeOf fp) (typeOf dp)
@@ -431,7 +389,7 @@ let checkParamTypesPrim (prim : PrimCommand) (sem : PrimSemantics) : Result<Prim
         prim.Args
         sem.Args
     |> collect
-    |> lift (fun _ -> prim)
+    |> lift (fun _ -> sem)
 
 /// <summary>
 ///     Lifts lvalue and rvalue traversals onto a microcode instruction.
@@ -625,176 +583,59 @@ let microcodeRoutineToBool
         processedR 
 
 /// <summary>
-///     Converts a microcode instruction set into a two-state Boolean predicate.
+///     Converts a primitive command to its representation as a disjoint
+///     parallel composition of microcode instructions.
 /// </summary>
-let microcodeToBool
-  (instrs : Microcode<Expr<Sym<Var>>, Sym<Var>> list)
-  : Result<BoolExpr<Sym<MarkedVar>>, Error> =
-    (* First, normalise the expression: this will make framing much easier
-       later. *)
-    let normalisedResult = normaliseMicrocode instrs
-
-    (* We need some traversals to rewrite the expressions to their
-       pre- and post-states.  The normalisation has already sifted things that
-       are post-states onto the LHS of an Assign, and pre-states everywhere
-       else. *)
-    let toAfter = traverseTypedSymWithMarker After
-    let toAfterV =
-        mapTraversal (tliftToExprDest toAfter)
-        >> mapMessages Traversal
-    let toBefore = traverseTypedSymWithMarker Before
-    let toBeforeE =
-        mapTraversal (tliftOverExpr toBefore) >> mapMessages Traversal
-    let toBeforeB =
-        mapTraversal (tliftToBoolSrc (tliftToExprDest toBefore))
-        >> mapMessages Traversal
-
-    let rec translateInstrs is =
-        // TODO(CaptainHayashi): convert to variable LVs.
-        // TODO(CaptainHayashi): framing (currently done elsewhere).
-        let translateInstr =
-            function
-            | Assign (x, y) -> lift2 mkEq (toAfterV (mapCTyped Reg x)) (toBeforeE y)
-            | Assume x -> toBeforeB x
-            | Branch (i, t, e) ->
-                lift3
-                    (fun iX tX eX ->
-                        mkAnd2 (mkImplies iX tX) (mkImplies (mkNot iX) eX))
-                    (toBeforeB i)
-                    (translateInstrs t)
-                    (translateInstrs e)
-        lift mkAnd (collect (List.map translateInstr is))
-
-    bind translateInstrs normalisedResult
-
-/// Instantiates a PrimCommand from a PrimSemantics instance
-let instantiatePrim
-  (smap : PrimSemanticsMap)
-  (prim : PrimCommand)
-  : Result<SMBoolExpr option, Error> =
-    let primDefResult = lookupPrim prim smap
-    let typeCheckedDefResult =
-        bind
-            (function
-             | None -> ok None
-             | Some sem ->
-                lift (fun _ -> Some sem) (checkParamTypesPrim prim sem))
-            primDefResult
-
-    let instantiate =
-        function
-        | None -> ok None
-        | Some s ->
-            let subInMCode =
-                    tchainL (tliftToMicrocode (primParamSubFun prim s)) id
-            let subbedMCode =
-                mapMessages Traversal (mapTraversal subInMCode s.Body)
-            let subbed = bind microcodeToBool subbedMCode
-            lift Some subbed
-
-    bind instantiate typeCheckedDefResult
-
-/// Translate a primitive command to an expression characterising it
-/// by instantiating the semantics from the core semantics map with
-/// the variables from the command
-let instantiateSemanticsOfPrim
+/// <param name="semantics">The map from command to microcode schemata.</param>
+/// <param name="prim">The primitive command to instantiate.</param>
+/// <returns>
+///     If the instantiation succeeded, the resulting list of parallel-composed
+///     <see cref="Microcode"/> instructions.
+/// </returns>
+let instantiateToMicrocode
   (semantics : PrimSemanticsMap)
   (prim : PrimCommand)
-  : Result<SMBoolExpr, Error> =
-    (* First, instantiate according to the semantics.
-     * This can succeed but return None.  This means there is no
-     * entry (erroneous or otherwise) in the semantics for this prim.
-     * Since this is an error in this case, make it one.
-     *)
-    prim
-    |> wrapMessages Instantiate (instantiatePrim semantics)
-    |> bind (failIfNone (MissingDef prim))
+  : Result<Microcode<Expr<Sym<Var>>, Sym<Var>> list, Error> =
+    let primDefR = lookupPrim prim semantics
+    let typeCheckedDefR = bind (checkParamTypesPrim prim) primDefR
 
-/// Given a list of BoolExpr's it sequentially composes them together
-/// this works by taking each BoolExpr in turn,
-///     converting *all* After variables to (Intermediate i) variables
-///     converts any Before variables where an Intermediate exists, to that Intermediate
-///
-/// the frame can then be constructed by taking the BoolExpr and looking for the aforementioned Intermediate
-/// variables and adding a (= (After v) (Intermediate maxInterValue v)) if it finds one
-let seqComposition (xs : BoolExpr<Sym<MarkedVar>> list)
-  : Result<BoolExpr<Sym<MarkedVar>>, Error> =
-    // since we are trying to keep track of explicit state (where we are in terms of the intermediate variables)
-    // it's _okay_ to include actual mutable state here!
-    let mutable dict = System.Collections.Generic.Dictionary<Var, bigint>()
+    let instantiate (s : PrimSemantics) =
+        let subInMCode =
+                tchainL (tliftToMicrocode (primParamSubFun prim s)) id
+        mapMessages Traversal (mapTraversal subInMCode s.Body)
 
-    let mapper x =
-        let dict2 = System.Collections.Generic.Dictionary<Var, bigint>(dict)
-        let isSet = System.Collections.Generic.HashSet<Var>()
+    bind instantiate typeCheckedDefR
 
-        let xRewriteVar =
-            function
-            | Before v as v' ->
-                if dict.ContainsKey (v) then
-                    let iv = dict.[v]
-                    Reg (Intermediate(iv, v))
-                else
-                    Reg v'
-            | After v ->
-                /// Have not set After v to a new Intermediate yet
-                if not (isSet.Contains(v)) then
-                    ignore <| isSet.Add(v)
-
-                    if dict2.ContainsKey(v) then
-                        let nLevel = dict2.[v] + 1I
-                        ignore <| dict2.Remove(v)
-                        dict2.Add(v, nLevel)
-                        Reg (Intermediate (nLevel, v))
-                    else
-                        dict2.Add(v, 0I)
-                        Reg (Intermediate (0I, v))
-                else
-                    Reg (Intermediate (dict2.[v], v))
-            | v -> Reg v
-
-        let xRewriteBool =
-            tliftToBoolSrc
-                (tliftToExprDest
-                    (tliftOverCTyped
-                        (tliftToSymSrc
-                            (ignoreContext (xRewriteVar >> ok)))))
-
-        let bexprResult = mapTraversal xRewriteBool x
-        dict <- dict2
-        bexprResult
-
-    let rec mapping =
-        function
-        | []        ->  ok BTrue
-        | x :: ys   ->  lift2 mkAnd2 (mapper x) (mapping ys)
-
-    mapMessages Traversal (mapping xs)
-
-/// Given a BoolExpr add the frame and return the new BoolExpr
-let addFrame svars tvars bexpr =
-    let frameSeqResult = frame svars tvars bexpr
-    let frameResult = lift (List.ofSeq >> mkAnd) frameSeqResult
-    let addResult = lift (flip mkAnd2 bexpr) frameResult
-    mapMessages Traversal addResult
-
-/// Translate a command to an expression characterising it.
-/// This is the sequential composition of the translations of each
-/// primitive inside it.
+/// <summary>
+///     Translates a command to a multi-state Boolean expression.
+/// </summary>
+/// <param name="semantics">The map from command to microcode schemata.</param>
+/// <param name="svars">The shared variable environment.</param>
+/// <param name="tvars">The thread-local variable environment.</param>
+/// <param name="cmd">The command to instantiate.</param>
+/// <returns>
+///     If the instantiation succeeded, the resulting Boolean expression.
+/// </returns>
 let semanticsOfCommand
   (semantics : PrimSemanticsMap)
   (svars : VarMap)
   (tvars : VarMap)
   (cmd : Command) : Result<CommandSemantics<SMBoolExpr>, Error> =
-    // Instantiate the semantic function of each primitive
-    Seq.map (instantiateSemanticsOfPrim semantics) cmd
-    |> collect
+    // First, get the microcode representation of each part of the command.
+    let microcodeR = collect (Seq.map (instantiateToMicrocode semantics) cmd)
 
-    // Compose them together with intermediates
-    |> bind seqComposition
+    (* Then, translate the microcode to a framed Boolean expression.
+       This requires us to provide all variables in the environment for framing
+       purposes. *)
+    let vars =
+        List.ofSeq
+            (Seq.append
+                (VarMap.toTypedVarSeq svars)
+                (VarMap.toTypedVarSeq tvars))
+    let semanticsR = bind (microcodeRoutineToBool vars) microcodeR
 
-    // Add the frame
-    |> bind (addFrame svars tvars)
-    |> lift (fun bexpr -> { Cmd = cmd; Semantics = bexpr })
+    // Finally, collect all of these results into a CommandSemantics record.
+    lift (fun semantics -> { Cmd = cmd; Semantics = semantics }) semanticsR
 
 open Starling.Core.Axiom.Types
 /// Translate a model over Prims to a model over semantic expressions.

--- a/SemanticsTests.fs
+++ b/SemanticsTests.fs
@@ -59,6 +59,40 @@ let aupd' eltype length arr idx var =
 let aupd eltype length arr idx var =
     Array (eltype, length, aupd' eltype length arr idx var)
 
+
+/// <summary>
+///     Tests for frame generation.
+/// </summary>
+module MakeFrame =
+    /// <summary>
+    ///     Checks the frame generated from an assign map against a given
+    ///     Boolean expression.
+    /// </summary>
+    /// <param name="expected">The expected list of frame expressions.</param>
+    /// <param name="toFrame">The assign map to convert to a frame.</param>
+    let check
+      (expected : BoolExpr<Sym<MarkedVar>> list)
+      (toFrame : Map<TypedVar, MarkedVar>)
+      : unit =
+        List.sort expected ?=? List.sort (makeFrame toFrame) 
+
+    [<Test>]
+    let ``the empty assign list generates the empty frame`` () =
+        check [] Map.empty
+
+    [<Test>]
+    let ``only non-after variables are framed`` () =
+        check
+            [ iEq (siAfter "serving") (siBefore "serving")
+              iEq (siAfter "ticket") (siBefore "ticket")
+              iEq (siAfter "t") (siInter 0I "t") ]
+            (Map.ofList
+                [ (Int "serving", Before "serving")
+                  (Int "ticket", Before "ticket")
+                  (Int "t", Intermediate (0I, "t"))
+                  (Int "s", After "s") ] )
+
+
 /// <summary>
 ///     Tests for microcode normalisation.
 /// </summary>

--- a/SemanticsTests.fs
+++ b/SemanticsTests.fs
@@ -99,12 +99,12 @@ module WriteMaps =
     [<Test>]
     let ``write map of x[3][i] <- 3; y[j] <- 4 is correct`` () =
         Map.ofList
-            [ (Array (Array (Int (), Some 320, ()), Some 240, Reg "x"),
+            [ (Array (Array (Int (), Some 320, ()), Some 240, "x"),
                Indices <| Map.ofList
                 [ (IInt 3L,
                     Indices <| Map.ofList
                         [ (IVar (Reg "i"), Entire (Int (IInt 3L))) ]) ] )
-              (Array (Int (), Some 320, Reg "y"),
+              (Array (Int (), Some 320, "y"),
                Indices <| Map.ofList
                 [ (IVar (Reg "j"), Entire (Int (IInt 4L))) ] ) ]
         ?=?
@@ -151,7 +151,7 @@ module Normalisation =
     [<Test>]
     let ``assign normalisation of x[3][i] <- 3; y[j] <- 4 is correct`` () =
         checkAssigns
-            [ (Array (Array (Int (), Some 320, ()), Some 240, Reg "x"),
+            [ (Array (Array (Int (), Some 320, ()), Some 240, "x"),
                aupd (Array (Int (), Some 320, ())) (Some 240) (AVar (Reg "x"))
                 (IInt 3L)
                 (aupd
@@ -164,7 +164,7 @@ module Normalisation =
                          IInt 3L))
                     (IVar (Reg "i"))
                     (Int (IInt 3L))))
-              (Array (Int (), Some 320, Reg "y"),
+              (Array (Int (), Some 320, "y"),
                aupd (Int()) (Some 320) (AVar (Reg "y"))
                     (IVar (Reg "j"))
                     (Int (IInt 4L))) ]
@@ -191,17 +191,17 @@ module Normalisation =
     let ``microcode normalisation of CAS(x[3], d[6], 2) is correct`` () =
         let xel = Int ()
         let xlen = Some 10
-        let xname = Reg "x"
+        let xname = "x"
         let xar = Array (xel, xlen, xname)
-        let x3 = IIdx (xel, xlen, AVar xname, IInt 3L)
-        let x3upd v = aupd xel xlen (AVar xname) (IInt 3L) v
+        let x3 = IIdx (xel, xlen, AVar (Reg xname), IInt 3L)
+        let x3upd v = aupd xel xlen (AVar (Reg xname)) (IInt 3L) v
 
         let del = Int ()
         let dlen = Some 10
-        let dname = Reg "d"
+        let dname = "d"
         let dar = Array (del, dlen, dname)
-        let d6 = IIdx (del, dlen, AVar dname, IInt 6L)
-        let d6upd v = aupd del dlen (AVar dname) (IInt 6L) v
+        let d6 = IIdx (del, dlen, AVar (Reg dname), IInt 6L)
+        let d6upd v = aupd del dlen (AVar (Reg dname)) (IInt 6L) v
 
         checkMicrocode
             // TODO(CaptainHayashi): order shouldn't matter in branches.

--- a/SemanticsTests.fs
+++ b/SemanticsTests.fs
@@ -197,9 +197,12 @@ module MicrocodeToBool =
         let tvars = VarMap.toTypedVarSeq tvars
         let vars = List.ofSeq (Seq.append svars tvars)
 
+        let processedR = processMicrocodeRoutine vars instrs
+        let microcodeR = lift (uncurry microcodeRoutineToBool) processedR
+
         assertOkAndEqual
             (trySort expected)
-            (lift trySort (microcodeRoutineToBool vars instrs))
+            (lift trySort microcodeR)
             (Pretty.printSemanticsError >> Core.Pretty.printUnstyled)
 
     [<Test>]


### PR DESCRIPTION
This PRQ does three big things:

1) Amends the definition of `Assign` in `Microcode` to allow assignment to nothing.  This represents a `havoc` and implements #104.
2) Rewrites the command framer to work on `Microcode` instead of `BoolExpr`, implementing #112.
3) Adds `Microcode` to `CommandSemantics`, freeing it up for use in backends directly instead of relying on the low-level Boolean semantics or high-level `PrimCommand` representation.

Most changes are internal for now.