### PR TITLE
Minor readability optimisation improvements

### DIFF
--- a/Grasshopper.fs
+++ b/Grasshopper.fs
@@ -471,20 +471,6 @@ let grassMicrocode (routine : Microcode<CTyped<MarkedVar>, Sym<MarkedVar>> list 
                         (normalBool x)
                 lift (fun x -> [ PureAssume x ]) (mapMessages Traversal grassifyR)
 
-(*            | Assume (NoSym x) ->
-                // Pure assumption.
-                let grassifyR =
-                    liftWithoutContext
-                        (Starling >> Reg >> ok)
-                        (tliftOverCTyped >> tliftToExprDest >> tliftToBoolSrc)
-                        (normalBool x)
-                lift (fun x -> [ PureAssume x ]) (mapMessages Traversal grassifyR)
-            | Assume _ ->
-                fail
-                    (CommandNotImplemented
-                        (cmd = ent,
-                         why = "Impure assumptions not yet supported.")) *)
-
         lift List.concat (collect (List.map grassMicrocodeInstruction ent))
     lift List.concat (collect (List.map grassMicrocodeEntry routine))
 

--- a/Grasshopper.fs
+++ b/Grasshopper.fs
@@ -149,9 +149,12 @@ module Pretty =
 
     /// Print infix operator (generic)
     let infexprG (combine : string -> Doc -> Doc) (op : string) (pxs : 'x -> Doc) (xs : seq<'x>) : Doc =
-        let mapped = Seq.map pxs xs
-        let resseq = Seq.map (combine op) (Seq.tail mapped)
-        parened (hsep [Seq.head mapped; (hsep resseq)])
+        match (List.map pxs (List.ofSeq xs)) with
+        | [] -> Nop
+        | [p] -> p
+        | p::ps ->
+            let resseq = Seq.map (combine op) ps
+            parened (hsep [p; (hsep resseq)])
 
     /// Print infix operator across multiple lines
     let infexprV (op : string) (pxs : 'x -> Doc) (xs : seq<'x>) : Doc =

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -783,7 +783,7 @@ and modelBoolExpr
                     match o with
                     | And -> mkAnd2
                     | Or -> mkOr2
-                    | Imp -> mkImpl
+                    | Imp -> mkImplies
                     | _ -> failwith "unreachable[modelBoolExpr::BoolIn]"
 
                 (* Both sides of the expression need to be unifiable to the

--- a/ModellerTests.fs
+++ b/ModellerTests.fs
@@ -203,7 +203,7 @@ module ArithmeticExprs =
                     (mkTypedSub
                         (mkArrayTypeRec (Int (normalRec, ())) (Some 10))
                         (AVar (Reg "nums")),
-                     IAdd [ IVar (Reg "foo"); IInt 3L ])))
+                     mkAdd2 (IVar (Reg "foo")) (IInt 3L))))
 
     [<Test>]
     let ``test modelling shared array access nums[lnode + 1] fails`` ()=


### PR DESCRIPTION
This is part of the #136 effort, and adds a few new heuristics to the integer optimisation logic such as

```
x + 5 + y + 12 -> x + y + 17
x + (y - 5) -> (x + y) - 5
x + 5 <= 6 -> x <= 1
x - 6 > 0 -> x > 6
```

and so on.

This doesn't do much for us in practice, as most of the problem for #136 is in complex nested Booleans, though it's managed to simplify

```
    exists ArcFoot:Set<ArcNode> :: (
        acc(ArcFoot) &*&
        (
            ((before_28_1_x in ArcFoot && 1 <= before_28_1_x.count) &&
                ((goal_36_n <= 2) ||
                    (goal_35_x != before_28_1_x) ||
                    (goal_35_x != before_28_1_x) ||
                    ((((goal_36_n - 2) + 1) <= 0) ||
                        (goal_35_x in ArcFoot && ((goal_36_n - 2) + 1) <= goal_35_x.count))) &&
                ((goal_35_x == before_28_1_x) ||
                    (goal_36_n <= 2) ||
                    (goal_35_x != before_28_1_x) ||
                    (goal_35_x != before_28_1_x) ||
                    ((((goal_36_n + (goal_36_n - 2)) + 1) <= 0) ||
                        (goal_35_x in ArcFoot && ((goal_36_n + (goal_36_n - 2)) + 1) <= goal_35_x.count))) &&
                ((goal_35_x == before_28_1_x) ||
                    (goal_36_n <= 2) ||
                    (goal_35_x != before_28_1_x) ||
                    (((goal_36_n + (goal_36_n - 2)) <= 0) ||
                        (goal_35_x in ArcFoot && (goal_36_n + (goal_36_n - 2)) <= goal_35_x.count))) &&
                ((goal_35_x == before_28_1_x) ||
                    (goal_35_x != before_28_1_x) ||
                    (((goal_36_n + 1) <= 0) ||
                        (goal_35_x in ArcFoot && (goal_36_n + 1) <= goal_35_x.count))) &&
                ((goal_35_x != before_28_1_x) ||
                    (goal_36_n <= 2) ||
                    (((goal_36_n - 2) <= 0) ||
                        (goal_35_x in ArcFoot && (goal_36_n - 2) <= goal_35_x.count))) &&
                ((goal_35_x == before_28_1_x) ||
                    ((goal_36_n <= 0) ||
                        (goal_35_x in ArcFoot && goal_36_n <= goal_35_x.count))))
        )
    )
```

to

```
    exists ArcFoot:Set<ArcNode> :: (
        acc(ArcFoot) &*&
        (
            ((before_28_1_x in ArcFoot && 1 <= before_28_1_x.count) &&
                ((goal_36_n <= 2) ||
                    (goal_35_x != before_28_1_x) ||
                    (goal_35_x != before_28_1_x) ||
                    ((goal_36_n <= 1) ||
                        (goal_35_x in ArcFoot && (goal_36_n - 1) <= goal_35_x.count))) &&
                ((goal_35_x == before_28_1_x) ||
                    (goal_36_n <= 2) ||
                    (goal_35_x != before_28_1_x) ||
                    (goal_35_x != before_28_1_x) ||
                    (((goal_36_n + goal_36_n) <= 1) ||
                        (goal_35_x in ArcFoot && ((goal_36_n + goal_36_n) - 1) <= goal_35_x.count))) &&
                ((goal_35_x == before_28_1_x) ||
                    (goal_36_n <= 2) ||
                    (goal_35_x != before_28_1_x) ||
                    (((goal_36_n + goal_36_n) <= 2) ||
                        (goal_35_x in ArcFoot && ((goal_36_n + goal_36_n) - 2) <= goal_35_x.count))) &&
                ((goal_35_x == before_28_1_x) ||
                    (goal_35_x != before_28_1_x) ||
                    ((goal_36_n <= -1) ||
                        (goal_35_x in ArcFoot && (goal_36_n + 1) <= goal_35_x.count))) &&
                ((goal_35_x != before_28_1_x) ||
                    (goal_36_n <= 2) ||
                    ((goal_36_n <= 2) ||
                        (goal_35_x in ArcFoot && (goal_36_n - 2) <= goal_35_x.count))) &&
                ((goal_35_x == before_28_1_x) ||
                    ((goal_36_n <= 0) ||
                        (goal_35_x in ArcFoot && goal_36_n <= goal_35_x.count))))
        )
    )
```