### PR TITLE
Change symbolic syntax.

### DIFF
--- a/AST.fs
+++ b/AST.fs
@@ -292,7 +292,9 @@ module Pretty =
     ///     The <see cref="Doc"/> resulting from printing <paramref name="s"/>.
     /// </returns> 
     and printSymbolic (s : Symbolic<Expression>) : Doc =
-        String "%" <-> braced (printSymbolic s)
+        String "%"
+        <->
+        braced (Starling.Core.Symbolic.Pretty.printSymbolic printExpression s)
 
     /// Pretty-prints views.
     let rec printView : View -> Doc =

--- a/AST.fs
+++ b/AST.fs
@@ -292,9 +292,7 @@ module Pretty =
     ///     The <see cref="Doc"/> resulting from printing <paramref name="s"/>.
     /// </returns> 
     and printSymbolic (s : Symbolic<Expression>) : Doc =
-        String "%"
-        <-> printSymbolicSentence s.Sentence
-        <-> parened (commaSep (List.map printExpression s.Args))
+        String "%" <-> braced (printSymbolic s)
 
     /// Pretty-prints views.
     let rec printView : View -> Doc =

--- a/Collator.fs
+++ b/Collator.fs
@@ -165,8 +165,12 @@ module ParamDesugar =
         // TODO(CaptainHayashi): this is a royal mess...
         let rewriteVar n = withDefault n (rmap.TryFind n)
 
-        let rec rewriteSymbolic { Sentence = s; Args = xs } =
-            { Sentence = s; Args = List.map rewriteExpression xs }
+        let rec rewriteSymbolic s =
+            List.map
+                (function
+                 | SymArg a -> SymArg (rewriteExpression a)
+                 | SymString t -> SymString t)
+                s
         and rewriteExpression expr =
             let rewriteExpression' =
                 function

--- a/CommandTests.fs
+++ b/CommandTests.fs
@@ -128,19 +128,19 @@ module Observable =
     [<Test>]
     let ``symbolics with are observable after the empty command`` () =
         check true
-            [ SymC { Sentence = [ SymString "foo" ]; Args = [] } ]
+            [ SymC [ SymString "foo" ] ]
             []
 
     [<Test>]
     let ``symbolics are observable after a local stored command`` () =
         check true
-            [ SymC { Sentence = [ SymString "foo" ]; Args = [] } ]
+            [ SymC [ SymString "foo" ] ]
             [ command "Foo" [ normalIntExpr (siVar "y") ] [ normalBoolExpr (sbVar "x") ] ]
 
     [<Test>]
     let ``symbolics are observable after a nonlocal stored command`` () =
         check true
-            [ SymC { Sentence = [ SymString "foo" ]; Args = [] } ]
+            [ SymC [ SymString "foo" ] ]
             [ command "Foo" [ normalIntExpr (siVar "g") ] [ normalBoolExpr (sbVar "x") ] ]
 
     [<Test>]

