### PR TITLE
Massively simplify and equalise primitive commands

### DIFF
--- a/AST.fs
+++ b/AST.fs
@@ -61,8 +61,10 @@ module Types =
         | ArraySubscript of array : Expression * subscript : Expression
     and Expression = Node<Expression'>
 
-    /// An atomic action.
-    type Atomic' =
+    /// <summary>
+    ///     A primitive command.
+    /// </summary>
+    type Prim' =
         | CompareAndSwap of
             src : Expression
             * test : Expression
@@ -71,8 +73,13 @@ module Types =
         | Postfix of Expression * FetchMode // <a++> or <a-->
         | Id // <id>
         | Assume of Expression // <assume(e)>
-        | SymAtomic of symbol : Symbolic<Expression> // %{xyz}(x, y)
+        | SymCommand of symbol : Symbolic<Expression> // %{xyz}(x, y)
         | Havoc of var : string // havoc var
+    and Prim = Node<Prim'>
+
+    /// An atomic action.
+    type Atomic' =
+        | APrim of Prim
         | ACond of
             cond : Expression
             * trueBranch : Atomic list
@@ -177,9 +184,9 @@ module Types =
 
     /// A set of primitives.
     type PrimSet =
-        { PreAssigns: (Expression * Expression) list
+        { PreLocals: Prim list
           Atomics: Atomic list
-          PostAssigns: (Expression * Expression) list }
+          PostLocals: Prim list }
 
     /// A statement in the command language.
     type Command' =
@@ -401,14 +408,14 @@ module Pretty =
         equality (printExpression dest) (printExpression src)
 
     /// <summary>
-    ///     Pretty-prints atomic actions.
+    ///     Pretty-prints primitive actions.
     /// </summary>
-    /// <param name="a">The <see cref="Atomic'"/> to print.</param>
+    /// <param name="p">The <see cref="Prim'"/> to print.</param>
     /// <returns>
-    ///     A <see cref="Doc"/> representing <paramref name="a"/>.
+    ///     A <see cref="Doc"/> representing <paramref name="p"/>.
     /// </returns>
-    let rec printAtomic' (a : Atomic') : Doc =
-        match a with
+    let rec printPrim' (p : Prim') : Doc =
+        match p with
         | CompareAndSwap(l, f, t) ->
             func "CAS" [ printExpression l
                          printExpression f
@@ -421,8 +428,20 @@ module Pretty =
             hjoin [ printExpression l; printFetchMode m ]
         | Id -> String "id"
         | Assume e -> func "assume" [ printExpression e ]
-        | SymAtomic sym -> printSymbolic sym
+        | SymCommand sym -> printSymbolic sym
         | Havoc var -> String "havoc" <+> String var
+    and printPrim (x : Prim) : Doc = printPrim' x.Node
+
+    /// <summary>
+    ///     Pretty-prints atomic actions.
+    /// </summary>
+    /// <param name="a">The <see cref="Atomic'"/> to print.</param>
+    /// <returns>
+    ///     A <see cref="Doc"/> representing <paramref name="a"/>.
+    /// </returns>
+    let rec printAtomic' (a : Atomic') : Doc =
+        match a with
+        | APrim p -> printPrim p
         | ACond (cond = c; trueBranch = t; falseBranch = f) ->
             Helpers.printITE printExpression printAtomic c t f
     and printAtomic (x : Atomic) : Doc = printAtomic' x.Node
@@ -433,12 +452,12 @@ module Pretty =
         (* The trick here is to make Prim [] appear as ;, but
            Prim [x; y; z] appear as x; y; z;, and to do the same with
            atomic lists. *)
-        | Command'.Prim { PreAssigns = ps; Atomics = ts; PostAssigns = qs } ->
-            seq { yield! Seq.map (uncurry printAssign) ps
+        | Command'.Prim { PreLocals = ps; Atomics = ts; PostLocals = qs } ->
+            seq { yield! Seq.map printPrim ps
                   yield (ts
                          |> Seq.map printAtomic
                          |> semiSep |> withSemi |> braced |> angled)
-                  yield! Seq.map (uncurry printAssign) qs }
+                  yield! Seq.map printPrim qs }
             |> semiSep |> withSemi
         | Command'.If(c, t, f) ->
             Helpers.printITE printExpression printCommand c t f

--- a/AST.fs
+++ b/AST.fs
@@ -592,7 +592,7 @@ let (|BoolExp'|ArithExp'|AnyExp'|) (e : Expression')
     | ArraySubscript _ -> AnyExp' e
     | Num _ -> ArithExp' e
     | True | False -> BoolExp' e
-    | BopExpr(BoolOp, _, _) | UopExpr(_,_) -> BoolExp' e
+    | BopExpr(BoolOp, _, _) | UopExpr(_) -> BoolExp' e
     | BopExpr(ArithOp, _, _) -> ArithExp' e
 
 /// Active pattern classifying expressions as to whether they are

--- a/Command.fs
+++ b/Command.fs
@@ -57,7 +57,7 @@ module Types =
         { Name : string
           Results : SVExpr list
           Args : SVExpr list
-          Node : AST.Types.Atomic option }
+          Node : AST.Types.Prim option }
         override this.ToString() = sprintf "%A" this
 
     /// <summary>
@@ -169,9 +169,7 @@ module Queries =
     /// </returns>
     let assumptionOf (prim : PrimCommand) : BoolExpr<Sym<Var>> option =
         match prim with
-        // TODO (CaptainHayashi): more deep analysis here
-        | Stored { Name = n; Args = [ Bool (_, e) ] } when n = "Assume" ->
-            Some e
+        | Assume x -> Some x
         | _ -> None
 
     /// <summary>
@@ -364,7 +362,7 @@ module Create =
     let command (name : string) (results : SVExpr list) (args : SVExpr list) : PrimCommand =
         Stored { Name = name; Results = results; Args = args; Node = None }
 
-    let command' (name : string) (ast : AST.Types.Atomic) (results : SVExpr list) (args : SVExpr list) : PrimCommand =
+    let command' (name : string) (ast : AST.Types.Prim) (results : SVExpr list) (args : SVExpr list) : PrimCommand =
         Stored { Name = name; Results = results; Args = args; Node = Some ast }
 
 /// <summary>

--- a/Command.fs
+++ b/Command.fs
@@ -58,23 +58,10 @@ module Types =
         override this.ToString() = sprintf "%A" this
 
     /// <summary>
-    ///     An intrinsic assignment type.
-    /// </summary>
-    type AssignType =
-        /// <summary>Loading into thread lvalue from shared lvalue.</summary>
-        | Load
-        /// <summary>Storing into shared lvalue from thread expression.</summary>
-        | Store
-        /// <summary>Storing into thread lvalue from thread expression.</summary>
-        | Local
-
-    /// <summary>
     ///     An intrinsic primitive assignment record.
     /// </summary>
     type Assignment<'Expr> =
