### PR TITLE
Make traversals generic in the variable being collected

### DIFF
--- a/Command.fs
+++ b/Command.fs
@@ -73,12 +73,13 @@ module Traversal =
     /// <typeparam name="Error">
     ///     The type of any returned errors.
     /// </typeparam>
+    /// <typeparam name="Var">The type of context variables.</typeparam>
     /// <returns>The lifted <see cref="Traversal"/>.</returns>
     let tliftOverCommandSemantics
-      (traversal : Traversal<Expr<'SrcVar>, Expr<'DstVar>, 'Error>)
+      (traversal : Traversal<Expr<'SrcVar>, Expr<'DstVar>, 'Error, 'Var>)
       : Traversal<CommandSemantics<BoolExpr<'SrcVar>>,
                   CommandSemantics<BoolExpr<'DstVar>>,
-                  'Error> =
+                  'Error, 'Var> =
         fun ctx { Cmd = c; Semantics = s } ->
             let swapSemantics s' = { Cmd = c; Semantics = s' }
             let result = traverseBoolAsExpr traversal ctx s
@@ -134,7 +135,7 @@ module Queries =
     /// Retrieves the type annotated vars from the arguments to a
     /// command as a list
     let commandArgs cmd =
-        let f c = List.map SVExprVars c.Args
+        let f c = List.map symExprVars c.Args
         let vars = collect (concatMap f cmd)
         lift Set.unionMany vars
 

--- a/Grasshopper.fs
+++ b/Grasshopper.fs
@@ -107,7 +107,7 @@ module Pretty =
     /// Get the set of accessed variables. 
     let findVarsGrass (zterm : Backends.Z3.Types.ZTerm) : seq<MarkedVar> = 
         BAnd [zterm.SymBool.WPre; zterm.SymBool.Goal; zterm.SymBool.Cmd] 
-        |> findMarkedVars (tliftToBoolSrc (tliftToExprDest collectSymMarkedVars)) 
+        |> findVars (tliftToBoolSrc (tliftToExprDest collectSymVars)) 
         |> lift (Set.map valueOf >> Set.toSeq) 
         |> returnOrFail
 

--- a/GuardedView.fs
+++ b/GuardedView.fs
@@ -594,10 +594,11 @@ module Traversal =
     /// <typeparam name="Error">
     ///     The type of any returned errors.
     /// </typeparam>
+    /// <typeparam name="Var">The type of context variables.</typeparam>
     /// <returns>The lifted <see cref="Traversal"/>.</returns>
     let tliftOverGFunc