--- a/Examples/PassGH/arc.cvf
+++ b/Examples/PassGH/arc.cvf
@@ -20,43 +20,43 @@ thread Int c, pval;
 method init() {
   {| emp |}
     // TODO: broken local command syntax.
-    ret = %{new ArcNode}();
-    <%{#1.count := 1}(ret)>;
+    ret = %{new ArcNode};
+    <%{[|ret|].count := 1}>;
   {| arc(ret) |}
 }
 
 method clone(ArcNode x) {
   {| arc(x) |}
-    <%{#1.count := #1.count + 1}(x)>;
+    <%{[|x|].count := [|x|].count + 1}>;
   {| arc(x) * arc(x) |}
 }
 
 method print(ArcNode x) {
   {| arc(x) |}
     // TODO: broken local command syntax.
-    pval = %{ #1.val }(x);
+    pval = %{ [|x|].val };
   {| arc(x) |}
 }
 
 method drop(ArcNode x) {
   {| arc(x) |}
     // TODO: broken local command syntax.
-    c = %{ #1.count }(x);
-    <%{ #1.count := #1.count - 1 }(x)>;
+    c = %{ [|x|].count };
+    <%{ [|x|].count := [|x|].count - 1 }>;
   {| countCopy(x, c) |}
     if (c == 1) {
       {| countCopy(x, 1) |}
-         < %{ free(#1) }(x) >;
+         < %{ free([|x|]) } >;
       {| emp |}
     }
   {| emp |}
 }
 
 constraint iter[n] arc(x) ->
-    n > 0 => %{ #1 in ArcFoot && #2 <= #1.count}(x, n);
+    n > 0 => %{ [|x|] in ArcFoot && [|n|] <= [|x|].count};
 
 constraint countCopy(x, c) ->
-    c == 1 => %{ #1 in ArcFoot && #1.count == 0}(x);
+    c == 1 => %{ [|x|] in ArcFoot && [|x|].count == 0};
 
 constraint countCopy(x, m) * countCopy(y, n) ->
     x == y => ((m != 1) || (n != 1));

--- a/Examples/PassGH/clhLock.cvf
+++ b/Examples/PassGH/clhLock.cvf
@@ -15,15 +15,15 @@ view holdLock(Node x, Node xp);
 
 method lock(Node mynode) {
   {| loose(mynode, false) |}
-    < %{ #1.lock := true }(mynode) >;
+    < %{ [|mynode|].lock := true } >;
   {| loose(mynode, true) |}
     <{ mypred = tail;
        tail = mynode;
-       %{#1.pred := #2}(tail, mypred); }>;  // Ghost code
+       %{[|tail|].pred := [|mypred|]}; }>;  // Ghost code
   {| queued(mynode, mypred) |}
     do {
       {| queued(mynode, mypred) |}
-        test = %{ #1.lock }(mypred);
+        test = %{ [|mypred|].lock };
       {| if test then queued(mynode, mypred) else holdLock(mynode, mypred) |}
     } while (test);
   {| holdLock(mynode, mypred) |}
@@ -31,8 +31,8 @@ method lock(Node mynode) {
 
 method unlock(Node mynode, Node mypred) {
   {| holdLock(mynode, mypred) |}
-    <{ %{ #1.lock := false }(mynode);
-       %{ #1.pred := null }(mynode);  // Ghost code
+    <{ %{ [|mynode|].lock := false };
+       %{ [|mynode|].pred := null };  // Ghost code
        head = mynode;  // Ghost code
        }>;
   {| loose(mypred, false) |}
@@ -40,17 +40,17 @@ method unlock(Node mynode, Node mypred) {
   {| loose(mynode, false) |}
 }
 
-constraint emp -> %{ CLHfoot(Foot, #1, #2) }(head, tail);
+constraint emp -> %{ CLHfoot(Foot, [|head|], [|tail|]) };
 
-constraint queued(a, ap) -> %{ queuedG(Foot, #1, #2, #3, #4) }(a, head, tail, ap);
+constraint queued(a, ap) -> %{ queuedG(Foot, [|a|], [|head|], [|tail|], [|ap|]) };
 constraint queued(a, ap) * queued(b, bp) -> a != b;
 
 // Loose means the node is unlinked from the queue.
-constraint loose(a, l) -> %{ looseG(Foot, #1, #2) && #1.lock == #3 }(a, head, l);
+constraint loose(a, l) -> %{ looseG(Foot, [|a|], [|head|]) && [|a|].lock == [|l|] };
 constraint loose(a, al) * loose(b, bl) -> a != b;
 // loose and queued are contradictory by definition
 
-constraint holdLock(a, ap) -> %{ queuedG(Foot, #1, #2, #3, #4) && #4 == #2 }(a, head, tail, ap);
+constraint holdLock(a, ap) -> %{ queuedG(Foot, [|a|], [|head|], [|tail|], [|ap|]) && [|ap|] == [|head|] };
 
 constraint holdLock(a, ap) * queued(b, bp) -> a != b;
 constraint holdLock(a, ap) * holdLock(b, bp) -> false;

--- a/Examples/PassGH/lclist.cvf
+++ b/Examples/PassGH/lclist.cvf
@@ -19,56 +19,56 @@ method deleteVal(int v) {
   {| wf(v) |}
     <prev = head>;
   {| wf(v) * isHead(prev) |}
-   <{ %{ waitLock(#1); takeLock(#1) }(prev); }>;
+   <{ %{ waitLock([|prev|]); takeLock([|prev|]) }; }>;
   {| wf(v) * has1LockAnon(prev) * isHead(prev) |}
-   curr = (%{ #1.next }(prev));
+   curr = %{ [|prev|].next };
   {| wf(v) * has1Lock(prev, curr) * isHead(prev) |}
-   <{ %{ waitLock(#1); takeLock(#1) }(curr); }>;
+   <{ %{ waitLock([|curr|]); takeLock([|curr|]) }; }>;
   {| wf(v) * has2Lock(prev, curr) |}
-   cv = (%{ #1.val }(curr));
+   cv = %{ [|curr|].val };
   {| wf(v) * has2Lock(prev,curr) * isVal(curr, cv) |}
     while (cv < v ) {
       {| wf(v) * wf(cv) * has2Lock(prev, curr) * isVal(curr, cv) |}
-        <%{ releaseLock(#1) }(prev)>;
+        <%{ releaseLock([|prev|]) }>;
       {| wf(v) * wf(cv) * has1LockAnon(curr) * isVal(curr, cv) |}
         prev = curr;
-        curr = (%{ #1.next }(curr));
+        curr = %{ [|curr|].next };
       {| wf(v) * wf(cv) * has1Lock(prev, curr) * isVal(prev,cv) |}
-        <{ %{ waitLock(#1); takeLock(#1) }(curr); }>;
+        <{ %{ waitLock([|curr|]); takeLock([|curr|]) }; }>;
       {| wf(v) * has2Lock(prev, curr) |}
-        cv = (%{ #1.val }(curr));
+        cv = %{ [|curr|].val };
       {| wf(v) * has2Lock(prev, curr) * isVal(curr,cv) |}
     }
   {| wf(v) * has2Lock(prev, curr) * isVal(curr, cv) |}
-    if ( cv == v) {
+    if (cv == v) {
       {| wf(cv) * has2Lock(prev, curr) * isVal(curr, cv) |}
         // Merged these two to avoid dangling nodes
-        <{ %{ #1.next := #2.next }(prev, curr);
-           %{ disposeNode(#1) }(curr); }>;
+        <{ %{ [|prev|].next := [|curr|].next };
+           %{ disposeNode([|curr|]) }; }>;
       {| has1LockAnon(prev) |}
     }
     else {
       {| has2Lock(prev, curr) |}
-        <%{ releaseLock(#1)}(curr)>;
+        <%{ releaseLock([|curr|])}>;
       {| has1LockAnon(prev) |}
     }
   {| has1LockAnon(prev) |}
-    <%{ releaseLock(#1) }(prev)>;
+    <%{ releaseLock([|prev|]) }>;
   {| emp |}
 }
 
-constraint emp -> %{ isListG(X, #1,#2) }(head,ub);
+constraint emp -> %{ isListG(X, [|head|], [|ub|]) };
 
 constraint wf(v)      ->  v < ub;
 constraint isHead(x)  ->  x == head;
 
-constraint has1Lock(a,b)    ->  %{ has1LockG(X, #1,#2) }(a,b);
-constraint has1LockAnon(a)  ->  %{ exists e: Node :: has1LockG(X, #1, e) }(a);
-constraint has2Lock(a,b)    ->  %{ exists e: Node :: has2LockG(X, #1, #2, e) }(a,b);
+constraint has1Lock(a,b)    ->  %{ has1LockG(X, [|a|], [|b|]) };
+constraint has1LockAnon(a)  ->  %{ exists e: Node :: has1LockG(X, [|a|], e) };
+constraint has2Lock(a,b)    ->  %{ exists e: Node :: has2LockG(X, [|a|], [|b|], e) };
 
-constraint has1Lock(a, b)  * isVal(node,v)  ->  a == node => %{ isValG(X,#1,#2) }(node, v);
-constraint has1LockAnon(a) * isVal(node,v)  ->  a == node => %{ isValG(X,#1,#2) }(node, v);
-constraint has2Lock(a, b)  * isVal(node,v)  ->  b == node => %{ isValG(X,#1,#2) }(node, v);
+constraint has1Lock(a, b)  * isVal(node,v)  ->  a == node => %{ isValG(X,[|node|],[|v|]) };
+constraint has1LockAnon(a) * isVal(node,v)  ->  a == node => %{ isValG(X,[|node|],[|v|]) };
+constraint has2Lock(a, b)  * isVal(node,v)  ->  b == node => %{ isValG(X,[|node|],[|v|]) };
 
 // Constraints on view interactions
 constraint has1Lock(a,b)   * has1Lock(c,d)    ->  a != c;

--- a/Examples/PassGH/spinLock.cvf
+++ b/Examples/PassGH/spinLock.cvf
@@ -13,9 +13,9 @@ view newLock(Lock x), holdLock(Lock x), isLock(Lock x);
 
 method newLock() {
   {| emp |}
-    ret = %{new Lock}();
+    ret = %{new Lock};
   {| newLock(ret) |}
-    <%{#1.lock := false}(ret)>;
+    <%{[|ret|].lock := false}>;
   {| isLock(ret) |}
 }
 
@@ -25,7 +25,7 @@ method lock(Lock x) {
       {| isLock(x) |}
         test = false;
       {| if test == false then isLock(x) else False() |}
-        test = %{ CAS_to_true(#1) }(x);
+        test = %{ CAS_to_true([|x|]) };
       {| if test == false then isLock(x) else holdLock(x) |}
     } while (test == false);
   {| holdLock(x) |}
@@ -33,7 +33,7 @@ method lock(Lock x) {
 
 method unlock(Lock x) {
   {| holdLock(x) |}
-    <%{#1.lock := false}(x)>;
+    <%{[|x|].lock := false}>;
   {| isLock(x) |}
 }
 
@@ -47,9 +47,9 @@ method split(Lock x) {
 view False();
 constraint False() -> false;
 
-constraint holdLock(x)  ->  %{ #1 in LockFoot && #1.lock == true }(x);
-constraint isLock(x)    ->  %{ #1 in LockFoot }(x);
-constraint newLock(x)   ->  %{ #1 in LockFoot }(x);
+constraint holdLock(x)  ->  %{ [|x|] in LockFoot && [|x|].lock };
+constraint isLock(x)    ->  %{ [|x|] in LockFoot };
+constraint newLock(x)   ->  %{ [|x|] in LockFoot };
 
 constraint isLock(x)   * newLock(y)   ->  x != y;
 constraint holdLock(x) * newLock(y)   ->  x != y;

--- a/Examples/PassGH/ticketLock.cvf
+++ b/Examples/PassGH/ticketLock.cvf
@@ -13,20 +13,20 @@ view newLock(Lock x), holdTick(Lock x, int t), holdLock(Lock x), isLock(Lock x);
 
 method newLock() {
   {| emp |}
-    ret = %{new Lock}();
+    ret = %{new Lock};
   {| newLock(ret) |} 
-    <%{#1.ticket := 0; #1.serving := 0}(ret)>;
+    <%{[|ret|].ticket := 0; [|ret|].serving := 0}>;
   {| isLock(ret) |}
 }
 
 method lock(Lock x) {
   {| isLock(x) |}
-    t = %{ #1.ticket }(x);
-    <%{ #1.ticket := #1.ticket + 1 }(x)>;
+    t = %{ [|x|].ticket };
+    <%{ [|x|].ticket := [|x|].ticket + 1 }>;
   {| holdTick(x, t) |}
     do {
       {| holdTick(x, t) |}
-        s = %{ #1.serving }(x);
+        s = %{ [|x|].serving };
       {| if s == t then holdLock(x) else holdTick(x, t) |}
     } while (s != t);
   {| holdLock(x) |}
@@ -34,7 +34,7 @@ method lock(Lock x) {
 
 method unlock(Lock x) {
   {| holdLock(x) |}
-    <%{#1.serving := #1.serving + 1}(x)>;
+    <%{[|x|].serving := [|x|].serving + 1}>;
   {| isLock(x) |}
 }
 
@@ -44,12 +44,12 @@ method split(Lock x) {
   {| isLock(x) * isLock(x) |}
 }
 
-constraint newLock(x)     -> %{ #1 in LockFoot }(x);
-constraint isLock(x)      -> %{ #1 in LockFoot && #1.ticket >= #1.serving }(x);
-constraint holdTick(x, t) -> %{ #1 in LockFoot && #1.ticket >= #1.serving && #1.ticket > #2 }(x, t);
-constraint holdLock(x)    -> %{ #1 in LockFoot && #1.ticket >  #1.serving }(x);
+constraint newLock(x)     -> %{ [|x|] in LockFoot };
+constraint isLock(x)      -> %{ [|x|] in LockFoot && [|x|].ticket >= [|x|].serving };
+constraint holdTick(x, t) -> %{ [|x|] in LockFoot && [|x|].ticket >= [|x|].serving && [|x|].ticket > [|t|] };
+constraint holdLock(x)    -> %{ [|x|] in LockFoot && [|x|].ticket >  [|x|].serving };
 
-constraint holdLock(x)     * holdTick(y, t)  -> x != y || %{ #1.serving != #2 }(y, t);
+constraint holdLock(x)     * holdTick(y, t)  -> x != y || %{ [|y|].serving != [|t|] };
 constraint holdTick(x, ta) * holdTick(y, tb) -> x != y || ta != tb;
 
 constraint holdLock(x)    * holdLock(y) -> x != y;

--- a/Grasshopper.fs
+++ b/Grasshopper.fs
@@ -261,8 +261,11 @@ module Pretty =
                     x)
 
     let printSymbolicGrass (pArg : 'Arg -> Doc) (s : Symbolic<'Arg>) : Doc =
-        let { Sentence = ws; Args = xs } = s
-        printInterpolatedSymbolicSentence pArg ws xs
+        let p =
+            function
+            | SymString s -> String s
+            | SymArg a -> pArg a
+        hjoin (List.map p s)
 
     /// Pretty-prints a symbolic sentence
     let rec printSymGrass (pReg : 'Var -> Doc) (sym : Sym<'Var>) : Doc =

--- a/ModellerTests.fs
+++ b/ModellerTests.fs
@@ -323,15 +323,15 @@ module Atomics =
             (command' "!BLoad" ast [ normalBoolExpr (sbVar "baz") ] [ normalBoolExpr (sbVar "y") ])
 
     [<Test>]
-    let ``model symbolic store <x = %{foo}(baz)>`` () =
+    let ``model symbolic store <x = %{foo [|baz|]}>`` () =
         let ast =
             freshNode
                 (Fetch
                     (freshNode (Identifier "x"),
                      freshNode
                         (Symbolic
-                          { Sentence = [ SymString "foo" ]
-                            Args = [ freshNode (Identifier "baz") ] }),
+                            [ SymString "foo"
+                              SymArg (freshNode (Identifier "baz")) ]),
                      Direct))
         check
             ast
@@ -342,9 +342,9 @@ module Atomics =
                       LValue = IVar (Reg "x")
                       RValue =
                         IVar
-                            (sym
-                                [ SymString "foo" ]
-                                [ normalBoolExpr (BVar (Reg "baz")) ] ) } ))
+                            (Sym
+                                [ SymString "foo"
+                                  SymArg (normalBoolExpr (BVar (Reg "baz")))] ) }))
 
 
 module CommandAxioms =
@@ -396,8 +396,8 @@ module CommandAxioms =
                 (freshNode (Identifier "baz"))
                 (freshNode
                     (Symbolic
-                        { Sentence = [ SymString "foo" ]
-                          Args = [ freshNode (Identifier "bar") ] }))
+                        [ SymString "foo"
+                          SymArg (freshNode (Identifier "bar")) ] ))
 
         check
             ast
@@ -409,9 +409,9 @@ module CommandAxioms =
                           LValue = BVar (Reg "baz")
                           RValue =
                             BVar
-                                (sym
-                                    [ SymString "foo" ]
-                                    [ normalIntExpr (IVar (Reg "bar")) ])})])
+                                (Sym
+                                    [ SymString "foo"
+                                      SymArg (normalIntExpr (IVar (Reg "bar"))) ])})])
 
 
 module ViewDefs =

--- a/ParserTests.fs
+++ b/ParserTests.fs
@@ -40,13 +40,11 @@ let ( ** ) = ( <| )
 
 module SymbolicTests =
     [<Test>]
-    let ``Test symbolic %{foo #1 bar}(x) is parsed correctly`` () =
-        check parseSymbolic "%{foo #1 bar}(x)"
-            { Sentence =
-                [ SymString "foo "; SymParamRef 1; SymString " bar" ]
-              Args =
-                [ node "" 1L 15L (Identifier "x") ] }
-
+    let ``Test symbolic %{foo [|x|] bar} is parsed correctly`` () =
+        check parseSymbolic "%{foo [|x|] bar}"
+            [ SymString "foo "
+              SymArg ( node "" 1L 9L (Identifier "x") )
+              SymString " bar" ]
 
 module ViewProtoTests =
     [<Test>]
@@ -225,14 +223,11 @@ module AtomicActionTests =
 
     [<Test>]
     let ``parse symbolic atomic``() =
-        check parseAtomic "%{foo(#1)}(x)"
+        check parseAtomic "%{foo([|x|])}"
             (node "" 1L 1L <| SymAtomic
-                { Sentence =
-                       [ SymString "foo("
-                         SymParamRef 1
-                         SymString ")" ]
-                  Args =
-                       [ node "" 1L 12L (Identifier "x") ] } )
+               [ SymString "foo("
+                 SymArg ( node "" 1L 9L (Identifier "x") )
+                 SymString ")" ] )
 
 
 module AtomicSetTests =

--- a/PrettyTests.fs
+++ b/PrettyTests.fs
@@ -5,24 +5,36 @@ module Starling.Tests.Pretty
 
 open NUnit.Framework
 open Starling
+open Starling.Utils.Testing
 open Starling.Core.Var
 open Starling.Lang.AST
 open Starling.Lang.AST.Pretty
 
-/// Tests for the pretty printer.
-type PrettyTests() =
+/// <summary>
+///     Tests for <see cref="printExpression"/>.
+/// </summary>
+module ExpressionTests =
+    let check expr str =
+        Core.Pretty.printUnstyled (printExpression (freshNode expr)) ?=? str
 
-    /// Test cases for printExpression.
-    static member Exprs =
-        [ TestCaseData(freshNode <| Num 5L).Returns("5")
-          TestCaseData(freshNode <| BopExpr(Div, freshNode <| Num 6L, freshNode <| Identifier "bar")).Returns("(6 / bar)")
+    [<Test>]
+    let ``expression '5' is printed correctly`` =
+        check (Num 5L) "5"
 
-          TestCaseData(freshNode <| BopExpr(Mul, freshNode <| BopExpr(Add, freshNode <| Num 1L, freshNode <| Num 2L), freshNode <| Num 3L)).Returns("((1 + 2) * 3)") ]
-        |> List.map (fun d -> d.SetName(sprintf "Print expression %A" d.ExpectedResult))
+    [<Test>]
+    let ``expression '(6 / bar)' is printed correctly`` =
+        check
+            (BopExpr(Div, freshNode <| Num 6L, freshNode <| Identifier "bar"))
+            "(6 / bar)"
 
-    [<TestCaseSource("Exprs")>]
-    /// Tests whether printExpression behaves itself.
-    member x.``printExpression correctly prints expressions`` expr =
-        expr
-        |> printExpression
-        |> Core.Pretty.printUnstyled
+    [<Test>]
+    let ``expression '((1 + 2) * 3)' is printed correctly`` =
+        check
+            (BopExpr
+                (Mul,
+                 freshNode <| BopExpr
+                    (Add,
+                     freshNode (Num 1L),
+                     freshNode (Num 2L)),
+                 freshNode (Num 3L)))
+            "((1 + 2) * 3)"

--- a/PrettyTests.fs
+++ b/PrettyTests.fs
@@ -18,17 +18,17 @@ module ExpressionTests =
         Core.Pretty.printUnstyled (printExpression (freshNode expr)) ?=? str
 
     [<Test>]
-    let ``expression '5' is printed correctly`` =
+    let ``expression '5' is printed correctly`` () =
         check (Num 5L) "5"
 
     [<Test>]
-    let ``expression '(6 / bar)' is printed correctly`` =
+    let ``expression '(6 / bar)' is printed correctly`` () =
         check
             (BopExpr(Div, freshNode <| Num 6L, freshNode <| Identifier "bar"))
             "(6 / bar)"
 
     [<Test>]
-    let ``expression '((1 + 2) * 3)' is printed correctly`` =
+    let ``expression '((1 + 2) * 3)' is printed correctly`` () =
         check
             (BopExpr
                 (Mul,
@@ -38,3 +38,38 @@ module ExpressionTests =
                      freshNode (Num 2L)),
                  freshNode (Num 3L)))
             "((1 + 2) * 3)"
+
+/// <summary>
+///     Tests for <see cref="printSymbolic"/>.
+/// </summary>
+module SymbolicTests =
+    open Starling.Core.Symbolic
+
+    let check sym str =
+        Core.Pretty.printUnstyled (printSymbolic sym) ?=? str
+
+    [<Test>]
+    let ``the empty symbol %{} is printed correctly`` () =
+        check [] "%{}"
+
+    [<Test>]
+    let ``the symbol %{hello, world} is printed correctly`` () =
+        check [ SymString "hello, world" ] "%{hello, world}"
+
+    [<Test>]
+    let ``the split symbol %{hello, world} is printed correctly`` () =
+        check
+            [ SymString "hello,"
+              SymString " "
+              SymString "world" ]
+            "%{hello, world}"
+
+    [<Test>]
+    let ``the symbol %{[|2|] + [|2|] = [|5|]} is printed correctly`` () =
+        check
+            [ SymArg (freshNode (Num 2L))
+              SymString " + "
+              SymArg (freshNode (Num 2L))
+              SymString " = "
+              SymArg (freshNode (Num 5L)) ]
+            "%{[|2|] + [|2|] = [|5|]}"

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -416,8 +416,8 @@ let traverseMicrocode
         let tml = tchainL tm id
 
         match mc with
-        | Symbol { Sentence = s; Args = xs } ->
-            tchainL rtrav (fun xs' -> Symbol { Sentence = s; Args = xs' }) ctx xs
+        | Symbol s ->
+            tchainL (tliftOverSymbolicWord rtrav) Symbol ctx s
         | Assign (lv, Some rv) ->
             tchain2 ltrav rtrav (pairMap id Some >> Assign) ctx (lv, rv)
         | Assign (lv, None) ->

--- a/SemanticsTests.fs
+++ b/SemanticsTests.fs
@@ -629,11 +629,12 @@ module CommandTests =
                             (IInt 1L)))) ] )
 
     [<Test>]
-    let ``Semantically translate <%{foo(#1)}(serving)> using the ticket lock model``() =
+    let ``Semantically translate <%{foo([|serving|]}> using the ticket lock model``() =
         check ticketLockModel.SharedVars ticketLockModel.ThreadVars
               [ SymC
-                    { Sentence = [ SymString "foo("; SymParamRef 1; SymString ")" ]
-                      Args = [ normalIntExpr (siVar "serving") ] } ]
+                    [ SymString "foo("
+                      SymArg (normalIntExpr (siVar "serving") )
+                      SymString ")" ] ]
         <| Some (Set.ofList
             [
                 iEq (siAfter "s") (siBefore "s")
@@ -641,8 +642,10 @@ module CommandTests =
                 iEq (siAfter "ticket") (siBefore "ticket")
                 iEq (siAfter "serving") (siBefore "serving")
                 BVar (
-                    sym [ SymString "foo("; SymParamRef 1; SymString ")" ]
-                        [ normalIntExpr (siBefore "serving") ]
+                    Sym
+                        [ SymString "foo("
+                          SymArg (normalIntExpr (siBefore "serving") )
+                          SymString ")" ]
                 )
             ])
 


### PR DESCRIPTION
Instead of the previous syntax

```
%{ #1 := #2.lock }(x, y)
```

We now have the rather more readable

```
%{ [|x|] := [|y|].lock }
```

This has required a fair amount of surgery to Starling, as the
symbolic representation has changed from sentence/arguments to a
list of inline strings and expressions.

All of the currently passing GRASShopper examples have been
converted over.