-        { /// <summary>The type of assignment being done.</summary>
-          AssignType : AssignType
-          /// <summary>The extended type record of both sides of the assignment.</summary>
+        { /// <summary>The extended type record of both sides of the assignment.</summary>
           TypeRec : PrimTypeRec
           /// <summary>The lvalue of the assignment.</summary>
           LValue : 'Expr
@@ -428,25 +415,17 @@ module Pretty =
     open Starling.Core.TypeSystem.Pretty
     open Starling.Core.Symbolic.Pretty
 
-    /// <summary>Pretty-prints an AssignType.</summary>
-    let printAssignType (a : AssignType) : Doc =
-        String
-            (match a with
-             | Store -> "store"
-             | Load  -> "load"
-             | Local -> "local")
-
     /// <summary>Pretty-prints an IntrinsicCommand.</summary>
     let printIntrinsicCommand (cmd : IntrinsicCommand) : Doc =
         match cmd with
-        | BAssign { AssignType = a; TypeRec = ty; LValue = x; RValue = y } ->
+        | BAssign { TypeRec = ty; LValue = x; RValue = y } ->
             parened <| hsep
-                [ String "assign<bool:" <-> printType (Int (ty, ())) <-> String ":" <-> printAssignType a <-> String ">"
+                [ String "assign<bool:" <-> printType (Int (ty, ())) <-> String ">"
                   printBoolExpr (printSym printVar) x
                   printBoolExpr (printSym printVar) y ]
-        | IAssign { AssignType = a; TypeRec = ty; LValue = x; RValue = y } ->
+        | IAssign { TypeRec = ty; LValue = x; RValue = y } ->
             parened <| hsep
-                [ String "assign<int:" <-> printType (Int (ty, ())) <-> String ":" <-> printAssignType a <-> String ">"
+                [ String "assign<int:" <-> printType (Int (ty, ())) <-> String ">"
                   printIntExpr (printSym printVar) x
                   printIntExpr (printSym printVar) y ]
         | Havoc v ->

--- a/CommandTests.fs
+++ b/CommandTests.fs
@@ -128,61 +128,49 @@ module Observable =
     [<Test>]
     let ``symbolics with are observable after the empty command`` () =
         check true
-            [ SymC [ SymString "foo" ] ]
+            [ Symbol [ SymString "foo" ] ]
             []
 
     [<Test>]
     let ``symbolics are observable after a local stored command`` () =
         check true
-            [ SymC [ SymString "foo" ] ]
+            [ Symbol [ SymString "foo" ] ]
             [ command "Foo" [ normalIntExpr (siVar "y") ] [ normalBoolExpr (sbVar "x") ] ]
 
     [<Test>]
     let ``symbolics are observable after a nonlocal stored command`` () =
         check true
-            [ SymC [ SymString "foo" ] ]
+            [ Symbol [ SymString "foo" ] ]
             [ command "Foo" [ normalIntExpr (siVar "g") ] [ normalBoolExpr (sbVar "x") ] ]
 
     [<Test>]
     let ``local assignment is observable after a disjoint assignment`` () =
         check true
-            [ Intrinsic
-                (IAssign
-                    { TypeRec = normalRec
-                      LValue = siVar "y"
-                      RValue = mkAdd2 (siVar "y") (IInt 1L) } ) ]
-            [ Intrinsic
-                (IAssign
-                    { TypeRec = normalRec
-                      LValue = siVar "g"
-                      RValue = mkAdd2 (siVar "y") (IInt 1L) } ) ]
+            [ normalIntExpr (siVar "y")
+              *<- 
+              normalIntExpr (mkAdd2 (siVar "y") (IInt 1L)) ]
+            [ normalIntExpr (siVar "g")
+              *<-
+              normalIntExpr (mkAdd2 (siVar "y") (IInt 1L)) ]
 
 
     [<Test>]
     let ``local assignment is observable after a chained assignment`` () =
         check true
-            [ Intrinsic
-                (IAssign
-                    { TypeRec = normalRec
-                      LValue = siVar "y"
-                      RValue = mkAdd2 (siVar "y") (IInt 1L) } ) ]
-            [ Intrinsic
-                (IAssign
-                    { TypeRec = normalRec
-                      LValue = siVar "g"
-                      RValue = siVar "y" } ) ]
+            [ normalIntExpr (siVar "y")
+              *<-
+              normalIntExpr (mkAdd2 (siVar "y") (IInt 1L)) ]
+            [ normalIntExpr (siVar "g")
+              *<-
+              normalIntExpr (siVar "y") ]
 
     [<Test>]
     let ``local assignment is unobservable after an overwiting assignment`` () =
         check false
-            [ Intrinsic
-                (IAssign
-                    { TypeRec = normalRec
-                      LValue = siVar "y"
-                      RValue = mkAdd2 (siVar "y") (IInt 1L) } ) ]
-            [ Intrinsic
-                (IAssign
-                    { TypeRec = normalRec
-                      LValue = siVar "y"
-                      RValue = siVar "g" } ) ]
+            [ normalIntExpr (siVar "y")
+              *<-
+              normalIntExpr (mkAdd2 (siVar "y") (IInt 1L)) ]
+            [ normalIntExpr (siVar "y")
+              *<-
+              normalIntExpr (siVar "g") ]
 

--- a/CommandTests.fs
+++ b/CommandTests.fs
@@ -148,10 +148,10 @@ module Observable =
         check true
             [ normalIntExpr (siVar "y")
               *<- 
-              normalIntExpr (mkAdd2 (siVar "y") (IInt 1L)) ]
+              normalIntExpr (mkInc (siVar "y")) ]
             [ normalIntExpr (siVar "g")
               *<-
-              normalIntExpr (mkAdd2 (siVar "y") (IInt 1L)) ]
+              normalIntExpr (mkInc (siVar "y")) ]
 
 
     [<Test>]

--- a/CommandTests.fs
+++ b/CommandTests.fs
@@ -41,7 +41,7 @@ module Nops =
 
     [<Test>]
     let ``Classify Assume(x!before) as a no-op``() =
-        check [ command "Assume" [] [ normalBoolExpr (sbVar "x") ] ]
+        check [ Microcode.Assume (sbVar "x") ]
 
     [<Test>]
     let ``Reject baz <- Foo(bar) as a no-op``() =
@@ -50,7 +50,7 @@ module Nops =
     [<Test>]
     let ``Reject Assume (x!before); baz <- Foo(bar) as a no-op``() =
         checkNot
-            [ command "Assume" [] [ normalBoolExpr (sbVar "x") ]
+            [ Microcode.Assume (sbVar "x")
               command "Foo" [ normalIntExpr (siVar "baz") ] [ normalIntExpr (siVar "bar") ] ]
 
 module Assumes =
@@ -68,12 +68,12 @@ module Assumes =
 
     [<Test>]
     let ``Classify Assume(x!before) as an assume``() =
-        check [ command "Assume" [] [ normalBoolExpr (sbVar "x") ] ]
+        check [ Microcode.Assume (sbVar "x") ]
 
     [<Test>]
     let ``Reject baz <- Foo(bar); Assume(x!before) as an Assume`` ()=
         checkNot [ command "Foo" [ normalIntExpr (siVar "baz") ] [ normalIntExpr (siVar "bar") ]
-                   command "Assume" [] [ normalBoolExpr (sbVar "x") ] ]
+                   Microcode.Assume (sbVar "x") ]
 
 module Observable =
     open Starling.Core.Command.Queries
@@ -110,19 +110,19 @@ module Observable =
     [<Test>]
     let ``assumes are observable after the empty command`` () =
         check true
-            [ command "Assume" [] [ normalBoolExpr (sbVar "x") ] ]
+            [ Microcode.Assume (sbVar "x") ]
             []
 
     [<Test>]
     let ``assumes are observable after a local stored command`` () =
         check true
-            [ command "Assume" [] [ normalBoolExpr (sbVar "x") ] ]
+            [ Microcode.Assume (sbVar "x") ]
             [ command "Foo" [ normalIntExpr (siVar "y") ] [ normalBoolExpr (sbVar "x") ] ]
 
     [<Test>]
     let ``assumes are observable after a nonlocal stored command`` () =
         check true
-            [ command "Assume" [] [ normalBoolExpr (sbVar "x") ] ]
+            [ Microcode.Assume (sbVar "x") ]
             [ command "Foo" [ normalIntExpr (siVar "g") ] [ normalBoolExpr (sbVar "x") ] ]
 
     [<Test>]

--- a/CommandTests.fs
+++ b/CommandTests.fs
@@ -148,14 +148,12 @@ module Observable =
         check true
             [ Intrinsic
                 (IAssign
-                    { AssignType = Local
-                      TypeRec = normalRec
+                    { TypeRec = normalRec
                       LValue = siVar "y"
                       RValue = mkAdd2 (siVar "y") (IInt 1L) } ) ]
             [ Intrinsic
                 (IAssign
-                    { AssignType = Store
-                      TypeRec = normalRec
+                    { TypeRec = normalRec
                       LValue = siVar "g"
                       RValue = mkAdd2 (siVar "y") (IInt 1L) } ) ]
 
@@ -165,14 +163,12 @@ module Observable =
         check true
             [ Intrinsic
                 (IAssign
-                    { AssignType = Local
-                      TypeRec = normalRec
+                    { TypeRec = normalRec
                       LValue = siVar "y"
                       RValue = mkAdd2 (siVar "y") (IInt 1L) } ) ]
             [ Intrinsic
                 (IAssign
-                    { AssignType = Store
-                      TypeRec = normalRec
+                    { TypeRec = normalRec
                       LValue = siVar "g"
                       RValue = siVar "y" } ) ]
 
@@ -181,14 +177,12 @@ module Observable =
         check false
             [ Intrinsic
                 (IAssign
-                    { AssignType = Local
-                      TypeRec = normalRec
+                    { TypeRec = normalRec
                       LValue = siVar "y"
                       RValue = mkAdd2 (siVar "y") (IInt 1L) } ) ]
             [ Intrinsic
                 (IAssign
-                    { AssignType = Load
-                      TypeRec = normalRec
+                    { TypeRec = normalRec
                       LValue = siVar "y"
                       RValue = siVar "g" } ) ]
 

--- a/Examples/PassGH/spinLockAtomicBranch.cvf
+++ b/Examples/PassGH/spinLockAtomicBranch.cvf
@@ -24,12 +24,10 @@ method lock(Lock x) {
     do {
       {| isLock(x) |}
         test = false;
-      {| if test == false then isLock(x) else False() |}
-        <| test = %{ [|x|].lock };
-           if (%{ [|x|].lock } == false) {
+        <| if (%{ [|x|].lock } == false) {
+               test = true;
                %{ [|x|].lock := true };
            } |>
-        test = !test;
       {| if test == false then isLock(x) else holdLock(x) |}
     } while (test == false);
   {| holdLock(x) |}

--- a/Expr.fs
+++ b/Expr.fs
@@ -772,8 +772,15 @@ and mkAdd2 (l : IntExpr<'var>) (r : IntExpr<'var>) : IntExpr<'var> =
     | (ISub [ x ; IInt k ], IInt l) -> mkSub2 x (IInt (k - l))
     | _                             -> IAdd (foldInts (+) 0L [ l; r ])
 
+/// Makes an increment expression.
+let mkInc (x : IntExpr<'Var>) : IntExpr<'Var> = mkAdd2 x (IInt 1L)
+
 /// Makes a variable increment expression.
-let incVar (x : 'Var) : IntExpr<'Var> = mkAdd2 (IVar x) (IInt 1L)
+let incVar (x : 'Var) : IntExpr<'Var> = mkInc (IVar x)
+
+/// Makes a decrement expression.
+let mkDec (x : IntExpr<'Var>) : IntExpr<'Var> = mkSub2 x (IInt 1L)
+
 
 /// Makes an Add out of a sequence of expressions.
 let mkAdd (xs : IntExpr<'var> seq) : IntExpr<'var> =

--- a/GraphTests.fs
+++ b/GraphTests.fs
@@ -86,10 +86,7 @@ module Tests =
                               { Name = "lock_C003"
                                 Src = "lock_V004"
                                 Command =
-                                    [ command "Assume" []
-                                           [ normalBoolExpr
-                                                 (iEq (siVar "s")
-                                                      (siVar "t")) ]] },
+                                    [ Microcode.Assume (iEq (siVar "s") (siVar "t")) ] },
                            Exit))
                         ("lock_V003",
                          (Mandatory <| Multiset.singleton (gHoldTick BTrue),
@@ -104,10 +101,7 @@ module Tests =
                               [ { Name = "lock_C002"
                                   Src = "lock_V004"
                                   Command =
-                                      [ command "Assume" []
-                                             [ normalBoolExpr
-                                                   (BNot (iEq (siVar "s")
-                                                              (siVar "t"))) ]] }
+                                      [ Microcode.Assume (BNot (iEq (siVar "s") (siVar "t"))) ] }
                                 { Name = "lock_C004"
                                   Src = "lock_V001"
                                   Command = [] } ],
@@ -121,17 +115,11 @@ module Tests =
                               [ { Name = "lock_C002"
                                   Dest = "lock_V003"
                                   Command =
-                                      [ command "Assume" []
-                                             [ normalBoolExpr
-                                                   (BNot (iEq (siVar "s")
-                                                              (siVar "t"))) ]] }
+                                      [ Microcode.Assume (BNot (iEq (siVar "s") (siVar "t"))) ] }
                                 { Name = "lock_C003"
                                   Dest = "lock_V002"
                                   Command =
-                                      [ command "Assume" []
-                                             [ normalBoolExpr
-                                                   (iEq (siVar "s")
-                                                        (siVar "t")) ]] } ],
+                                      [ Microcode.Assume (iEq (siVar "s") (siVar "t")) ] } ],
                           Set.singleton
                               { Name = "lock_C001"
                                 Src = "lock_V003"
@@ -204,19 +192,11 @@ module Tests =
                                   "lock_V004")
                         ("lock_C002",
                              edge "lock_V004"
-                                  [ command "Assume"
-                                         []
-                                         [ normalBoolExpr
-                                               (BNot (iEq (siVar "s")
-                                                          (siVar "t"))) ]]
+                                  [ Microcode.Assume (BNot (iEq (siVar "s") (siVar "t"))) ]
                                   "lock_V003")
                         ("lock_C003",
                              edge "lock_V004"
-                                  [ command "Assume"
-                                         []
-                                         [ normalBoolExpr
-                                               (iEq (siVar "s")
-                                                    (siVar "t")) ]]
+                                  [ Microcode.Assume (iEq (siVar "s") (siVar "t")) ]
                                   "lock_V002")
                         ("lock_C004",
                              edge "lock_V001"

--- a/Grapher.fs
+++ b/Grapher.fs
@@ -25,11 +25,7 @@ open Starling.Core.Command
 open Starling.Core.Command.Create
 
 let cId : Command = []
-(* TODO(CaptainHayashi): currently we're assuming Assumed expressions
-   are in pre-state position.  When we move to type-safe renaming this
-   change should happen *here*. *)
-let cAssume (expr : SVBoolExpr) : Command =
-    command "Assume" [] [ Expr.Bool (normalRec, simp expr) ] |> List.singleton
+let cAssume (expr : SVBoolExpr) : Command = [ Assume (simp expr) ]
 let cAssumeNot : SVBoolExpr -> Command = mkNot >> cAssume
 
 /// <summary>

--- a/Grasshopper.fs
+++ b/Grasshopper.fs
@@ -89,7 +89,7 @@ module Types =
         | /// <summary>
           ///     The given microcode command cannot be expressed in Grasshopper.
           /// </summary>
-          CommandNotImplemented of cmd : Microcode<CTyped<MarkedVar>, Sym<MarkedVar>>
+          CommandNotImplemented of cmd : Microcode<CTyped<MarkedVar>, Sym<MarkedVar>, unit>
                                  * why : string
         | /// <summary>
           ///     The given expression cannot be expressed in Grasshopper.
@@ -135,6 +135,7 @@ module Pretty =
                     [ printMicrocode
                          (printCTyped printMarkedVar)
                          (printSym printMarkedVar)
+                         (fun _ -> String "?")
                          cmd ]
                   errorInfo (String "Reason:" <+> String why) ]
         | ExpressionNotImplemented (expr, why) ->
@@ -417,7 +418,7 @@ let findTermVars (term : Backends.Z3.Types.ZTerm)
 /// <returns>
 ///     A Chessie result, containing a list of Grasshopper commands.
 /// </returns>
-let rec grassMicrocode (routine : Microcode<CTyped<MarkedVar>, Sym<MarkedVar>> list)
+let rec grassMicrocode (routine : Microcode<CTyped<MarkedVar>, Sym<MarkedVar>, unit> list)
   : Result<GrassCommand list, Error> =
     let translateAssign (x, y) =
         maybe BTrue (mkEq (mkVarExp (mapCTyped Reg x))) y
@@ -481,6 +482,11 @@ let rec grassMicrocode (routine : Microcode<CTyped<MarkedVar>, Sym<MarkedVar>> l
                 (CommandNotImplemented
                     (cmd = ent,
                      why = "Assignments cannot mix symbols and pure expressions."))
+        | Microcode.Stored _ ->
+            fail
+                (CommandNotImplemented
+                    (cmd = ent,
+                     why = "Somehow arrived at a stored command here."))
         | Assume x ->
             // Pure assumption.
             lift (fun x -> [ PureAssume x ]) (grassBool x)

--- a/Model.fs
+++ b/Model.fs
@@ -102,7 +102,7 @@ module Types =
         { Name: string
           Results: TypedVar list
           Args: TypedVar list
-          Body: Microcode<TypedVar, Var> list }
+          Body: Microcode<TypedVar, Var, unit> list }
     type SemanticsMap<'a> = Map<string, 'a>
     type PrimSemanticsMap = SemanticsMap<PrimSemantics>
 
@@ -180,13 +180,13 @@ module Types =
 /// <summary>
 ///     Creates a deterministic assign.
 /// </summary>
-let ( *<- ) (lv : 'L) (rv : Expr<'RV>) : Microcode<'L, 'RV> =
+let ( *<- ) (lv : 'L) (rv : Expr<'RV>) : Microcode<'L, 'RV, 'S> =
     Assign (lv, Some rv)
 
 /// <summary>
 ///     Creates a nondeterministic assign.
 /// </summary>
-let havoc (lv : 'L) : Microcode<'L, 'RV> =
+let havoc (lv : 'L) : Microcode<'L, 'RV, 'S> =
     Assign (lv, None)
 
 

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -1466,8 +1466,7 @@ let modelIntLoad
                 ok
                     (Intrinsic
                         (IAssign
-                            { AssignType = Load
-                              TypeRec = srec
+                            { TypeRec = srec
                               LValue = stripTypeRec dstE
                               RValue = stripTypeRec srcE } ))
             | Increment -> mkStored "!ILoad++"
@@ -1535,8 +1534,7 @@ let modelIntStore
                 ok
                     (Intrinsic
                         (IAssign
-                            { AssignType = Store
-                              TypeRec = srec
+                            { TypeRec = srec
                               LValue = stripTypeRec dstE
                               RValue = stripTypeRec srcE } ))
             | Increment -> mkStored "!IStore++"
@@ -1806,8 +1804,7 @@ and modelAssign
                     ok
                         (Intrinsic
                             (IAssign
-                                { AssignType = Local
-                                  TypeRec = dst
+                                { TypeRec = dst
                                   LValue = d
                                   RValue = stripTypeRec srcE } ))
                 | None ->
@@ -1825,8 +1822,7 @@ and modelAssign
                     ok
                         (Intrinsic
                             (BAssign
-                                { AssignType = Local
-                                  TypeRec = dst
+                                { TypeRec = dst
                                   LValue = d
                                   RValue = stripTypeRec srcE } ))
                 | None ->

--- a/Modeller.fs
+++ b/Modeller.fs
@@ -755,7 +755,7 @@ and modelBoolExpr
             (* Symbols have an indefinite subtype, and can include thread-local
                scope. *)
             lift
-                (fun a -> indefBool (BVar (Sym a)))
+                (Sym >> BVar >> indefBool)
                 (tryMapSym (modelExpr env (symbolicScopeOf scope) varF) sa)
         | ArraySubscript (arr, idx) ->
             let arrR = ma arr
@@ -899,7 +899,7 @@ and modelIntExpr
          | Symbolic sa ->
             // Symbols have indefinite subtype.
             lift
-                (fun a -> indefInt (IVar (Sym a)))
+                (Sym >> IVar >> indefInt)
                 (tryMapSym (modelExpr env (symbolicScopeOf scope) varF) sa)
         | ArraySubscript (arr, idx) ->
             let arrR = ma arr
@@ -1757,7 +1757,7 @@ let rec modelAtomic
             |> lift (typedBoolToExpr >> List.singleton >> command "Assume" [])
         | Havoc var ->
             let varMR = mapMessages SymVarError (Env.lookup ctx.Env Full var)
-            lift (fun varM -> Intrinsic (IntrinsicCommand.Havoc varM)) varMR
+            lift (IntrinsicCommand.Havoc >> Intrinsic) varMR
         | SymAtomic sym ->
             // TODO(CaptainHayashi): split out.
             let symMR =
@@ -1832,7 +1832,7 @@ and modelAssign
                             (Exact (Bool (dt, ())))
                             (Exact (typedBoolToType srcE)))
             bind modelWithSrc (mapMessages (curry BadExpr src) srcR)
-        | Array (_, _) ->
+        | Array (_) ->
             fail (PrimNotImplemented "array local assign")
 
     (* The permitted type of src depends on the type of dest.
@@ -2088,7 +2088,7 @@ let convertViewProtos
         | NoIterator (func, isAnonymous) ->
             lift (fun f -> NoIterator (f, isAnonymous)) (convertViewFunc vp func)
         | WithIterator func ->
-            lift (fun f -> WithIterator f) (convertViewFunc vp func)
+            lift WithIterator (convertViewFunc vp func)
 
     collect (List.map convertViewProto vps)
 

--- a/ModellerTests.fs
+++ b/ModellerTests.fs
@@ -406,6 +406,13 @@ module CommandAxioms =
                          VarInWrongScope (expected = Thread, got = Shared)))) ]
 
     [<Test>]
+    let ``modelling command <foo = x> passes`` () =
+        let ast = freshNode (Fetch(freshNode (Identifier "foo"), freshNode (Identifier "x"), Direct))
+        check
+            (prim ast)
+            <| Prim [ normalIntExpr (siVar "foo") *<- normalIntExpr (siVar "x") ]
+
+    [<Test>]
     let ``modelling command <foo = x++> passes`` () =
         let ast = freshNode (Fetch(freshNode (Identifier "foo"), freshNode (Identifier "x"), Increment))
         check

--- a/ModellerTests.fs
+++ b/ModellerTests.fs
@@ -336,19 +336,18 @@ module Atomics =
                      Direct))
         check
             ast
-            (Intrinsic
-                (IAssign
-                    { TypeRec = normalRec
-                      LValue = IVar (Reg "x")
-                      RValue =
-                        IVar
-                            (Sym
-                                [ SymString "foo"
-                                  SymArg (normalBoolExpr (BVar (Reg "baz")))] ) }))
+            (normalIntExpr (siVar "x")
+             *<-
+             normalIntExpr
+                (IVar
+                    (Sym
+                        [ SymString "foo"
+                          SymArg (normalBoolExpr (BVar (Reg "baz")))] )))
 
 
 module CommandAxioms =
     open Starling.Core.Pretty
+    open Starling.Core.View.Pretty
     open Starling.Lang.Modeller.Pretty
 
     let check (c : FullCommand) (cmd : ModellerPartCmd) : unit =
@@ -402,15 +401,13 @@ module CommandAxioms =
         check
             ast
             (Prim
-                [ Intrinsic
-                    ( BAssign
-                        { TypeRec = normalRec
-                          LValue = BVar (Reg "baz")
-                          RValue =
-                            BVar
-                                (Sym
-                                    [ SymString "foo"
-                                      SymArg (normalIntExpr (IVar (Reg "bar"))) ])})])
+                [ (normalBoolExpr (sbVar "baz")
+                   *<-
+                   normalBoolExpr
+                       (BVar
+                           (Sym
+                               [ SymString "foo"
+                                 SymArg (normalIntExpr (IVar (Reg "bar"))) ]))) ] )
 
 
 module ViewDefs =

--- a/ModellerTests.fs
+++ b/ModellerTests.fs
@@ -322,6 +322,34 @@ module Atomics =
             [ normalBoolExpr (sbVar "baz") *<- normalBoolExpr (sbVar "y") ]
 
     [<Test>]
+    let ``model integer increment on local variable`` () =
+        let ast = freshNode (Postfix(freshNode (Identifier "x"), Increment))
+        check
+            ast
+            [ normalIntExpr (siVar "x") *<- normalIntExpr (mkInc (siVar "x")) ]
+
+    [<Test>]
+    let ``model integer decrement on local variable`` () =
+        let ast = freshNode (Postfix(freshNode (Identifier "x"), Decrement))
+        check
+            ast
+            [ normalIntExpr (siVar "x") *<- normalIntExpr (mkDec (siVar "x")) ]
+
+    [<Test>]
+    let ``model integer increment on shared variable`` () =
+        let ast = freshNode (Postfix(freshNode (Identifier "bar"), Increment))
+        check
+            ast
+            [ normalIntExpr (siVar "bar") *<- normalIntExpr (mkInc (siVar "bar")) ]
+
+    [<Test>]
+    let ``model integer decrement on shared variable`` ()=
+        let ast = freshNode (Postfix(freshNode (Identifier "bar"), Decrement))
+        check
+            ast
+            [ normalIntExpr (siVar "bar") *<- normalIntExpr (mkDec (siVar "bar")) ]
+
+    [<Test>]
     let ``model Boolean atomic assign from shared to shared memory`` ()=
         let ast = freshNode (Fetch(freshNode (Identifier "baz"), freshNode (Identifier "emp"), Direct))
         check

--- a/ModellerTests.fs
+++ b/ModellerTests.fs
@@ -321,7 +321,7 @@ module Atomics =
         let ast = freshNode (Fetch(freshNode (Identifier "baz"), freshNode (Identifier "y"), Direct))
         check
             ast
-            (command' "!BLoad" ast [ normalBoolExpr (sbVar "baz") ] [ normalBoolExpr (sbVar "y") ])
+            (normalBoolExpr (sbVar "baz") *<- normalBoolExpr (sbVar "y"))
 
     [<Test>]
     let ``model symbolic store <x = %{foo [|baz|]}>`` () =
@@ -417,20 +417,17 @@ module CommandAxioms =
         let ast = freshNode (Fetch(freshNode (Identifier "foo"), freshNode (Identifier "x"), Increment))
         check
             (prim ast)
-            <| Prim ([ command' "!ILoad++"
+            <| Prim [ command' "!ILoad++"
                         ast
                         [ normalIntExpr (siVar "foo"); normalIntExpr (siVar "x") ]
-                        [ normalIntExpr (siVar "x") ] ])
+                        [ normalIntExpr (siVar "x") ] ]
 
     [<Test>]
     let ``modelling command <baz = y> passes`` () =
         let ast = freshNode (Fetch(freshNode (Identifier "baz"), freshNode (Identifier "y"), Direct))
         check
             (prim <| ast)
-            <| Prim ([ command' "!BLoad"
-                        ast
-                        [ normalBoolExpr (sbVar "baz") ]
-                        [ normalBoolExpr (sbVar "y") ] ])
+            <| Prim [ normalBoolExpr (sbVar "baz") *<- normalBoolExpr (sbVar "y") ]
 
     [<Test>]
     let ``model local Boolean symbolic load {baz = %{foo}(bar)}`` () =

--- a/ModellerTests.fs
+++ b/ModellerTests.fs
@@ -338,8 +338,7 @@ module Atomics =
             ast
             (Intrinsic
                 (IAssign
-                    { AssignType = Store
-                      TypeRec = normalRec
+                    { TypeRec = normalRec
                       LValue = IVar (Reg "x")
                       RValue =
                         IVar
@@ -405,8 +404,7 @@ module CommandAxioms =
             (Prim
                 [ Intrinsic
                     ( BAssign
-                        { AssignType = Local
-                          TypeRec = normalRec
+                        { TypeRec = normalRec
                           LValue = BVar (Reg "baz")
                           RValue =
                             BVar

--- a/ModellerTests.fs
+++ b/ModellerTests.fs
@@ -303,7 +303,7 @@ module Atomics =
     let check (ast : Atomic) (cmd : PrimCommand list) : unit =
         assertOkAndEqual
             cmd
-            (modelAtomic sharedContext ast)
+            (Atomics.model sharedContext.Env ast)
             (printPrimError >> printUnstyled)
 
     [<Test>]

--- a/ModellerTests.fs
+++ b/ModellerTests.fs
@@ -422,30 +422,30 @@ module CommandAxioms =
         let ast = freshNode (Fetch(freshNode (Identifier "foo"), freshNode (Identifier "x"), Direct))
         check
             (prim ast)
-            <| Prim [ normalIntExpr (siVar "foo") *<- normalIntExpr (siVar "x") ]
+            (Prim [ normalIntExpr (siVar "foo") *<- normalIntExpr (siVar "x") ])
 
     [<Test>]
     let ``modelling command <foo = x++> passes`` () =
         let ast = freshNode (Fetch(freshNode (Identifier "foo"), freshNode (Identifier "x"), Increment))
         check
             (prim ast)
-            <| Prim [ normalIntExpr (siVar "foo") *<- normalIntExpr (siVar "x")
-                      normalIntExpr (siVar "x") *<- normalIntExpr (mkInc (siVar "x")) ]
+            (Prim [ normalIntExpr (siVar "foo") *<- normalIntExpr (siVar "x")
+                    normalIntExpr (siVar "x") *<- normalIntExpr (mkInc (siVar "x")) ])
 
     [<Test>]
     let ``modelling command <foo = x--> passes`` () =
         let ast = freshNode (Fetch(freshNode (Identifier "foo"), freshNode (Identifier "x"), Decrement))
         check
             (prim ast)
-            <| Prim [ normalIntExpr (siVar "foo") *<- normalIntExpr (siVar "x")
-                      normalIntExpr (siVar "x") *<- normalIntExpr (mkDec (siVar "x")) ]
+            (Prim [ normalIntExpr (siVar "foo") *<- normalIntExpr (siVar "x")
+                    normalIntExpr (siVar "x") *<- normalIntExpr (mkDec (siVar "x")) ])
 
     [<Test>]
     let ``modelling command <baz = y> passes`` () =
         let ast = freshNode (Fetch(freshNode (Identifier "baz"), freshNode (Identifier "y"), Direct))
         check
-            (prim <| ast)
-            <| Prim [ normalBoolExpr (sbVar "baz") *<- normalBoolExpr (sbVar "y") ]
+            (prim ast)
+            (Prim [ normalBoolExpr (sbVar "baz") *<- normalBoolExpr (sbVar "y") ])
 
     [<Test>]
     let ``model local Boolean symbolic load {baz = %{foo}(bar)}`` () =

--- a/Optimiser.fs
+++ b/Optimiser.fs
@@ -579,17 +579,14 @@ module Graph =
         let rec isLocalPrim prim =
             match prim with
             | // TODO(CaptainHayashi): too conservative?
-              SymC _ -> false
-            | Intrinsic (IAssign { TypeRec = t; LValue = l; RValue = r }) ->
-                isLocalArg (Int (t, l)) && isLocalArg (Int (t, l))
-            | Intrinsic (BAssign { TypeRec = t; LValue = l; RValue = r }) ->
-                isLocalArg (Bool (t, l)) && isLocalArg (Bool (t, l))
-            | // TODO(CaptainHayashi): is this correct?
-              Intrinsic (Havoc v) -> typedVarIsThreadLocal v
-            | Stored { Args = ps } -> Seq.forall isLocalArg ps
-            | PrimBranch (trueBranch = t; falseBranch = f) ->
-                List.forall isLocalPrim t
-                && maybe true (List.forall isLocalPrim) f
+              Symbol _ -> false
+            | Assign (l, ro) ->
+                isLocalArg l && maybe true isLocalArg ro
+            | // TODO(CaptainHayashi): too conservative?
+              Microcode.Assume l -> isLocalArg (normalBoolExpr l)
+            | Microcode.Stored { StoredCommand.Args = ps } -> Seq.forall isLocalArg ps
+            | Branch (trueBranch = t; falseBranch = f) ->
+                List.forall isLocalPrim t && List.forall isLocalPrim f
                 
 
         List.forall isLocalPrim cmd

--- a/Optimiser.fs
+++ b/Optimiser.fs
@@ -580,8 +580,10 @@ module Graph =
             match prim with
             | // TODO(CaptainHayashi): too conservative?
               SymC _ -> false
-            | Intrinsic (IAssign { AssignType = t })
-            | Intrinsic (BAssign { AssignType = t }) -> t = Local
+            | Intrinsic (IAssign { TypeRec = t; LValue = l; RValue = r }) ->
+                isLocalArg (Int (t, l)) && isLocalArg (Int (t, l))
+            | Intrinsic (BAssign { TypeRec = t; LValue = l; RValue = r }) ->
+                isLocalArg (Bool (t, l)) && isLocalArg (Bool (t, l))
             | // TODO(CaptainHayashi): is this correct?
               Intrinsic (Havoc v) -> typedVarIsThreadLocal v
             | Stored { Args = ps } -> Seq.forall isLocalArg ps

--- a/ParserTests.fs
+++ b/ParserTests.fs
@@ -174,79 +174,91 @@ module AtomicActionTests =
     [<Test>]
     let ``foo++``() =
         check parseAtomic "foo++;"
-            (node "" 1L 1L <| Postfix
-                (node "" 1L 1L (Identifier "foo"),
-                Increment))
+            (node "" 1L 1L <| APrim
+                (node "" 1L 1L <| Postfix
+                    (node "" 1L 1L (Identifier "foo"),
+                    Increment)))
 
     [<Test>]
     let ``foo--`` =
         check parseAtomic "foo--;"
-            (node "" 1L 1L <| Postfix
-                (node "" 1L 1L (Identifier "foo"),
-                 Decrement))
+            (node "" 1L 1L <| APrim
+                (node "" 1L 1L <| Postfix
+                    (node "" 1L 1L (Identifier "foo"),
+                    Decrement)))
 
     [<Test>]
     let ``foo = bar`` =
         check parseAtomic "foo = bar;"
-            (node "" 1L 1L <| Fetch
-                (node "" 1L 1L (Identifier "foo"),
-                 node "" 1L 7L (Identifier "bar"),
-                 Direct))
+            (node "" 1L 1L <| APrim
+                (node "" 1L 1L <| Fetch
+                    (node "" 1L 1L (Identifier "foo"),
+                    node "" 1L 7L (Identifier "bar"),
+                    Direct)))
 
     [<Test>]
     let ``foo = bar++`` =
         check parseAtomic "foo = bar++;"
-            (node "" 1L 1L <| Fetch
-                (node "" 1L 1L (Identifier "foo"),
-                 node "" 1L 7L (Identifier "bar"),
-                 Increment))
+            (node "" 1L 1L <| APrim
+                (node "" 1L 1L <| Fetch
+                    (node "" 1L 1L (Identifier "foo"),
+                    node "" 1L 7L (Identifier "bar"),
+                    Increment)))
 
     [<Test>]
     let ``foo = bar--`` =
         check parseAtomic "foo = bar--;"
-            (node "" 1L 1L <| Fetch
-                (node "" 1L 1L (Identifier "foo"),
-                 node "" 1L 7L (Identifier "bar"),
-                 Decrement))
+            (node "" 1L 1L <| APrim
+                (node "" 1L 1L <| Fetch
+                    (node "" 1L 1L (Identifier "foo"),
+                    node "" 1L 7L (Identifier "bar"),
+                    Decrement)))
 
     [<Test>]
     let ``Compare and swap``() =
         check parseAtomic "CAS(foo, bar, 2);"
-            (node "" 1L 1L <| CompareAndSwap
-                (node "" 1L 5L (Identifier "foo"),
-                 node "" 1L 10L (Identifier "bar"),
-                 node "" 1L 15L (Num 2L)))
+            (node "" 1L 1L <| APrim
+                (node "" 1L 1L <| CompareAndSwap
+                    (node "" 1L 5L (Identifier "foo"),
+                    node "" 1L 10L (Identifier "bar"),
+                    node "" 1L 15L (Num 2L))))
 
     [<Test>]
     let ``parse havoc``() =
-        check parseAtomic "havoc y;" (node "" 1L 1L <| Havoc "y")
+        check parseAtomic "havoc y;"
+            (node "" 1L 1L <| APrim
+                (node "" 1L 1L <| Havoc "y"))
 
     [<Test>]
     let ``parse symbolic atomic``() =
         check parseAtomic "%{foo([|x|])};"
-            (node "" 1L 1L <| SymAtomic
-               [ SymString "foo("
-                 SymArg ( node "" 1L 9L (Identifier "x") )
-                 SymString ")" ] )
+            (node "" 1L 1L <| APrim
+                (node "" 1L 1L <| SymCommand
+                [ SymString "foo("
+                  SymArg ( node "" 1L 9L (Identifier "x") )
+                  SymString ")" ] ))
 
 
 module AtomicSetTests =
     [<Test>]
     let ``Single atomic block``() =
         check parseAtomicSet "<| foo++; |>"
-            [ node "" 1L 4L <| Postfix
-                (node "" 1L 4L (Identifier "foo"),
-                 Increment) ]
+            [ node "" 1L 4L <| APrim
+                (node "" 1L 4L <| Postfix
+                    (node "" 1L 4L (Identifier "foo"),
+                     Increment)) ]
 
     [<Test>]
     let ``Multiple in block valid``() =
         check parseAtomicSet "<| foo++; bar--; |>"
-            [ node "" 1L 4L <| Postfix
-                (node "" 1L 4L (Identifier "foo"),
-                 Increment)
-              node "" 1L 11L <| Postfix
-                (node "" 1L 11L (Identifier "bar"),
-                 Decrement) ]
+            [ node "" 1L 4L <| APrim
+                (node "" 1L 4L <| Postfix
+                    (node "" 1L 4L (Identifier "foo"),
+                     Increment))
+              node "" 1L 11L <| APrim
+                (node "" 1L 11L <| Postfix
+                    (node "" 1L 11L (Identifier "bar"),
+                     Decrement)) ]
 
 module ConstraintTests =
     [<Test>]

--- a/Semantics.fs
+++ b/Semantics.fs
@@ -150,8 +150,8 @@ let varAndIdxPath (expr : Expr<Sym<Var>>)
 /// <param name="instrs">The set of instructions to normalise.</param>
 /// <returns>On success, the normalised listing (in arbitrary order).</returns>
 let rec normaliseMicrocode
-  (instrs : Microcode<Expr<Sym<Var>>, Sym<Var>> list)
-  : Result<Microcode<TypedVar, Sym<Var>> list, Error> =
+  (instrs : Microcode<Expr<Sym<Var>>, Sym<Var>, unit> list)
+  : Result<Microcode<TypedVar, Sym<Var>, unit> list, Error> =
     (* The only thing normalisation affects is assignments, and it
        distributes over branches.  We first look at how to normalise
        assignments. *)
@@ -206,6 +206,7 @@ let rec normaliseMicrocode
                 (normaliseMicrocode t)
                 (normaliseMicrocode f)
         | Assign (l, rO) -> normaliseAssign l rO
+        | Stored () -> ok (Stored ())
 
     collect (List.map normaliseInstr instrs)
 
@@ -271,8 +272,8 @@ let checkParamTypesPrim (prim : StoredCommand) (sem : PrimSemantics) : Result<Pr
 let traverseMicrocode
   (ltrav : Traversal<'L, 'LO, 'Error, 'Var>)
   (rtrav : Traversal<Expr<'RV>, Expr<'RVO>, 'Error, 'Var>)
-  : Traversal<Microcode<'L, 'RV>,
-              Microcode<'LO, 'RVO>, 'Error, 'Var> =
+  : Traversal<Microcode<'L, 'RV, unit>,
+              Microcode<'LO, 'RVO, unit>, 'Error, 'Var> =
     let brtrav = traverseBoolAsExpr rtrav
 
     let rec tm ctx mc =
@@ -287,6 +288,7 @@ let traverseMicrocode
             tchain ltrav (flip mkPair None >> Assign) ctx lv
         | Assume assumption -> tchain brtrav Assume ctx (mkTypedSub normalRec assumption)
         | Branch (i, t, e) -> tchain3 brtrav tml tml Branch ctx (mkTypedSub normalRec i, t, e)
+        | Stored () -> ok (ctx, Stored ())
     tm
 
 /// <summary>
@@ -300,8 +302,8 @@ let traverseMicrocode
 /// </returns>
 let tliftToMicrocode
   (trav : Traversal<TypedVar, Expr<Sym<Var>>, Error, 'Var>)
-  : Traversal<Microcode<TypedVar, Var>,
-              Microcode<Expr<Sym<Var>>, Sym<Var>>, Error, 'Var> =
+  : Traversal<Microcode<TypedVar, Var, unit>,
+              Microcode<Expr<Sym<Var>>, Sym<Var>, unit>, Error, 'Var> =
     traverseMicrocode trav (tliftToExprSrc trav)
 
 /// <summary>
@@ -311,8 +313,8 @@ let tliftToMicrocode
 let rec markMicrocode
   (postMark : Var -> MarkedVar)
   (preStates : Map<TypedVar, MarkedVar>)
-  : Traversal<Microcode<TypedVar, Sym<Var>>,
-              Microcode<CTyped<MarkedVar>, Sym<MarkedVar>>,
+  : Traversal<Microcode<TypedVar, Sym<Var>, unit>,
+              Microcode<CTyped<MarkedVar>, Sym<MarkedVar>, unit>,
               Error, 'Var> =
     // Define marker functions for lvalues and rvalues...
     let lf var = ok (postMark var)
@@ -333,7 +335,7 @@ let rec markMicrocode
 ///     Converts a microcode instruction into a two-state Boolean predicate.
 /// </summary>
 let rec markedMicrocodeToBool
-  (instr : Microcode<CTyped<MarkedVar>, Sym<MarkedVar>>)
+  (instr : Microcode<CTyped<MarkedVar>, Sym<MarkedVar>, unit>)
   : BoolExpr<Sym<MarkedVar>> =
     match instr with
     | Symbol s -> BVar (Sym s)
@@ -346,6 +348,7 @@ let rec markedMicrocodeToBool
         let tX = mkAnd (List.map markedMicrocodeToBool t)
         let eX = mkAnd (List.map markedMicrocodeToBool e)
         mkAnd2 (mkImplies i tX) (mkImplies (mkNot i) eX)
+    | Stored () -> BTrue
 
 /// <summary>
 ///     Generates a frame from a state assignment map.
@@ -378,8 +381,8 @@ let makeFrame (states : Map<TypedVar, MarkedVar>) : BoolExpr<Sym<MarkedVar>> lis
 let mergeBranch
   (tMap : Map<TypedVar, MarkedVar>)
   (fMap : Map<TypedVar, MarkedVar>)
-  : (Microcode<CTyped<MarkedVar>, Sym<MarkedVar>> list
-     * Microcode<CTyped<MarkedVar>, Sym<MarkedVar>> list
+  : (Microcode<CTyped<MarkedVar>, Sym<MarkedVar>, unit> list
+     * Microcode<CTyped<MarkedVar>, Sym<MarkedVar>, unit> list
      * Map<TypedVar, MarkedVar>) =
     let assign tvar high low =
         let ttype = typeOf tvar
@@ -443,9 +446,9 @@ let updateState (st : Map<TypedVar, MarkedVar>) (vars : CTyped<MarkedVar> list)
 /// </summary>
 let capInstructions
   (state : Map<TypedVar, MarkedVar>)
-  (instrs : Microcode<CTyped<MarkedVar>, Sym<MarkedVar>> list)
+  (instrs : Microcode<CTyped<MarkedVar>, Sym<MarkedVar>, unit> list)
   : Result<Map<TypedVar, MarkedVar>
-           * Microcode<CTyped<MarkedVar>, Sym<MarkedVar>> list,
+           * Microcode<CTyped<MarkedVar>, Sym<MarkedVar>, unit> list,
            TraversalError<Error>> =
     // TODO(MattWindsor91): proper doc comment.
     (* As above, patch up the lvalues and rvalues in the instruction, generating a
@@ -491,8 +494,8 @@ let capInstructions
 /// </returns>
 let processMicrocodeRoutineUncapped
   (vars : TypedVar list)
-  (routine : Microcode<Expr<Sym<Var>>, Sym<Var>> list)
-  : Result<( Microcode<CTyped<MarkedVar>, Sym<MarkedVar>> list
+  (routine : Microcode<Expr<Sym<Var>>, Sym<Var>, unit> list)
+  : Result<( Microcode<CTyped<MarkedVar>, Sym<MarkedVar>, unit> list
              * Map<TypedVar, MarkedVar> ),
            Error> =
     (* First, normalise the listing.
@@ -504,7 +507,7 @@ let processMicrocodeRoutineUncapped
        This is inherently recursive, because the microcode can contain
        branches. *)
     let rec markInstructions topState instrs
-      : Result<Microcode<CTyped<MarkedVar>, Sym<MarkedVar>> list
+      : Result<Microcode<CTyped<MarkedVar>, Sym<MarkedVar>, unit> list
                * Map<TypedVar, MarkedVar>,
                TraversalError<Error>> =
         (* Generic logic to go through a traversable and, whenever we see a
@@ -528,7 +531,7 @@ let processMicrocodeRoutineUncapped
 
         let markInstruction state (index, instr)
           : Result<Map<TypedVar, MarkedVar>
-                   * Microcode<CTyped<MarkedVar>, Sym<MarkedVar>>,
+                   * Microcode<CTyped<MarkedVar>, Sym<MarkedVar>, unit>,
                    TraversalError<Error>> =
             let rt =
                 tliftToExprSrc
@@ -538,6 +541,7 @@ let processMicrocodeRoutineUncapped
             (* First, get all of the non-assigning instructions out of the way.
                Anything that isn't an assign contains only rvalues, which we
                can mark using the pre-state only. *)
+            | Stored () -> ok (state, Stored ())
             | Symbol s ->
                 lift
                     (mkPair state)
@@ -588,7 +592,6 @@ let processMicrocodeRoutineUncapped
                         | _ -> failwith "markMicrocode: bad context")
                     lR rR
 
-
         let indexed = Seq.mapi mkPair instrs
         let R = bindAccumL markInstruction topState (List.ofSeq indexed)
         lift (fun (st, xs) -> (xs, st)) R
@@ -615,8 +618,8 @@ let processMicrocodeRoutineUncapped
 /// </returns>
 let processMicrocodeRoutine
   (vars : TypedVar list)
-  (routine : Microcode<Expr<Sym<Var>>, Sym<Var>> list)
-  : Result<( Microcode<CTyped<MarkedVar>, Sym<MarkedVar>> list
+  (routine : Microcode<Expr<Sym<Var>>, Sym<Var>, unit> list)
+  : Result<( Microcode<CTyped<MarkedVar>, Sym<MarkedVar>, unit> list
              * Map<TypedVar, MarkedVar> ),
            Error> =
     let intermediateMarkedR =
@@ -638,15 +641,14 @@ let processMicrocodeRoutine
 ///     Converts a processed microcode routine into a two-state Boolean predicate.
 /// </summary>
 let microcodeRoutineToBool
-  (routine : Microcode<CTyped<MarkedVar>, Sym<MarkedVar>> list)
+  (routine : Microcode<CTyped<MarkedVar>, Sym<MarkedVar>, unit> list)
   (assignMap : Map<TypedVar, MarkedVar>)
   : BoolExpr<Sym<MarkedVar>> =
     let bools = List.map markedMicrocodeToBool routine
     mkAnd (makeFrame assignMap @ bools)
 
 /// <summary>
-///     Converts a primitive command to its representation as a disjoint
-///     parallel composition of microcode instructions.
+///     Converts a primitive command to stored-command-less microcode.
 /// </summary>
 /// <param name="semantics">The map from command to microcode schemata.</param>
 /// <param name="prim">The primitive command to instantiate.</param>
@@ -657,22 +659,8 @@ let microcodeRoutineToBool
 let rec instantiateToMicrocode
   (semantics : PrimSemanticsMap)
   (prim : PrimCommand)
-  : Result<Microcode<Expr<Sym<Var>>, Sym<Var>> list, Error> =
+  : Result<Microcode<Expr<Sym<Var>>, Sym<Var>, unit> list, Error> =
     match prim with
-    | SymC s ->
-        (* A symbol is passed through directly. *)
-        ok [ Symbol s]
-    | Intrinsic s ->
-        (* An intrinsic can be directly converted into microcode,
-           throwing away the actual direction of the intrinsic. *)
-        match s with
-        | IAssign { TypeRec = ty; LValue = x; RValue = y } ->
-            ok [ Expr.Int (ty, x) *<- Expr.Int (ty, y) ]
-        | BAssign { TypeRec = ty; LValue = x; RValue = y } ->
-            ok [ Expr.Bool (ty, x) *<- Expr.Bool (ty, y) ]
-        | Havoc var ->
-            (* A havoc is converted to an expression. *)
-            ok [ havoc (mkVarExp (mapCTyped Reg var)) ]
     | Stored sc ->
         // A stored command is a lookup into a microcode table.
         let primDefR = lookupPrim sc semantics
@@ -684,7 +672,7 @@ let rec instantiateToMicrocode
             mapMessages Traversal (mapTraversal subInMCode s.Body)
 
         bind instantiate typeCheckedDefR
-    | PrimBranch (cond = c; trueBranch = t; falseBranch = f) ->
+    | Branch (cond = c; trueBranch = t; falseBranch = f) ->
         let inst =
             List.map (instantiateToMicrocode semantics)
             >> collect
@@ -693,7 +681,13 @@ let rec instantiateToMicrocode
         lift2 
             (fun tM fM -> [ Branch (c, tM, fM) ])
             (inst t)
-            (maybe (ok []) inst f)
+            (inst f)
+    (* Anything else is passed through verbatim.
+       We have to destruct and re-construct the Microcode line because of the
+       type change. *)
+    | Assign (l, r) -> ok [ Assign (l, r) ]
+    | Assume l -> ok [ Assume l ]
+    | Symbol s -> ok [ Symbol s ]
 
 /// <summary>
 ///     Translates a command to a multi-state Boolean expression.

--- a/SemanticsTests.fs
+++ b/SemanticsTests.fs
@@ -38,9 +38,9 @@ module Cap =
     /// <param name="instr">The instructions to cap.</param>
     let check
       (expectedMap : Map<TypedVar, MarkedVar>)
-      (expectedInstrs : Microcode<CTyped<MarkedVar>, Sym<MarkedVar>> list)
+      (expectedInstrs : Microcode<CTyped<MarkedVar>, Sym<MarkedVar>, unit> list)
       (map : Map<TypedVar, MarkedVar>)
-      (instrs : Microcode<CTyped<MarkedVar>, Sym<MarkedVar>> list)
+      (instrs : Microcode<CTyped<MarkedVar>, Sym<MarkedVar>, unit> list)
       : unit =
         assertOkAndEqual
             (expectedMap, expectedInstrs)
@@ -301,8 +301,8 @@ module ProcessMicrocode =
     /// <param name="instrs">The instructions to convert.</param>
     let check (cap : bool) (svars : VarMap) (tvars : VarMap)
       (expectedMap : Map<TypedVar, MarkedVar>)
-      (expectedInstrs : Microcode<CTyped<MarkedVar>, Sym<MarkedVar>> list)
-      (instrs : Microcode<Expr<Sym<Var>>, Sym<Var>> list)
+      (expectedInstrs : Microcode<CTyped<MarkedVar>, Sym<MarkedVar>, unit> list)
+      (instrs : Microcode<Expr<Sym<Var>>, Sym<Var>, unit> list)
       : unit =
         let svars = VarMap.toTypedVarSeq svars
         let tvars = VarMap.toTypedVarSeq tvars
@@ -382,7 +382,7 @@ module MicrocodeToBool =
       (svars : VarMap)
       (tvars : VarMap)
       (expected : BoolExpr<Sym<MarkedVar>> list)
-      (instrs : Microcode<Expr<Sym<Var>>, Sym<Var>> list)
+      (instrs : Microcode<Expr<Sym<Var>>, Sym<Var>, unit> list)
       : unit =
         // Try to make the check order-independent.
         let rec trySort bool =
@@ -678,7 +678,7 @@ module CommandTests =
     [<Test>]
     let ``Semantically translate <%{foo([|serving|]}> using the ticket lock model``() =
         check ticketLockModel.SharedVars ticketLockModel.ThreadVars
-              [ SymC
+              [ Symbol
                     [ SymString "foo("
                       SymArg (normalIntExpr (siVar "serving") )
                       SymString ")" ] ]

--- a/SemanticsTests.fs
+++ b/SemanticsTests.fs
@@ -627,7 +627,7 @@ module CommandTests =
     [<Test>]
     let ``Semantically translate <assume(s == t)> using the ticket lock model`` () =
         check ticketLockModel.SharedVars ticketLockModel.ThreadVars
-              [ command "Assume" [] [ normalBoolExpr <| iEq (siVar "s") (siVar "t") ]]
+              [ Assume (iEq (siVar "s") (siVar "t")) ]
         <| Some (Set.ofList
                    [ iEq (siAfter "serving") (siBefore "serving")
                      iEq (siAfter "ticket") (siBefore "ticket")
@@ -660,9 +660,8 @@ module CommandTests =
                 (AIdx (gridv, siVar "x")))
 
         check testShared testThread
-            [ command "!I++"
-                [ normalIntExpr (IIdx (gridxv, siVar "y")) ]
-            [ normalIntExpr (IIdx (gridxv, siVar "y")) ] ]
+            [ normalIntExpr (IIdx (gridxv, siVar "y"))
+              *<- normalIntExpr (mkInc (IIdx (gridxv, siVar "y"))) ]
         <| Some (Set.ofList
             [ iEq (siAfter "x") (siBefore "x")
               iEq (siAfter "y") (siBefore "y")
@@ -699,7 +698,7 @@ module CommandTests =
     [<Test>]
     let ``Semantically translate <serving++> using the ticket lock model``() =
         check ticketLockModel.SharedVars ticketLockModel.ThreadVars
-              [ command "!I++" [ normalIntExpr (siVar "serving") ] [ normalIntExpr <| siVar "serving" ] ]
+              [ normalIntExpr (siVar "serving") *<- normalIntExpr (mkInc (siVar "serving")) ]
         <| Some (Set.ofList
             [
                 iEq (siAfter "s") (siBefore "s")

--- a/TestStudies.fs
+++ b/TestStudies.fs
@@ -70,14 +70,14 @@ let ticketLockLockMethodAST =
       Body =
         [ pos 14L 3L (ViewExpr (Unmarked Unit))
           pos 15L 5L <| Command'.Prim
-               { PreAssigns = []
+               { PreLocals = []
                  Atomics =
-                     [ pos 15L 6L <|
-                           Fetch
-                                (pos 15L 6L (Identifier "t"),
-                                 pos 15L 10L (Identifier "ticket"),
-                                 Increment) ]
-                 PostAssigns = [] }
+                     [ pos 15L 6L <| APrim
+                        (pos 15L 6L <| Fetch
+                            (pos 15L 6L (Identifier "t"),
+                             pos 15L 10L (Identifier "ticket"),
+                             Increment)) ]
+                 PostLocals = [] }
           pos 16L 3L <| ViewExpr
             (Unmarked
                 (View.Func
@@ -90,13 +90,15 @@ let ticketLockLockMethodAST =
                         { Name = "holdTick"
                           Params = [ pos 18L 19L <| Identifier "t" ] }))
                pos 19L 9L <| Command'.Prim
-                { PreAssigns = []
+                { PreLocals = []
                   Atomics =
-                   [ pos 19L 10L <| Fetch
-                       (pos 19L 10L <| Identifier "s",
-                        pos 19L 14L <| Identifier "serving",
-                        Direct) ]
-                  PostAssigns = [] }
+                   [ pos 19L 10L <| APrim
+                       (pos 19L 10L
+                           (Fetch
+                               (pos 19L 10L <| Identifier "s",
+                                pos 19L 14L <| Identifier "serving",
+                                Direct))) ]
+                  PostLocals = [] }
                pos 20L 7L <| ViewExpr
                 (Unmarked
                     (View.If
@@ -122,12 +124,13 @@ let ticketLockUnlockMethodAST =
         [ pos 29L 3L <| ViewExpr
             (Unmarked (View.Func { Name = "holdLock"; Params = [];}))
           pos 30L 5L <| Command'.Prim
-            { PreAssigns = []
+            { PreLocals = []
               Atomics =
-                [ pos 30L 6L <| Postfix
-                    (pos 30L 6L (Identifier "serving"),
-                     Increment) ]
-              PostAssigns = [] }
+                [ pos 30L 6L <| APrim
+                    (pos 30L 6L <| Postfix
+                        (pos 30L 6L (Identifier "serving"),
+                         Increment)) ]
+              PostLocals = [] }
           pos 31L 3L <| ViewExpr (Unmarked Unit) ] }
 
 let ticketLockConstraint01 =

--- a/Var.fs
+++ b/Var.fs
@@ -65,12 +65,12 @@ module Types =
           Thread
         | /// <summary>
           ///     Look up variables in shared scope.
-          ///     Switch to thread scope for indices, and full scope for
+          ///     Switch to thread scope for indices, and Any scope for
           ///     symbols.
           /// </summary>
           Shared
         | /// <summary>Look up variables in local first, then shared.</summary>
-          Full
+          Any
         | /// <summary>
           ///     Look up variables in the given local map first, then the next
           ///     scope.
@@ -185,7 +185,7 @@ module VarMap =
 /// </summary>
 module Env =
     /// <summary>
-    ///     A full variable environment.
+    ///     A Any variable environment.
     /// </summary>
     type Env =
         { /// <summary>The set of thread-local variables.</summary>
@@ -225,7 +225,7 @@ module Env =
     let rec symbolicScopeOf (scope : Scope) : Scope =
         match scope with
         | WithMap (map, rest) -> WithMap (map, symbolicScopeOf rest)
-        | Shared -> Full
+        | Shared -> Any
         | x -> x
 
     /// <summary>
@@ -263,7 +263,7 @@ module Env =
                         fail
                             (VarInWrongScope (expected = Shared, got = Thread)))
                     (VarMap.tryLookup env.TVars var)
-        | Full ->
+        | Any ->
             (* Currently, the order doesn't matter as both are disjoint.
                However, one day, it might, in which case the thread scope is
                'closer' to program code. *)
@@ -352,7 +352,7 @@ module Pretty =
         | WithMap (_, r) -> String "local arguments or" <+> printScope r
         | Thread -> String "thread"
         | Shared -> String "shared"
-        | Full -> String "thread or shared"
+        | Any -> String "thread or shared"
 
     /// Pretty-prints variable conversion errors.
     let printVarMapError =

--- a/ViewDesugar.fs
+++ b/ViewDesugar.fs
@@ -105,12 +105,12 @@ module Pretty =
         (* The trick here is to make Prim [] appear as ;, but
            Prim [x; y; z] appear as x; y; z;, and to do the same with
            atomic lists. *)
-        | FPrim { PreAssigns = ps; Atomics = ts; PostAssigns = qs } ->
-            seq { yield! Seq.map (uncurry printAssign) ps
+        | FPrim { PreLocals = ps; Atomics = ts; PostLocals = qs } ->
+            seq { yield! Seq.map printPrim ps
                   yield (ts
                          |> Seq.map printAtomic
                          |> semiSep |> withSemi |> braced |> angled)
-                  yield! Seq.map (uncurry printAssign) qs }
+                  yield! Seq.map printPrim qs }
             |> semiSep |> withSemi
         | FIf(c, t, fo) ->
             hsep [ "if" |> String |> syntax
@@ -252,7 +252,7 @@ and desugarBlock (tvars: Map<string, Type>) (fg: bigint ref)
     let (blockP, pre) = cap block
 
     let skip () =
-        freshNode (Prim { PreAssigns = []; Atomics = []; PostAssigns = [] })
+        freshNode (Prim { PreLocals = []; Atomics = []; PostLocals = [] })
 
     (* If the last item isn't a view, we have to synthesise a block
        postcondition.


### PR DESCRIPTION
**NOTE:** In typical me fashion, this is based on a previous pull request (#142), and shouldn't be merged (or really looked at in detail) until that one is up.

This is a fairly heavy PRQ (got a bit carried away with simplification, as usual) that does a lot of simplifying and expressivity-boosting changes to the primitive commands (assignment, postfix, assume, etc).

## What does this do?

- Atomic assignments and postfixes can now mention thread-local variables anywhere.  (I _think_ they're still restricted inside indices to _only_ using thread-local variables, but I didn't check as this isn't a problem yet.)
- `Microcode` and `PrimCommand`s have been merged (sort of): Microcode can now contain stored commands (atomic function calls), and does so until the point where we used to expand out PrimCommands.  `PrimCommand` is now a type alias for a certain type of `Microcode`.  This makes `Microcode` the _only_ internal representation of Starling's command language.
- Internally, every stored command other than `BCAS` and `ICAS` is gone, and the modeller models postfixes, assumes, and id-transitions directly as microcode.
- Local commands now use the exact same AST and internal representation as atomics.  The only difference between the two, now, is that local commands can only name thread-local variables.  This means commands like `{| foo() |} local++ {| bar() |}` are now possible.
- Added a load more tests.
- Fixed the weirdly specified CAS in #142.