### PR TITLE
Shared symbols can take thread-locals, and other environment fixes

### DIFF
--- a/AST.fs
+++ b/AST.fs
@@ -586,6 +586,8 @@ let node (streamname : string)
          : Node<'a> =
     { Position = { StreamName = streamname; Line = line; Column = column }; Node = a }
 
+let unwrap { Node = n } = n;
+
 /// <summary>
 ///     Type-constrained version of <c>func</c> for <c>AFunc</c>s.
 /// </summary>

--- a/AST.fs
+++ b/AST.fs
@@ -586,8 +586,6 @@ let node (streamname : string)
          : Node<'a> =
     { Position = { StreamName = streamname; Line = line; Column = column }; Node = a }
 
-let unwrap { Node = n } = n;
-
 /// <summary>
 ///     Type-constrained version of <c>func</c> for <c>AFunc</c>s.
 /// </summary>

--- a/Examples/Errors/local_in_shared_context.cvf
+++ b/Examples/Errors/local_in_shared_context.cvf
@@ -1,0 +1,47 @@
+/*
+ * Linux-style ticket lock.
+ */
+
+shared int ticket;  // The next ticket to hand out.
+shared int serving; // The current ticket holding the lock.
+thread int t;  // The thread's current ticket.
+thread int s;  // The thread's current view of serving.
+
+/*
+ * Locks the ticket lock.
+ */
+method lock() {
+  {| emp |}
+    <t = s++>; // <-- Thread-local in shared context
+  {| holdTick(t) |}
+    do {
+      {| holdTick(t) |}
+        <s = serving>;
+      {| if s == t then holdLock() else holdTick(t) |}
+    } while (s != t);
+  {| holdLock() |}
+}
+
+/*
+ * Unlocks the ticket lock.
+ */
+method unlock() {
+  {| holdLock() |}
+    <serving++>;
+  {| emp |}
+}
+
+view holdTick(int t);
+view holdLock();
+
+// Invariant
+constraint emp                         -> ticket >= serving;
+
+// Predicate definitions
+constraint holdTick(t)                 -> ticket > t;
+constraint holdLock()                  -> ticket != serving;
+
+// Interactions
+constraint holdLock()   * holdTick(t)  -> serving != t;
+constraint holdTick(ta) * holdTick(tb) -> ta != tb;
+constraint holdLock()   * holdLock()   -> false;

--- a/Examples/Errors/shared_in_local_context.cvf
+++ b/Examples/Errors/shared_in_local_context.cvf
@@ -1,0 +1,47 @@
+/*
+ * Linux-style ticket lock.
+ */
+
+shared int ticket;  // The next ticket to hand out.
+shared int serving; // The current ticket holding the lock.
+thread int t;  // The thread's current ticket.
+thread int s;  // The thread's current view of serving.
+
+/*
+ * Locks the ticket lock.
+ */
+method lock() {
+  {| emp |}
+    <ticket = ticket++>; // <-- shared in local context
+  {| holdTick(t) |}
+    do {
+      {| holdTick(t) |}
+        <s = serving>;
+      {| if s == t then holdLock() else holdTick(t) |}
+    } while (s != t);
+  {| holdLock() |}
+}
+
+/*
+ * Unlocks the ticket lock.
+ */
+method unlock() {
+  {| holdLock() |}
+    <serving++>;
+  {| emp |}
+}
+
+view holdTick(int t);
+view holdLock();
+
+// Invariant
+constraint emp                         -> ticket >= serving;
+
+// Predicate definitions
+constraint holdTick(t)                 -> ticket > t;
+constraint holdLock()                  -> ticket != serving;
+
+// Interactions
+constraint holdLock()   * holdTick(t)  -> serving != t;
+constraint holdTick(ta) * holdTick(tb) -> ta != tb;
+constraint holdLock()   * holdLock()   -> false;

--- a/Examples/PassGH/arc.cvf
+++ b/Examples/PassGH/arc.cvf
@@ -19,9 +19,8 @@ thread Int c, pval;
 
 method init() {
   {| emp |}
-    // TODO: broken local command syntax.
-    ret = %{new ArcNode};
-    <%{[|ret|].count := 1}>;
+    <{ ret = %{new ArcNode};
+       %{[|ret|].count := 1}; }>;
   {| arc(ret) |}
 }
 