-      (traversal : Traversal<Expr<'SrcVar>, Expr<'DstVar>, 'Error>)
-      : Traversal<GFunc<'SrcVar>, GFunc<'DstVar>, 'Error> =
+      (traversal : Traversal<Expr<'SrcVar>, Expr<'DstVar>, 'Error, 'Var>)
+      : Traversal<GFunc<'SrcVar>, GFunc<'DstVar>, 'Error, 'Var> =
         fun ctx { Cond = cond; Item = item } ->
             let tBool = traverseBoolAsExpr traversal
             let tFunc = tliftOverFunc traversal
@@ -625,10 +626,11 @@ module Traversal =
     /// <typeparam name="Error">
     ///     The type of any returned errors.
     /// </typeparam>
+    /// <typeparam name="Var">The type of context variables.</typeparam>
     /// <returns>The lifted <see cref="Traversal"/>.</returns>
     let tliftOverIteratedGFunc
-      (traversal : Traversal<Expr<'SrcVar>, Expr<'DstVar>, 'Error>)
-      : Traversal<IteratedGFunc<'SrcVar>, IteratedGFunc<'DstVar>, 'Error> =
+      (traversal : Traversal<Expr<'SrcVar>, Expr<'DstVar>, 'Error, 'Var>)
+      : Traversal<IteratedGFunc<'SrcVar>, IteratedGFunc<'DstVar>, 'Error, 'Var> =
         fun ctx { Iterator = iter ; Func = func } ->
             let tInt = traverseIntAsExpr traversal
             let tGFunc = tliftOverGFunc traversal
@@ -653,12 +655,13 @@ module Traversal =
     /// <typeparam name="Error">
     ///     The type of any returned errors.
     /// </typeparam>
+    /// <typeparam name="Var">The type of context variables.</typeparam>
     /// <returns>The lifted <see cref="Traversal"/>.</returns>
     let tliftOverTerm
-      (traversal : Traversal<Expr<'SrcVar>, Expr<'DstVar>, 'Error>)
+      (traversal : Traversal<Expr<'SrcVar>, Expr<'DstVar>, 'Error, 'Var>)
       : Traversal<Term<BoolExpr<'SrcVar>, GView<'SrcVar>, VFunc<'SrcVar>>,
                   Term<BoolExpr<'DstVar>, GView<'DstVar>, VFunc<'DstVar>>,
-                  'Error> =
+                  'Error, 'Var> =
         fun ctx { Cmd = c ; WPre = w; Goal = g } ->
             let tCmd = traverseBoolAsExpr traversal
             let tWPre = tchainM (tliftOverGFunc traversal) id
@@ -688,12 +691,13 @@ module Traversal =
     /// <typeparam name="Error">
     ///     The type of any returned errors.
     /// </typeparam>
+    /// <typeparam name="Var">The type of context variables.</typeparam>
     /// <returns>The lifted <see cref="Traversal"/>.</returns>
     let tliftOverCmdTerm
-      (traversal : Traversal<Expr<'SrcVar>, Expr<'DstVar>, 'Error>)
+      (traversal : Traversal<Expr<'SrcVar>, Expr<'DstVar>, 'Error, 'Var>)
       : Traversal<CmdTerm<BoolExpr<'SrcVar>, GView<'SrcVar>, VFunc<'SrcVar>>,
                   CmdTerm<BoolExpr<'DstVar>, GView<'DstVar>, VFunc<'DstVar>>,
-                  'Error> =
+                  'Error, 'Var> =
         fun ctx { Cmd = c ; WPre = w; Goal = g } ->
             let tCmd = tliftOverCommandSemantics traversal
             let tWPre = tchainM (tliftOverGFunc traversal) id

--- a/GuardedViewTests.fs
+++ b/GuardedViewTests.fs
@@ -29,7 +29,7 @@ module Tests =
     /// <summary>
     ///     Test traversal for position-based substitution.
     /// </summary>
-    let positionTestSub : Traversal<Expr<Var>, Expr<Var>, unit> =
+    let positionTestSub : Traversal<Expr<Var>, Expr<Var>, unit, unit> =
         let ptsVar ctx tv =
             let exp =
                 match (typeOf tv) with
@@ -69,7 +69,7 @@ module Tests =
         /// </summary>
         let check
           (expected : Term<BoolExpr<Var>, GView<Var>, Func<Expr<Var>>>)
-          (pos : TraversalContext)
+          (pos : TraversalContext<unit>)
           (gv : Term<BoolExpr<Var>, GView<Var>, Func<Expr<Var>>>) : unit =
             let trav = tliftOverTerm positionTestSub
             let result = trav pos gv
@@ -89,7 +89,7 @@ module Tests =
                             [ Typed.Int (IAdd [ IInt 0L; IInt 0L ]) ] ]
                   Goal =
                     (vfunc "bar" [ Typed.Int (IInt 1L); Typed.Bool BTrue ]) }
-                Context.positive
+                (Context.positive ())
                 { Cmd =
                     BAnd
                         [ bEq (BVar "foo") (BVar "bar")
@@ -120,7 +120,7 @@ module Tests =
                             [ Typed.Int (IAdd [ IInt 1L; IInt 1L ]) ] ]
                   Goal =
                     vfunc "bar" [ Typed.Int (IInt 0L); Typed.Bool BFalse ] }
-                Context.negative
+                (Context.negative ())
                 { Cmd =
                     BAnd
                         [ bEq (BVar "foo") (BVar "bar")
@@ -149,7 +149,7 @@ module Tests =
         /// </summary>
         let check
           (expected : GFunc<Var>)
-          (pos : TraversalContext)
+          (pos : TraversalContext<unit>)
           (gv : GFunc<Var>) : unit =
             let trav = tliftOverGFunc positionTestSub
             let result = trav pos gv
@@ -161,7 +161,7 @@ module Tests =
         let ``GFunc substitution in +ve case works properly`` () =
             check
                 (gfunc BFalse "bar" [ Typed.Int (IInt 1L); Typed.Bool BTrue ] )
-                Context.positive
+                (Context.positive ())
                 (gfunc (BVar "foo") "bar"
                     [ Typed.Int (IVar "baz"); Typed.Bool (BVar "fizz") ] )
 
@@ -169,7 +169,7 @@ module Tests =
         let ``GFunc substitution in -ve case works properly`` () =
             check
                 (gfunc BTrue "bar" [ Typed.Int (IInt 0L); Typed.Bool BFalse ] )
-                Context.negative
+                (Context.negative ())
                 (gfunc (BVar "foo") "bar"
                     [ Typed.Int (IVar "baz"); Typed.Bool (BVar "fizz") ])
 
@@ -187,7 +187,7 @@ module Tests =
         /// </summary>
         let check
           (expected : GView<Var>)
-          (pos : TraversalContext)
+          (pos : TraversalContext<unit>)
           (gv : GView<Var>) : unit =
             let trav = tchainM (tliftOverGFunc positionTestSub) id
             let result = trav pos gv
@@ -197,11 +197,11 @@ module Tests =
 
         [<Test>]
         let ``+ve empty GView substitution is a no-op`` () =
-            check Multiset.empty Context.positive Multiset.empty
+            check Multiset.empty (Context.positive ()) Multiset.empty
 
         [<Test>]
         let ``-ve empty GView substitution is a no-op`` () =
-            check Multiset.empty Context.negative Multiset.empty
+            check Multiset.empty (Context.negative ()) Multiset.empty
 
         [<Test>]
         let ``Singleton GView substitution in +ve case works properly`` () =
@@ -210,7 +210,7 @@ module Tests =
                     (gfunc BFalse "bar"
                         [ Typed.Int (IInt 1L)
                           Typed.Bool BTrue ] ))
-                Context.positive
+                (Context.positive ())
                 (Multiset.singleton
                     (gfunc (BVar "foo") "bar"
                         [ Typed.Int (IVar "baz")
@@ -222,7 +222,7 @@ module Tests =
                 (Multiset.singleton
                     (gfunc BTrue "bar"
                         [ Typed.Int (IInt 0L); Typed.Bool BFalse ] ))
-                Context.negative
+                (Context.negative ())
                 (Multiset.singleton
                     (gfunc (BVar "foo") "bar"
                         [ Typed.Int (IVar "baz")
@@ -238,7 +238,7 @@ module Tests =
                       gfunc (BGt (IInt 0L, IInt 0L)) "barbaz"
                         [ Typed.Int
                               (IAdd [ IInt 1L; IInt 1L ]) ] ] )
-                Context.positive
+                (Context.positive ())
                 (Multiset.ofFlatList
                     [ gfunc (BVar "foo") "bar"
                         [ Typed.Int (IVar "baz")
@@ -255,7 +255,7 @@ module Tests =
                         [ Typed.Int (IInt 0L); Typed.Bool BFalse ]
                       gfunc (BGt (IInt 1L, IInt 1L)) "barbaz"
                         [ Typed.Int (IAdd [ IInt 0L; IInt 0L ]) ] ] )
-                Context.negative
+                (Context.negative ())
                 (Multiset.ofFlatList
                     [ gfunc (BVar "foo") "bar"
                         [ Typed.Int (IVar "baz"); Typed.Bool (BVar "fizz") ]

--- a/Instantiate.fs
+++ b/Instantiate.fs
@@ -180,13 +180,14 @@ module Pretty =
 /// <param name="dfunc">
 ///     The <c>DFunc</c> into which we are substituting.
 /// </param>
+/// <typeparam name="Var">The type of context variables.</typeparam>
 /// <returns>
 ///     A <see cref="Traversal"/> performing the above substitutions.
 /// </returns>
 let paramSubFun
   (vfunc : VFunc<Sym<MarkedVar>>)
   (dfunc : DFunc)
-  : Traversal<TypedVar, Expr<Sym<MarkedVar>>, Error> =
+  : Traversal<TypedVar, Expr<Sym<MarkedVar>>, Error, 'Var> =
     let dpars = dfunc.Params
     let fpars = vfunc.Params
     let pmap = Map.ofSeq (Seq.map2 (fun par up -> valueOf par, up) dpars fpars)
@@ -426,13 +427,13 @@ module Phase =
                approximated by removing certain part-symbolic parts of them.
 
                Commands appear on the LHS of a term, thus in -ve position. *)
-            tryApproxInBool Context.negative
+            tryApproxInBool (Context.negative ())
               (Starling.Core.Command.SymRemove.removeSym cmdSemantics)
 
         // Weakest precondition is on the LHS of a term, thus in -ve position.
-        let mapWPre wPre = tryApproxInBool Context.negative wPre
+        let mapWPre wPre = tryApproxInBool (Context.negative ()) wPre
         // Goal is on the RHS of a term, thus in +ve position.
-        let mapGoal goal = tryApproxInBool Context.positive goal
+        let mapGoal goal = tryApproxInBool (Context.positive ()) goal
 
         tryMapTerm mapCmd mapWPre mapGoal symterm
 

--- a/MuZ3Backend.fs
+++ b/MuZ3Backend.fs
@@ -533,7 +533,7 @@ module Translator =
       (head : VFunc<'Var>)
       : Result<Z3.BoolExpr option, Error> =
         // We use a _lot_ of traversals in this function!
-        let toVarTrav : Traversal<CTyped<'Var>, Expr<Var>, Error> =
+        let toVarTrav : Traversal<CTyped<'Var>, Expr<Var>, Error, unit> =
             tliftToExprDest
                 (tliftOverCTyped (ignoreContext (toVar >> ok)))
         let toVarTravExpr = tliftToExprSrc toVarTrav
@@ -541,7 +541,7 @@ module Translator =
         let toVarTravGView = tchainM (tliftOverGFunc toVarTravExpr) id
         let toVarTravVFunc = tliftOverFunc toVarTravExpr
 
-        let findVarTrav : Traversal<TypedVar, Expr<Var>, Error> =
+        let findVarTrav : Traversal<TypedVar, Expr<Var>, Error, Var> =
             tliftToExprDest collectVars
         let findVarTravExpr = tliftToExprSrc findVarTrav
         let findVarTravBool = tliftToBoolSrc findVarTrav

--- a/Optimiser.fs
+++ b/Optimiser.fs
@@ -952,7 +952,7 @@ module Term =
     let rec (|ConstantBoolFunction|_|) (x : BoolExpr<Sym<MarkedVar>>)
       : MarkedVar option =
         x
-        |> findMarkedVars (tliftToBoolSrc (tliftToExprDest collectSymMarkedVars))
+        |> findVars (tliftToBoolSrc (tliftToExprDest collectSymVars))
         |> okOption |> Option.map (Seq.map valueOf) |> Option.bind onlyOne
 
     /// Partial pattern that matches a Boolean expression in terms of exactly one /
@@ -960,7 +960,7 @@ module Term =
     let rec (|ConstantIntFunction|_|) (x : IntExpr<Sym<MarkedVar>>)
       : MarkedVar option =
         x
-        |> findMarkedVars (tliftToIntSrc (tliftToExprDest collectSymMarkedVars))
+        |> findVars (tliftToIntSrc (tliftToExprDest collectSymVars))
         |> okOption |> Option.map (Seq.map valueOf) |> Option.bind onlyOne
 
     /// Finds all instances of the pattern `x!after = f(x!before)` in an
@@ -1045,7 +1045,7 @@ module Term =
     let afterSubs
       (isubs : Map<Var, IntExpr<Sym<MarkedVar>>>)
       (bsubs : Map<Var, BoolExpr<Sym<MarkedVar>>>)
-      : Traversal<CTyped<MarkedVar>, Expr<Sym<MarkedVar>>, TermOptError> =
+      : Traversal<CTyped<MarkedVar>, Expr<Sym<MarkedVar>>, TermOptError, unit> =
         (* TODO(CaptainHayashi): just use one Map<Var, Expr<_>>, and raise a
            traversal error if we get the wrong type out. *)
         let switch =
@@ -1061,7 +1061,7 @@ module Term =
     let interSubs
       (isubs : Map<bigint * Var, IntExpr<Sym<MarkedVar>>>)
       (bsubs : Map<bigint * Var, BoolExpr<Sym<MarkedVar>>>)
-      : Traversal<CTyped<MarkedVar>, Expr<Sym<MarkedVar>>, TermOptError> =
+      : Traversal<CTyped<MarkedVar>, Expr<Sym<MarkedVar>>, TermOptError, unit> =
         (* TODO(CaptainHayashi): just use one Map<Var, Expr<_>>, and raise a
            traversal error if we get the wrong type out. *)
         let switch =

--- a/SymbolicTests.fs
+++ b/SymbolicTests.fs
@@ -57,7 +57,7 @@ module PostStateRewrite =
 module BoolApprox =
     let check
       (expected : BoolExpr<Sym<MarkedVar>>)
-      (ctx : TraversalContext)
+      (ctx : TraversalContext<unit>)
       (expr : BoolExpr<Sym<MarkedVar>>)
       : unit =
         let result = tliftToBoolSrc approx ctx expr
@@ -70,7 +70,7 @@ module BoolApprox =
             (BAnd
                 [ bEq (sbBefore "foo") (sbAfter "bar")
                   BGt (siBefore "baz", IInt 1L) ] )
-            Context.positive
+            (Context.positive ())
             (BAnd
                 [ bEq (sbBefore "foo") (sbAfter "bar")
                   BGt (siBefore "baz", IInt 1L) ] )
@@ -79,21 +79,21 @@ module BoolApprox =
     let ``Rewrite +ve param-less Bool symbol to false`` () =
         check
             BFalse
-            Context.positive
+            (Context.positive ())
             (BVar (Sym { Sentence = [ SymString "test" ]; Args = ([] : SMExpr list) } ))
 
     [<Test>]
     let ``Rewrite -ve param-less Bool symbol to true`` () =
         check
             BTrue
-            Context.negative
+            (Context.negative ())
             (BVar (Sym { Sentence = [ SymString "test" ]; Args = ([] : SMExpr list) } ))
 
     [<Test>]
     let ``Rewrite +ve Reg-params Bool symbol to false`` () =
         check
             BFalse
-            Context.positive
+            (Context.positive ())
             (BVar
                 (Sym
                     { Sentence = [ SymString "test" ]
@@ -105,7 +105,7 @@ module BoolApprox =
     let ``Rewrite -ve Reg-params Bool symbol to true`` () =
         check
             BTrue
-            Context.negative
+            (Context.negative ())
             (BVar
                 (Sym
                     { Sentence = [ SymString "test" ]
@@ -117,7 +117,7 @@ module BoolApprox =
     let ``Rewrite +ve implication correctly`` () =
         check
             (BImplies (BTrue, BFalse))
-            Context.positive
+            (Context.positive ())
             (BImplies
                 (BVar
                     (Sym
@@ -136,7 +136,7 @@ module BoolApprox =
     let ``Rewrite -ve implication correctly`` () =
         check
             (BImplies (BFalse, BTrue))
-            Context.negative
+            (Context.negative ())
             (BImplies
                 (BVar
                     (Sym
@@ -163,8 +163,7 @@ module FindSMVarsCases =
       (expected : CTyped<MarkedVar> list)
       (expr : Expr<Sym<MarkedVar>>)
       : unit =
-        let result =
-            findMarkedVars (tliftOverExpr collectSymMarkedVars) expr
+        let result = findVars (tliftOverExpr collectSymVars) expr
 
         assertOkAndEqual (Set.ofList expected) result
             (printTraversalError (fun () -> String "?" ) >> printUnstyled)

--- a/View.fs
+++ b/View.fs
@@ -377,9 +377,10 @@ module Traversal =
     /// <typeparam name="Error">
     ///     The type of any returned errors.
     /// </typeparam>
+    /// <typeparam name="Var">The type of context variables.</typeparam>
     /// <returns>The lifted <see cref="Traversal"/>.</returns>
     let tliftOverFunc
-      (traversal : Traversal<'SrcPar, 'DstPar, 'Error>)
-      : Traversal<Func<'SrcPar>, Func<'DstPar>, 'Error> =
+      (traversal : Traversal<'SrcPar, 'DstPar, 'Error, 'Var>)
+      : Traversal<Func<'SrcPar>, Func<'DstPar>, 'Error, 'Var> =
         fun context { Name = n ; Params = ps } ->
             tchainL traversal (func n) context ps


### PR DESCRIPTION
Small internal change, trades off some type complexity for less boilerplate.

Most of this is boring rewriting apart from the deletions in `Symbolic` and `Traversal`.

Fixes #113.