@@ -33,16 +32,14 @@ method clone(ArcNode x) {
 
 method print(ArcNode x) {
   {| arc(x) |}
-    // TODO: broken local command syntax.
-    pval = %{ [|x|].val };
+    <pval = %{ [|x|].val }>;
   {| arc(x) |}
 }
 
 method drop(ArcNode x) {
   {| arc(x) |}
-    // TODO: broken local command syntax.
-    c = %{ [|x|].count };
-    <%{ [|x|].count := [|x|].count - 1 }>;
+    <{ c = %{ [|x|].count };
+       %{ [|x|].count := [|x|].count - 1 }; }>;
   {| countCopy(x, c) |}
     if (c == 1) {
       {| countCopy(x, 1) |}

--- a/Examples/PassGH/clhLock.cvf
+++ b/Examples/PassGH/clhLock.cvf
@@ -23,7 +23,7 @@ method lock(Node mynode) {
   {| queued(mynode, mypred) |}
     do {
       {| queued(mynode, mypred) |}
-        test = %{ [|mypred|].lock };
+        <test = %{ [|mypred|].lock }>;
       {| if test then queued(mynode, mypred) else holdLock(mynode, mypred) |}
     } while (test);
   {| holdLock(mynode, mypred) |}

--- a/Examples/PassGH/lclist.cvf
+++ b/Examples/PassGH/lclist.cvf
@@ -21,11 +21,11 @@ method deleteVal(int v) {
   {| wf(v) * isHead(prev) |}
    <{ %{ waitLock([|prev|]); takeLock([|prev|]) }; }>;
   {| wf(v) * has1LockAnon(prev) * isHead(prev) |}
-   curr = %{ [|prev|].next };
+   < curr = %{ [|prev|].next } >;
   {| wf(v) * has1Lock(prev, curr) * isHead(prev) |}
    <{ %{ waitLock([|curr|]); takeLock([|curr|]) }; }>;
   {| wf(v) * has2Lock(prev, curr) |}
-   cv = %{ [|curr|].val };
+   < cv = %{ [|curr|].val } >;
   {| wf(v) * has2Lock(prev,curr) * isVal(curr, cv) |}
     while (cv < v ) {
       {| wf(v) * wf(cv) * has2Lock(prev, curr) * isVal(curr, cv) |}

--- a/Examples/PassGH/spinLock.cvf
+++ b/Examples/PassGH/spinLock.cvf
@@ -13,7 +13,7 @@ view newLock(Lock x), holdLock(Lock x), isLock(Lock x);
 
 method newLock() {
   {| emp |}
-    ret = %{new Lock};
+    <ret = %{new Lock}>;
   {| newLock(ret) |}
     <%{[|ret|].lock := false}>;
   {| isLock(ret) |}
@@ -25,7 +25,7 @@ method lock(Lock x) {
       {| isLock(x) |}
         test = false;
       {| if test == false then isLock(x) else False() |}
-        test = %{ CAS_to_true([|x|]) };
+        <test = %{ CAS_to_true([|x|]) }>;
       {| if test == false then isLock(x) else holdLock(x) |}
     } while (test == false);
   {| holdLock(x) |}

--- a/Examples/PassGH/ticketLock.cvf
+++ b/Examples/PassGH/ticketLock.cvf
@@ -13,7 +13,7 @@ view newLock(Lock x), holdTick(Lock x, int t), holdLock(Lock x), isLock(Lock x);
 
 method newLock() {
   {| emp |}
-    ret = %{new Lock};
+    <ret = %{new Lock}>;
   {| newLock(ret) |} 
     <%{[|ret|].ticket := 0; [|ret|].serving := 0}>;
   {| isLock(ret) |}
@@ -21,12 +21,12 @@ method newLock() {
 
 method lock(Lock x) {
   {| isLock(x) |}
-    t = %{ [|x|].ticket };
-    <%{ [|x|].ticket := [|x|].ticket + 1 }>;
+    <{ t = %{ [|x|].ticket };
+       %{ [|x|].ticket := [|x|].ticket + 1 }; }>;
   {| holdTick(x, t) |}
     do {
       {| holdTick(x, t) |}
-        s = %{ [|x|].serving };
+        <s = %{ [|x|].serving }>;
       {| if s == t then holdLock(x) else holdTick(x, t) |}
     } while (s != t);
   {| holdLock(x) |}

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -1355,6 +1355,17 @@ let modelIntLValue
     | RValue r -> fail (NeedLValue r)
     | LValue l -> wrapMessages BadExpr (modelIntExpr env idxEnv marker) l
 
+/// Model an expr that's either an IntLValue or a Symbolic Command
+let modelIntLValueOrSymbol
+  (env : VarMap) (idxEnv : VarMap) (marker : Var -> 'Var) (ex : Expression)
+  : Result<TypedIntExpr<Sym<'Var>>, PrimError> =
+    match ex with
+    | RValue r -> 
+        match unwrap r with
+        | Symbolic _ -> wrapMessages BadExpr (modelIntExpr env idxEnv marker) r
+        | _          -> fail (NeedLValue r)
+    | LValue l -> wrapMessages BadExpr (modelIntExpr env idxEnv marker) l
+
 /// <summary>
 ///     Models an lvalue given a potentially valid expression and
 ///     environment.
@@ -1438,7 +1449,7 @@ let modelIntLoad
 
     bind2 modelWithExprs
         (modelIntLValue ctx.ThreadVars ctx.ThreadVars id dest)
-        (modelIntLValue ctx.SharedVars ctx.ThreadVars id src)
+        (modelIntLValueOrSymbol ctx.SharedVars ctx.ThreadVars id src)
 
 /// Converts a Boolean store to a Prim.
 let modelBoolStore

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -1690,7 +1690,7 @@ let modelFetch
                     -> fail (PrimNotImplemented "array fetch")
                 | None ->
                     let v = varOfLValue d
-                    fail (BadExpr (dest, Var (v, NotFound v)))
+                    fail (BadExpr (dest, Var (v, VarNotInEnv)))
         | RValue _ -> fail (NeedLValue d)
 
     bind (fun f -> f ctx dest test mode) (findModeller dest)

--- a/ModellerTests.fs
+++ b/ModellerTests.fs
@@ -122,14 +122,14 @@ module ArithmeticExprs =
         let e = Env.env environ env
         assertOkAndEqual
             expectedExpr
-            (modelIntExpr e Env.Shared id ast)
+            (modelIntExpr e Shared id ast)
             (printExprError >> printUnstyled)
 
     let checkFail (env : VarMap) (ast : Expression) (expectedErrors : ExprError list) =
         let e = Env.env environ env
         assertFail
             expectedErrors
-            (modelIntExpr e Env.Shared id ast)
+            (modelIntExpr e Shared id ast)
             (stripTypeRec >> printIntExpr (printSym printVar) >> printUnstyled)
 
     [<Test>]
@@ -244,7 +244,7 @@ module ArithmeticExprs =
 module BooleanExprs =
     let check (env : VarMap) (ast : Expression) (expectedExpr : TypedBoolExpr<Sym<Var>>) =
         let e = Env.env environ env
-        let actualBoolExpr = okOption <| modelBoolExpr e Env.Shared id ast
+        let actualBoolExpr = okOption <| modelBoolExpr e Shared id ast
         AssertAreEqual(Some expectedExpr, actualBoolExpr)
 
     [<Test>]

--- a/ModellerTests.fs
+++ b/ModellerTests.fs
@@ -49,13 +49,11 @@ let shared =
 
 let context =
     { ViewProtos = ticketLockProtos
-      SharedVars = Map.empty
-      ThreadVars = environ }
+      Env = Env.env environ Map.empty }
 
 let sharedContext =
     { ViewProtos = ticketLockProtos
-      SharedVars = shared
-      ThreadVars = environ }
+      Env = Env.env environ shared }
 
 
 module ViewPass =
@@ -121,15 +119,17 @@ module ArithmeticExprs =
     open Starling.Lang.Modeller.Pretty
 
     let check (env : VarMap) (ast : Expression) (expectedExpr : TypedIntExpr<Sym<Var>>) =
+        let e = Env.env environ env
         assertOkAndEqual
             expectedExpr
-            (modelIntExpr env environ id ast)
+            (modelIntExpr e Env.Shared id ast)
             (printExprError >> printUnstyled)
 
     let checkFail (env : VarMap) (ast : Expression) (expectedErrors : ExprError list) =
+        let e = Env.env environ env
         assertFail
             expectedErrors
-            (modelIntExpr env environ id ast)
+            (modelIntExpr e Env.Shared id ast)
             (stripTypeRec >> printIntExpr (printSym printVar) >> printUnstyled)
 
     [<Test>]
@@ -243,7 +243,8 @@ module ArithmeticExprs =
 
 module BooleanExprs =
     let check (env : VarMap) (ast : Expression) (expectedExpr : TypedBoolExpr<Sym<Var>>) =
-        let actualBoolExpr = okOption <| modelBoolExpr env environ id ast
+        let e = Env.env environ env
+        let actualBoolExpr = okOption <| modelBoolExpr e Env.Shared id ast
         AssertAreEqual(Some expectedExpr, actualBoolExpr)
 
     [<Test>]

--- a/Pretty.fs
+++ b/Pretty.fs
@@ -58,7 +58,8 @@ let success d = Styled([Green], d)
 let inconclusive d = Styled([Blue], d)
 
 let errorStr s = error (String s)
-let errorInfoStr s = error (String s)
+let errorContextStr s = errorContext (String s)
+let errorInfoStr s = errorInfo (String s)
 
 /// <summary>
 ///     Styles a string with ANSI escape sequences.
@@ -125,7 +126,7 @@ type PrintState =
 let rec printState (state : PrintState) (doc : Doc) : string =
     match doc with
     | Header (heading, incmd) ->
-        printState state heading + ":" + lnIndent state.Level + printState state incmd + lnIndent state.Level
+        printState state heading + ":" + lnIndent state.Level + printState state incmd
     | Separator ->
         "----"
     | Styled (s, d) when state.UseStyles ->
@@ -307,7 +308,9 @@ let printList pItem lst =
 
 /// Formats an error that is wrapping another error.
 let wrapped wholeDesc whole err =
-    headed (sprintf "In %s '%s'" wholeDesc (print whole)) [ err ]
+    cmdHeaded
+        (errorContextStr "->" <+> errorContextStr wholeDesc <+> whole)
+        [ err ]
 
 /// <summary>
 ///     Prints an integer.

--- a/Var.fs
+++ b/Var.fs
@@ -358,17 +358,24 @@ module Pretty =
     let printVarMapError =
         function
         | Duplicate vn ->
-            errorStr "variable"
+            errorStr "Variable"
             <+> quoted (String vn)
-            <+> errorStr "is defined multiple times"
+            <+> errorStr "is defined multiple times."
         | VarNotInEnv ->
-            errorStr "this variable is undefined"
+            errorStr "This variable is undefined."
         | VarInWrongScope (expected, got) ->
-            errorStr "expected a variable from the"
-            <+> errorInfo (printScope expected)
-            <+> errorStr "scope, but this variable is in the"
-            <+> errorInfo (printScope got)
-            <+> errorStr "scope"
+            let error =
+                errorStr "Expected a variable from the"
+                <+> errorInfo (printScope expected)
+                <+> errorStr "scope, but this variable is in the"
+                <+> errorInfo (printScope got)
+                <+> errorStr "scope."
+            let hint =
+                match expected with
+                | Thread -> "Consider taking a thread-local copy"
+                | Shared -> "Consider using a local command instead."
+                | _ -> "No hint available."
+            vsep [ error; errorInfoStr hint ]
 
     /// <summary>
     ///     Pretty-prints a <c>MarkedVar</c>.


### PR DESCRIPTION
Thanks to @BenSimner for most of this PRQ!

- A symbol in a shared position can now reference thread-local variables (and, I think, parameters).
- Refactoring done for the above made it possible to work out which type of scope a variable reference is in at modelling point, as well as access to the entire environment at modelling point.  This means we've been able to fix #97.
- Some pretty-printer fixes, including removing excessive newlines after a heading (this might have broken something else!)